### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -2,8 +2,8 @@
     "crates/rust-mcp-sdk": "0.1.0",
     "crates/rust-mcp-macros": "0.1.0",
     "crates/rust-mcp-transport": "0.1.0",
-    "examples/hello-world-mcp-server": "0.1.0",
-    "examples/hello-world-mcp-server-core": "0.1.0",
-    "examples/simple-mcp-client": "0.1.0",
-    "examples/simple-mcp-client-core": "0.1.0"
+    "examples/hello-world-mcp-server": "0.1.1",
+    "examples/hello-world-mcp-server-core": "0.1.1",
+    "examples/simple-mcp-client": "0.1.1",
+    "examples/simple-mcp-client-core": "0.1.1"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "colored",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.0...rust-mcp-macros-v0.1.0) (2025-03-29)
+
+
+### Features
+
+* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
+
 ## [0.1.7](https://github.com/hashemix/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.6...rust-mcp-macros-v0.1.7) (2025-03-24)
 
 

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.0...rust-mcp-sdk-v0.1.0) (2025-03-29)
+
+
+### Features
+
+* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
+
 ## [0.1.7](https://github.com/hashemix/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.6...rust-mcp-sdk-v0.1.7) (2025-03-24)
 
 

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.0...rust-mcp-transport-v0.1.0) (2025-03-29)
+
+
+### Features
+
+* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
+
 ## [0.1.7](https://github.com/hashemix/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.6...rust-mcp-transport-v0.1.7) (2025-03-24)
 
 

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.1</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.1</summary>

### Dependencies


</details>

<details><summary>rust-mcp-macros: 0.1.0</summary>

## [0.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.0...rust-mcp-macros-v0.1.0) (2025-03-29)


### Features

* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
</details>

<details><summary>rust-mcp-sdk: 0.1.0</summary>

## [0.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.0...rust-mcp-sdk-v0.1.0) (2025-03-29)


### Features

* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
</details>

<details><summary>rust-mcp-transport: 0.1.0</summary>

## [0.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.0...rust-mcp-transport-v0.1.0) (2025-03-29)


### Features

* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
</details>

<details><summary>simple-mcp-client: 0.1.1</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.1</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).