### PR TITLE
refactor!: naming & less constrained dependencies

### DIFF
--- a/crates/rust-mcp-macros/README.md
+++ b/crates/rust-mcp-macros/README.md
@@ -5,7 +5,7 @@ A procedural macro, part of the [rust-mcp-sdk](https://github.com/rust-mcp-stack
 The `mcp_tool` macro generates an implementation for the annotated struct that includes:
 
 - A `tool_name()` method returning the tool's name as a string.
-- A `get_tool()` method returning a `rust_mcp_schema::Tool` instance with the tool's name,
+- A `tool()` method returning a `rust_mcp_schema::Tool` instance with the tool's name,
   description, and input schema derived from the struct's fields.
 
 ## Attributes
@@ -32,7 +32,7 @@ fn main() {
 
     assert_eq!(WriteFileTool::tool_name(), "write_file");
 
-    let tool: rust_mcp_schema::Tool = WriteFileTool::get_tool();
+    let tool: rust_mcp_schema::Tool = WriteFileTool::tool();
     assert_eq!(tool.name, "write_file");
     assert_eq!( tool.description.unwrap(),"Create a new file or completely overwrite an existing file with new content.");
 

--- a/crates/rust-mcp-macros/src/lib.rs
+++ b/crates/rust-mcp-macros/src/lib.rs
@@ -19,12 +19,12 @@ use utils::{is_option, renamed_field, type_to_json_schema};
 /// * `name` - An optional string representing the tool's name.
 /// * `description` - An optional string describing the tool.
 ///
-struct MCPToolMacroAttributes {
+struct McpToolMacroAttributes {
     name: Option<String>,
     description: Option<String>,
 }
 
-impl Parse for MCPToolMacroAttributes {
+impl Parse for McpToolMacroAttributes {
     /// Parses the macro attributes from a `ParseStream`.
     ///
     /// This implementation extracts `name` and `description` from the attribute input,
@@ -96,7 +96,7 @@ impl Parse for MCPToolMacroAttributes {
 ///
 /// The `mcp_tool` macro generates an implementation for the annotated struct that includes:
 /// - A `tool_name()` method returning the tool's name as a string.
-/// - A `get_tool()` method returning a `rust_mcp_schema::Tool` instance with the tool's name,
+/// - A `tool()` method returning a `rust_mcp_schema::Tool` instance with the tool's name,
 ///   description, and input schema derived from the struct's fields.
 ///
 /// # Attributes
@@ -116,7 +116,7 @@ impl Parse for MCPToolMacroAttributes {
 /// }
 ///
 /// assert_eq!(ExampleTool::tool_name() , "example_tool");
-/// let tool : rust_mcp_schema::Tool = ExampleTool::get_tool();
+/// let tool : rust_mcp_schema::Tool = ExampleTool::tool();
 /// assert_eq!(tool.name , "example_tool");
 /// assert_eq!(tool.description.unwrap() , "An example tool");
 ///
@@ -131,7 +131,7 @@ pub fn mcp_tool(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput); // Parse the input as a function
     let input_ident = &input.ident;
 
-    let macro_attributes = parse_macro_input!(attributes as MCPToolMacroAttributes);
+    let macro_attributes = parse_macro_input!(attributes as McpToolMacroAttributes);
 
     let tool_name = macro_attributes.name.unwrap_or_default();
     let tool_description = macro_attributes.description.unwrap_or_default();
@@ -147,7 +147,7 @@ pub fn mcp_tool(attributes: TokenStream, input: TokenStream) -> TokenStream {
             ///
             /// The tool includes the name, description, and input schema derived from
             /// the struct's attributes.
-            pub fn get_tool()-> rust_mcp_schema::Tool
+            pub fn tool()-> rust_mcp_schema::Tool
             {
                 let json_schema = &#input_ident::json_schema();
 

--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -28,7 +28,7 @@ pub fn is_vec(ty: &Type) -> bool {
 
 // Extract the inner type from Vec<T> or Option<T>
 #[allow(unused)]
-pub fn get_inner_type(ty: &Type) -> Option<&Type> {
+pub fn inner_type(ty: &Type) -> Option<&Type> {
     if let Type::Path(type_path) = ty {
         if type_path.path.segments.len() == 1 {
             let segment = &type_path.path.segments[0];
@@ -46,7 +46,7 @@ pub fn get_inner_type(ty: &Type) -> Option<&Type> {
     None
 }
 
-fn get_doc_comment(attrs: &[Attribute]) -> Option<String> {
+fn doc_comment(attrs: &[Attribute]) -> Option<String> {
     let mut docs = Vec::new();
     for attr in attrs {
         if attr.path().is_ident("doc") {
@@ -86,7 +86,7 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
     let number_types = [
         "i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "f32", "f64",
     ];
-    let doc_comment = get_doc_comment(attrs);
+    let doc_comment = doc_comment(attrs);
     let description = doc_comment.as_ref().map(|desc| {
         quote! {
             map.insert("description".to_string(), serde_json::Value::String(#desc.to_string()));

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -4,10 +4,10 @@
 
 # Rust MCP SDK
 
-A high-performance, asynchronous toolkit for building MCP servers and clients.  
+A high-performance, asynchronous toolkit for building MCP servers and clients.
 Focus on your app's logic while **rust-mcp-sdk** takes care of the rest!
 
-**rust-mcp-sdk** provides the necessary components for developing both servers and clients in the MCP ecosystem.  
+**rust-mcp-sdk** provides the necessary components for developing both servers and clients in the MCP ecosystem.
 Leveraging the [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) crate for type safe MCP schema objects and MCP type utilities simplifies the process of building robust and reliable MCP servers and clients, ensuring consistency and minimizing errors in data handling and message processing.
 
 **⚠️WARNING**: This project only supports Standard Input/Output (stdio) transport at this time, with support for SSE (Server-Sent Events) transport still in progress and not yet available. Project is currently under development and should be used at your own risk.
@@ -70,10 +70,10 @@ pub struct MyServerHandler;
 #[async_trait]
 impl ServerHandler for MyServerHandler {
     // Handle ListToolsRequest, return list of available tools as ListToolsResult
-    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn MCPServer) -> Result<ListToolsResult, JsonrpcErrorError> {
+    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn McpServer) -> Result<ListToolsResult, JsonrpcErrorError> {
 
         Ok(ListToolsResult {
-            tools: vec![SayHelloTool::get_tool()],
+            tools: vec![SayHelloTool::tool()],
             meta: None,
             next_cursor: None,
         })
@@ -81,7 +81,7 @@ impl ServerHandler for MyServerHandler {
     }
 
     /// Handles requests to call a specific tool.
-    async fn handle_call_tool_request( &self, request: CallToolRequest, runtime: &dyn MCPServer, ) -> Result<CallToolResult, CallToolError> {
+    async fn handle_call_tool_request( &self, request: CallToolRequest, runtime: &dyn McpServer, ) -> Result<CallToolResult, CallToolError> {
 
         if request.tool_name() == SayHelloTool::tool_name() {
             Ok(CallToolResult::text_content(
@@ -153,7 +153,7 @@ async fn main() -> SdkResult<()> {
     // STEP 7: use client methods to communicate with the MCP Server as you wish
 
     // Retrieve and display the list of tools available on the server
-    let server_version = client.get_server_version().unwrap();
+    let server_version = client.server_version().unwrap();
     let tools = client.list_tools(None).await?.tools;
 
     println!("List of tools for {}@{}", server_version.name, server_version.version);
@@ -195,10 +195,10 @@ If you are looking for a step-by-step tutorial on how to get started with `rust-
 
 [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) provides two type of handler traits that you can chose from:
 
-- **mcp_server_handler**: This is the recommended trait for your MCP project, offering a default implementation for all types of MCP messages. It includes predefined implementations within the trait, such as handling initialization or responding to ping requests, so you only need to override and customize the handler functions relevant to your specific needs.  
+- **mcp_server_handler**: This is the recommended trait for your MCP project, offering a default implementation for all types of MCP messages. It includes predefined implementations within the trait, such as handling initialization or responding to ping requests, so you only need to override and customize the handler functions relevant to your specific needs.
   Refer to [examples/hello-world-mcp-server/src/handler.rs](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/hello-world-mcp-server/src/handler.rs) for an example.
 
-- **mcp_server_handler_core**: If you need more control over MCP messages, consider using `mcp_server_handler_core`. It offers three primary methods to manage the three MCP message types: `request`, `notification`, and `error`. While still providing type-safe objects in these methods, it allows you to determine how to handle each message based on its type and parameters.  
+- **mcp_server_handler_core**: If you need more control over MCP messages, consider using `mcp_server_handler_core`. It offers three primary methods to manage the three MCP message types: `request`, `notification`, and `error`. While still providing type-safe objects in these methods, it allows you to determine how to handle each message based on its type and parameters.
   Refer to [examples/hello-world-mcp-server-core/src/handler.rs](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/hello-world-mcp-server-core/src/handler.rs) for an example.
 
 ---
@@ -209,8 +209,8 @@ If you are looking for a step-by-step tutorial on how to get started with `rust-
 
 ### Choosing Between `mcp_client_handler` and `mcp_client_handler_core`
 
-The same principles outlined above apply to the client-side handlers, `mcp_client_handler` and `mcp_client_handler_core`.  
-Use `client_runtime::create_client()` or `client_runtime_core::create_client()` , respectively.  
+The same principles outlined above apply to the client-side handlers, `mcp_client_handler` and `mcp_client_handler_core`.
+Use `client_runtime::create_client()` or `client_runtime_core::create_client()` , respectively.
 Check out the corresponding examples at: [examples/simple-mcp-client](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/simple-mcp-client) and [examples/simple-mcp-client-core](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/simple-mcp-client-core).
 
 ## License

--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -2,10 +2,10 @@ use rust_mcp_schema::JsonrpcErrorError;
 use rust_mcp_transport::error::TransportError;
 use thiserror::Error;
 
-pub type SdkResult<T> = core::result::Result<T, MCPSdkError>;
+pub type SdkResult<T> = core::result::Result<T, McpSdkError>;
 
 #[derive(Debug, Error)]
-pub enum MCPSdkError {
+pub enum McpSdkError {
     #[error("{0}")]
     JsonrpcErrorError(#[from] JsonrpcErrorError),
     #[error("{0}")]
@@ -15,7 +15,7 @@ pub enum MCPSdkError {
     #[error("{0}")]
     AnyErrorStatic(Box<(dyn std::error::Error + Send + Sync + 'static)>),
     #[error("{0}")]
-    AnyError(Box<(dyn std::error::Error + Send + Sync + 'static)>),
+    AnyError(Box<(dyn std::error::Error + Send + Sync)>),
     #[error("{0}")]
     SdkError(#[from] rust_mcp_schema::schema_utils::SdkError),
 }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
@@ -7,7 +7,7 @@ use rust_mcp_schema::{
 };
 use serde_json::Value;
 
-use crate::mcp_traits::mcp_client::MCPClient;
+use crate::mcp_traits::mcp_client::McpClient;
 
 /// Defines the `ClientHandler` trait for handling Model Context Protocol (MCP) operations on a client.
 /// This trait provides default implementations for request and notification handlers in an MCP client,
@@ -21,7 +21,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_ping_request(
         &self,
         request: PingRequest,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<Result, JsonrpcErrorError> {
         Ok(Result::default())
     }
@@ -29,7 +29,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_create_message_request(
         &self,
         request: CreateMessageRequest,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<CreateMessageResult, JsonrpcErrorError> {
         runtime.assert_client_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -41,7 +41,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_list_roots_request(
         &self,
         request: ListRootsRequest,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<ListRootsResult, JsonrpcErrorError> {
         runtime.assert_client_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -53,7 +53,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_custom_request(
         &self,
         request: Value,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<ListRootsResult, JsonrpcErrorError> {
         Err(JsonrpcErrorError::method_not_found()
             .with_message("No handler is implemented for custom requests.".to_string()))
@@ -66,7 +66,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_cancelled_notification(
         &self,
         notification: CancelledNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -74,7 +74,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_progress_notification(
         &self,
         notification: ProgressNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -82,7 +82,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_resource_list_changed_notification(
         &self,
         notification: ResourceListChangedNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -90,7 +90,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_resource_updated_notification(
         &self,
         notification: ResourceUpdatedNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -98,7 +98,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_prompt_list_changed_notification(
         &self,
         notification: PromptListChangedNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -106,7 +106,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_tool_list_changed_notification(
         &self,
         notification: ToolListChangedNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -114,7 +114,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_logging_message_notification(
         &self,
         notification: LoggingMessageNotification,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -122,7 +122,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_custom_notification(
         &self,
         notification: Value,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -133,7 +133,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_error(
         &self,
         error: JsonrpcErrorError,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -141,7 +141,7 @@ pub trait ClientHandler: Send + Sync + 'static {
     async fn handle_process_error(
         &self,
         error_message: String,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         if !runtime.is_shut_down().await {
             eprintln!("Process error: {}", error_message);

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use rust_mcp_schema::schema_utils::*;
 use rust_mcp_schema::*;
 
-use crate::mcp_traits::mcp_client::MCPClient;
+use crate::mcp_traits::mcp_client::McpClient;
 
 /// Defines the `ClientHandlerCore` trait for handling Model Context Protocol (MCP) client operations.
 /// Unlike `ClientHandler`, this trait offers no default implementations, providing full control over MCP message handling
@@ -19,7 +19,7 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
     async fn handle_request(
         &self,
         request: RequestFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<ResultFromClient, JsonrpcErrorError>;
 
     /// Asynchronously handles an incoming notification from the server.
@@ -29,7 +29,7 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
     async fn handle_notification(
         &self,
         notification: NotificationFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError>;
 
     /// Asynchronously handles an error received from the server.
@@ -39,13 +39,13 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
     async fn handle_error(
         &self,
         error: JsonrpcErrorError,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError>;
 
     async fn handle_process_error(
         &self,
         error_message: String,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         if !runtime.is_shut_down().await {
             eprintln!("Process error: {}", error_message);

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use rust_mcp_schema::{schema_utils::CallToolError, *};
 use serde_json::Value;
 
-use crate::mcp_traits::mcp_server::MCPServer;
+use crate::mcp_traits::mcp_server::McpServer;
 
 /// Defines the `ServerHandler` trait for handling Model Context Protocol (MCP) operations on a server.
 /// This trait provides default implementations for request and notification handlers in an MCP server,
@@ -15,7 +15,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     /// The `runtime` parameter provides access to the server's runtime environment, allowing
     /// interaction with the server's capabilities.
     /// The default implementation does nothing.
-    async fn on_initialized(&self, runtime: &dyn MCPServer) {}
+    async fn on_initialized(&self, runtime: &dyn McpServer) {}
 
     /// Handles the InitializeRequest from a client.
     ///
@@ -29,13 +29,13 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_initialize_request(
         &self,
         initialize_request: InitializeRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<InitializeResult, JsonrpcErrorError> {
         runtime
             .set_client_details(initialize_request.params.clone())
             .map_err(|err| JsonrpcErrorError::internal_error().with_message(format!("{}", err)))?;
 
-        Ok(runtime.get_server_info().to_owned())
+        Ok(runtime.server_info().to_owned())
     }
 
     /// Handles ping requests from clients.
@@ -46,7 +46,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_ping_request(
         &self,
         _: PingRequest,
-        _: &dyn MCPServer,
+        _: &dyn McpServer,
     ) -> std::result::Result<Result, JsonrpcErrorError> {
         Ok(Result::default())
     }
@@ -58,7 +58,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_resources_request(
         &self,
         request: ListResourcesRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ListResourcesResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -74,7 +74,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_resource_templates_request(
         &self,
         request: ListResourceTemplatesRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ListResourceTemplatesResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -90,7 +90,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_read_resource_request(
         &self,
         request: ReadResourceRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ReadResourceResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -106,7 +106,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_subscribe_request(
         &self,
         request: SubscribeRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<Result, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -122,7 +122,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_unsubscribe_request(
         &self,
         request: UnsubscribeRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<Result, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -138,7 +138,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_prompts_request(
         &self,
         request: ListPromptsRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ListPromptsResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -151,10 +151,10 @@ pub trait ServerHandler: Send + Sync + 'static {
     ///
     /// Default implementation returns method not found error.
     /// Customize this function in your specific handler to implement behavior tailored to your MCP server's capabilities and requirements.
-    async fn handle_get_prompt_request(
+    async fn handle_prompt_request(
         &self,
         request: GetPromptRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<GetPromptResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -170,7 +170,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_tools_request(
         &self,
         request: ListToolsRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ListToolsResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -186,7 +186,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_call_tool_request(
         &self,
         request: CallToolRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         runtime
             .assert_server_request_capabilities(request.method())
@@ -201,7 +201,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_set_level_request(
         &self,
         request: SetLevelRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<Result, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -217,7 +217,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_complete_request(
         &self,
         request: CompleteRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<CompleteResult, JsonrpcErrorError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(JsonrpcErrorError::method_not_found().with_message(format!(
@@ -233,7 +233,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_custom_request(
         &self,
         request: Value,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<Value, JsonrpcErrorError> {
         Err(JsonrpcErrorError::method_not_found()
             .with_message("No handler is implemented for custom requests.".to_string()))
@@ -246,7 +246,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_initialized_notification(
         &self,
         notification: InitializedNotification,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -256,7 +256,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_cancelled_notification(
         &self,
         notification: CancelledNotification,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -266,7 +266,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_progress_notification(
         &self,
         notification: ProgressNotification,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -276,7 +276,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_roots_list_changed_notification(
         &self,
         notification: RootsListChangedNotification,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -301,7 +301,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_error(
         &self,
         error: JsonrpcErrorError,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -310,7 +310,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ///
     /// Sends a "Server started successfully" message to stderr.
     /// Customize this function in your specific handler to implement behavior tailored to your MCP server's capabilities and requirements.
-    async fn on_server_started(&self, runtime: &dyn MCPServer) {
+    async fn on_server_started(&self, runtime: &dyn McpServer) {
         let _ = runtime
             .stderr_message("Server started successfully".into())
             .await;

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -151,7 +151,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ///
     /// Default implementation returns method not found error.
     /// Customize this function in your specific handler to implement behavior tailored to your MCP server's capabilities and requirements.
-    async fn handle_prompt_request(
+    async fn handle_get_prompt_request(
         &self,
         request: GetPromptRequest,
         runtime: &dyn McpServer,

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use rust_mcp_schema::schema_utils::*;
 use rust_mcp_schema::*;
 
-use crate::mcp_traits::mcp_server::MCPServer;
+use crate::mcp_traits::mcp_server::McpServer;
 
 /// Defines the `ServerHandlerCore` trait for handling Model Context Protocol (MCP) server operations.
 /// Unlike `ServerHandler`, this trait offers no default implementations, providing full control over MCP message handling
@@ -14,7 +14,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     /// The `runtime` parameter provides access to the server's runtime environment, allowing
     /// interaction with the server's capabilities.
     /// The default implementation does nothing.
-    async fn on_initialized(&self, _runtime: &dyn MCPServer) {}
+    async fn on_initialized(&self, _runtime: &dyn McpServer) {}
 
     /// Asynchronously handles an incoming request from the client.
     ///
@@ -26,7 +26,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     async fn handle_request(
         &self,
         request: RequestFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ResultFromServer, JsonrpcErrorError>;
 
     /// Asynchronously handles an incoming notification from the client.
@@ -36,7 +36,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     async fn handle_notification(
         &self,
         notification: NotificationFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError>;
 
     /// Asynchronously handles an error received from the client.
@@ -46,9 +46,9 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     async fn handle_error(
         &self,
         error: JsonrpcErrorError,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError>;
-    async fn on_server_started(&self, runtime: &dyn MCPServer) {
+    async fn on_server_started(&self, runtime: &dyn McpServer) {
         let _ = runtime
             .stderr_message("Server started successfully".into())
             .await;

--- a/crates/rust-mcp-sdk/src/mcp_macros/tool_box.rs
+++ b/crates/rust-mcp-sdk/src/mcp_macros/tool_box.rs
@@ -5,7 +5,7 @@
 ///
 /// This macro creates:
 /// - An enum with the specified name containing variants for each mcp tool
-/// - A `get_tools()` function returning a vector of supported tools
+/// - A `tools()` function returning a vector of supported tools
 /// - A `TryFrom<CallToolRequestParams>` implementation for converting requests to tool instances
 ///
 /// # Arguments
@@ -22,8 +22,8 @@
 /// //     EditFileTool(EditFileTool),
 /// //     SearchFilesTool(SearchFilesTool),
 /// // }
-/// // pub fn get_tools() -> Vec<Tool> {
-/// //     vec![ReadFileTool::get_tool(), EditFileTool::get_tool(), SearchFilesTool::get_tool()]
+/// // pub fn tools() -> Vec<Tool> {
+/// //     vec![ReadFileTool::tool(), EditFileTool::tool(), SearchFilesTool::tool()]
 /// // }
 ///
 /// // impl TryFrom<CallToolRequestParams> for FileSystemTools {
@@ -50,10 +50,10 @@ macro_rules! tool_box {
             }
 
             /// Returns a vector containing instances of all supported tools
-            pub fn get_tools() -> Vec<rust_mcp_schema::Tool> {
+            pub fn tools() -> Vec<rust_mcp_schema::Tool> {
                 vec![
                     $(
-                        $tool::get_tool(),
+                        $tool::tool(),
                     )*
                 ]
             }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime.rs
@@ -11,8 +11,8 @@ use rust_mcp_schema::{
 use rust_mcp_transport::Transport;
 
 use crate::{
-    error::SdkResult, mcp_client::ClientHandler, mcp_traits::mcp_handler::MCPClientHandler,
-    MCPClient,
+    error::SdkResult, mcp_client::ClientHandler, mcp_traits::mcp_handler::McpClientHandler,
+    McpClient,
 };
 
 use super::ClientRuntime;
@@ -61,15 +61,15 @@ impl ClientInternalHandler<Box<dyn ClientHandler>> {
     }
 }
 
-/// Implementation of the `MCPClientHandler` trait for `ClientInternalHandler`.
+/// Implementation of the `McpClientHandler` trait for `ClientInternalHandler`.
 /// This handles requests, notifications, and errors from the server by calling proper function of self.handler
 #[async_trait]
-impl MCPClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
+impl McpClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
     /// Handles a request received from the server by passing the request to self.handler
     async fn handle_request(
         &self,
         server_jsonrpc_request: RequestFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<ResultFromClient, JsonrpcErrorError> {
         match server_jsonrpc_request {
             RequestFromServer::ServerRequest(request) => match request {
@@ -103,7 +103,7 @@ impl MCPClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
     async fn handle_error(
         &self,
         jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;
         Ok(())
@@ -113,7 +113,7 @@ impl MCPClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
     async fn handle_notification(
         &self,
         server_jsonrpc_notification: NotificationFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()> {
         match server_jsonrpc_notification {
             NotificationFromServer::ServerNotification(server_notification) => {
@@ -198,7 +198,7 @@ impl MCPClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
     async fn handle_process_error(
         &self,
         error_message: String,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()> {
         self.handler
             .handle_process_error(error_message, runtime)

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime_core.rs
@@ -13,7 +13,7 @@ use rust_mcp_transport::Transport;
 use crate::{
     error::SdkResult,
     mcp_handlers::mcp_client_handler_core::ClientHandlerCore,
-    mcp_traits::{mcp_client::MCPClient, mcp_handler::MCPClientHandler},
+    mcp_traits::{mcp_client::McpClient, mcp_handler::McpClientHandler},
 };
 
 use super::ClientRuntime;
@@ -62,11 +62,11 @@ impl ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> {
 }
 
 #[async_trait]
-impl MCPClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> {
+impl McpClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> {
     async fn handle_request(
         &self,
         server_jsonrpc_request: RequestFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<ResultFromClient, JsonrpcErrorError> {
         // handle request and get the result
         self.handler
@@ -77,7 +77,7 @@ impl MCPClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> 
     async fn handle_error(
         &self,
         jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;
         Ok(())
@@ -85,7 +85,7 @@ impl MCPClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> 
     async fn handle_notification(
         &self,
         server_jsonrpc_notification: NotificationFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()> {
         // handle notification
         self.handler
@@ -97,7 +97,7 @@ impl MCPClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> 
     async fn handle_process_error(
         &self,
         error_message: String,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()> {
         self.handler
             .handle_process_error(error_message, runtime)

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -11,7 +11,7 @@ use rust_mcp_transport::Transport;
 use crate::{
     error::SdkResult,
     mcp_handlers::mcp_server_handler::ServerHandler,
-    mcp_traits::{mcp_handler::MCPServerHandler, mcp_server::MCPServer},
+    mcp_traits::{mcp_handler::McpServerHandler, mcp_server::McpServer},
 };
 
 use super::ServerRuntime;
@@ -56,11 +56,11 @@ impl ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
 }
 
 #[async_trait]
-impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
+impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
     async fn handle_request(
         &self,
         client_jsonrpc_request: RequestFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ResultFromServer, JsonrpcErrorError> {
         match client_jsonrpc_request {
             rust_mcp_schema::schema_utils::RequestFromClient::ClientRequest(client_request) => {
@@ -115,9 +115,9 @@ impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
                             .map(|value| value.into())
                     }
 
-                    rust_mcp_schema::ClientRequest::GetPromptRequest(get_prompt_request) => self
+                    rust_mcp_schema::ClientRequest::GetPromptRequest(prompt_request) => self
                         .handler
-                        .handle_get_prompt_request(get_prompt_request, runtime)
+                        .handle_prompt_request(prompt_request, runtime)
                         .await
                         .map(|value| value.into()),
                     rust_mcp_schema::ClientRequest::ListToolsRequest(list_tools_request) => self
@@ -159,7 +159,7 @@ impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
     async fn handle_error(
         &self,
         jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;
         Ok(())
@@ -168,7 +168,7 @@ impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
     async fn handle_notification(
         &self,
         client_jsonrpc_notification: NotificationFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> SdkResult<()> {
         match client_jsonrpc_notification {
             rust_mcp_schema::schema_utils::NotificationFromClient::ClientNotification(
@@ -214,7 +214,7 @@ impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
         Ok(())
     }
 
-    async fn on_server_started(&self, runtime: &dyn MCPServer) {
+    async fn on_server_started(&self, runtime: &dyn McpServer) {
         self.handler.on_server_started(runtime).await;
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -117,7 +117,7 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
 
                     rust_mcp_schema::ClientRequest::GetPromptRequest(prompt_request) => self
                         .handler
-                        .handle_prompt_request(prompt_request, runtime)
+                        .handle_get_prompt_request(prompt_request, runtime)
                         .await
                         .map(|value| value.into()),
                     rust_mcp_schema::ClientRequest::ListToolsRequest(list_tools_request) => self

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
@@ -8,8 +8,8 @@ use rust_mcp_transport::Transport;
 
 use crate::error::SdkResult;
 use crate::mcp_handlers::mcp_server_handler_core::ServerHandlerCore;
-use crate::mcp_traits::mcp_handler::MCPServerHandler;
-use crate::mcp_traits::mcp_server::MCPServer;
+use crate::mcp_traits::mcp_handler::McpServerHandler;
+use crate::mcp_traits::mcp_server::McpServer;
 
 use super::ServerRuntime;
 
@@ -54,11 +54,11 @@ impl RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>> {
 }
 
 #[async_trait]
-impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>> {
+impl McpServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>> {
     async fn handle_request(
         &self,
         client_jsonrpc_request: RequestFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ResultFromServer, JsonrpcErrorError> {
         // store the client details if the request is a client initialization request
         if let schema_utils::RequestFromClient::ClientRequest(
@@ -81,7 +81,7 @@ impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
     async fn handle_error(
         &self,
         jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;
         Ok(())
@@ -89,7 +89,7 @@ impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
     async fn handle_notification(
         &self,
         client_jsonrpc_notification: NotificationFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> SdkResult<()> {
         // Trigger the `on_initialized()` callback if an `initialized_notification` is received from the client.
         if client_jsonrpc_notification.is_initialized_notification() {
@@ -102,7 +102,7 @@ impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
             .await?;
         Ok(())
     }
-    async fn on_server_started(&self, runtime: &dyn MCPServer) {
+    async fn on_server_started(&self, runtime: &dyn McpServer) {
         self.handler.on_server_started(runtime).await;
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
@@ -9,49 +9,49 @@ use rust_mcp_schema::{
 
 use crate::error::SdkResult;
 
-use super::{mcp_client::MCPClient, mcp_server::MCPServer};
+use super::{mcp_client::McpClient, mcp_server::McpServer};
 
 #[async_trait]
-pub trait MCPServerHandler: Send + Sync {
-    async fn on_server_started(&self, runtime: &dyn MCPServer);
+pub trait McpServerHandler: Send + Sync {
+    async fn on_server_started(&self, runtime: &dyn McpServer);
     async fn handle_request(
         &self,
         client_jsonrpc_request: RequestFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ResultFromServer, JsonrpcErrorError>;
     async fn handle_error(
         &self,
         jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> SdkResult<()>;
     async fn handle_notification(
         &self,
         client_jsonrpc_notification: NotificationFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> SdkResult<()>;
 }
 
 #[async_trait]
-pub trait MCPClientHandler: Send + Sync {
+pub trait McpClientHandler: Send + Sync {
     async fn handle_request(
         &self,
         server_jsonrpc_request: RequestFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<ResultFromClient, JsonrpcErrorError>;
     async fn handle_error(
         &self,
         jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()>;
     async fn handle_notification(
         &self,
         server_jsonrpc_notification: NotificationFromServer,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()>;
 
     async fn handle_process_error(
         &self,
         error_message: String,
-        runtime: &dyn MCPClient,
+        runtime: &dyn McpClient,
     ) -> SdkResult<()>;
 }

--- a/crates/rust-mcp-transport/src/mcp_stream.rs
+++ b/crates/rust-mcp-transport/src/mcp_stream.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{GenericSendError, TransportError},
     message_dispatcher::MessageDispatcher,
-    IOStream,
+    IoStream,
 };
 use futures::Stream;
 use rust_mcp_schema::{schema_utils::RPCMessage, JsonrpcErrorError, RequestId};
@@ -22,23 +22,23 @@ pub struct MCPStream {}
 
 impl MCPStream {
     /// Creates a new asynchronous stream and associated components for handling I/O operations.
-    /// This function takes in a readable stream, a writable stream wrapped in a `Mutex`, and an `IOStream`
+    /// This function takes in a readable stream, a writable stream wrapped in a `Mutex`, and an `IoStream`
     /// # Returns
     ///
     /// A tuple containing:
     /// - A `Pin<Box<dyn Stream<Item = R> + Send>>`: A stream that yields items of type `R`.
     /// - A `MessageDispatcher<R>`: A sender that can be used to send messages of type `R`.
-    /// - An `IOStream`: An error handling stream for managing error I/O (stderr).
+    /// - An `IoStream`: An error handling stream for managing error I/O (stderr).
     pub fn create<R>(
         readable: Pin<Box<dyn tokio::io::AsyncRead + Send + Sync>>,
         writable: Mutex<Pin<Box<dyn tokio::io::AsyncWrite + Send + Sync>>>,
-        error_io: IOStream,
+        error_io: IoStream,
         timeout_msec: u64,
         shutdown_rx: Receiver<bool>,
     ) -> (
         Pin<Box<dyn Stream<Item = R> + Send>>,
         MessageDispatcher<R>,
-        IOStream,
+        IoStream,
     )
     where
         R: RPCMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,

--- a/crates/rust-mcp-transport/src/message_dispatcher.rs
+++ b/crates/rust-mcp-transport/src/message_dispatcher.rs
@@ -14,13 +14,13 @@ use tokio::sync::Mutex;
 
 use crate::error::TransportResult;
 use crate::utils::await_timeout;
-use crate::MCPDispatch;
+use crate::McpDispatch;
 
 /// Provides a dispatcher for sending MCP messages and handling responses.
 ///
 /// `MessageDispatcher` facilitates MCP communication by managing message sending, request tracking,
 /// and response handling. It supports both client-to-server and server-to-client message flows through
-/// implementations of the `MCPDispatch` trait. The dispatcher uses a transport mechanism
+/// implementations of the `McpDispatch` trait. The dispatcher uses a transport mechanism
 /// (e.g., stdin/stdout) to serialize and send messages, and it tracks pending requests with
 /// a configurable timeout mechanism for asynchronous responses.
 pub struct MessageDispatcher<R> {
@@ -90,7 +90,7 @@ impl<R> MessageDispatcher<R> {
 }
 
 #[async_trait]
-impl MCPDispatch<ServerMessage, MessageFromClient> for MessageDispatcher<ServerMessage> {
+impl McpDispatch<ServerMessage, MessageFromClient> for MessageDispatcher<ServerMessage> {
     /// Sends a message from the client to the server and awaits a response if applicable.
     ///
     /// Serializes the `MessageFromClient` to JSON, writes it to the transport, and waits for a
@@ -158,7 +158,7 @@ impl MCPDispatch<ServerMessage, MessageFromClient> for MessageDispatcher<ServerM
 }
 
 #[async_trait]
-impl MCPDispatch<ClientMessage, MessageFromServer> for MessageDispatcher<ClientMessage> {
+impl McpDispatch<ClientMessage, MessageFromServer> for MessageDispatcher<ClientMessage> {
     /// Sends a message from the server to the client and awaits a response if applicable.
     ///
     /// Serializes the `MessageFromServer` to JSON, writes it to the transport, and waits for a

--- a/crates/rust-mcp-transport/src/transport.rs
+++ b/crates/rust-mcp-transport/src/transport.rs
@@ -18,7 +18,7 @@ const DEFAULT_TIMEOUT_MSEC: u64 = 60_000;
 /// - `Readable`: A stream that implements the `AsyncRead` trait for reading data asynchronously.
 /// - `Writable`: A stream that implements the `AsyncWrite` trait for writing data asynchronously.
 ///
-pub enum IOStream {
+pub enum IoStream {
     Readable(Pin<Box<dyn tokio::io::AsyncRead + Send + Sync>>),
     Writable(Pin<Box<dyn tokio::io::AsyncWrite + Send + Sync>>),
 }
@@ -43,7 +43,7 @@ impl Default for TransportOptions {
 ///
 ///It is intended to be implemented by types that send messages in the MCP protocol, such as servers or clients.
 ///
-/// The `MCPDispatch` trait requires two associated types:
+/// The `McpDispatch` trait requires two associated types:
 /// - `R`: The type of the response, which must implement the `MCPMessage` trait and be capable of deserialization.
 /// - `S`: The type of the message to send, which must be serializable and cloneable.
 ///
@@ -72,11 +72,11 @@ impl Default for TransportOptions {
 ///
 /// # Example
 ///
-/// let sender: Box<dyn MCPDispatch<MyResponse, MyMessage>> = ...;
+/// let sender: Box<dyn McpDispatch<MyResponse, MyMessage>> = ...;
 /// let result = sender.send(my_message, Some(request_id)).await;
 ///
 #[async_trait]
-pub trait MCPDispatch<R, S>: Send + Sync + 'static
+pub trait McpDispatch<R, S>: Send + Sync + 'static
 where
     R: MCPMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
     S: Clone + Send + Sync + serde::Serialize + 'static,
@@ -109,10 +109,10 @@ where
     ) -> TransportResult<(
         Pin<Box<dyn Stream<Item = R> + Send>>,
         MessageDispatcher<R>,
-        IOStream,
+        IoStream,
     )>
     where
-        MessageDispatcher<R>: MCPDispatch<R, S>;
+        MessageDispatcher<R>: McpDispatch<R, S>;
     async fn shut_down(&self) -> TransportResult<()>;
     async fn is_shut_down(&self) -> bool;
 }

--- a/examples/hello-world-mcp-server-core/src/handler.rs
+++ b/examples/hello-world-mcp-server-core/src/handler.rs
@@ -4,7 +4,7 @@ use rust_mcp_schema::{
     schema_utils::{CallToolError, NotificationFromClient, RequestFromClient, ResultFromServer},
     ClientRequest, JsonrpcErrorError, ListToolsResult,
 };
-use rust_mcp_sdk::{mcp_server::ServerHandlerCore, MCPServer};
+use rust_mcp_sdk::{mcp_server::ServerHandlerCore, McpServer};
 
 use crate::tools::GreetingTools;
 
@@ -19,22 +19,20 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_request(
         &self,
         request: RequestFromClient,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ResultFromServer, JsonrpcErrorError> {
         let method_name = &request.method().to_owned();
         match request {
             //Handle client requests according to their specific type.
             RequestFromClient::ClientRequest(client_request) => match client_request {
                 // Handle the initialization request
-                ClientRequest::InitializeRequest(_) => {
-                    Ok(runtime.get_server_info().to_owned().into())
-                }
+                ClientRequest::InitializeRequest(_) => Ok(runtime.server_info().to_owned().into()),
 
                 // Handle ListToolsRequest, return list of available tools
                 ClientRequest::ListToolsRequest(_) => Ok(ListToolsResult {
                     meta: None,
                     next_cursor: None,
-                    tools: GreetingTools::get_tools(),
+                    tools: GreetingTools::tools(),
                 }
                 .into()),
 
@@ -76,7 +74,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_notification(
         &self,
         notification: NotificationFromClient,
-        _: &dyn MCPServer,
+        _: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }
@@ -85,7 +83,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_error(
         &self,
         error: JsonrpcErrorError,
-        _: &dyn MCPServer,
+        _: &dyn McpServer,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Ok(())
     }

--- a/examples/hello-world-mcp-server-core/src/main.rs
+++ b/examples/hello-world-mcp-server-core/src/main.rs
@@ -6,7 +6,7 @@ use rust_mcp_schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };
-use rust_mcp_sdk::MCPServer;
+use rust_mcp_sdk::McpServer;
 use rust_mcp_sdk::{error::SdkResult, mcp_server::server_runtime_core};
 use rust_mcp_transport::{StdioTransport, TransportOptions};
 

--- a/examples/hello-world-mcp-server/src/handler.rs
+++ b/examples/hello-world-mcp-server/src/handler.rs
@@ -3,7 +3,7 @@ use rust_mcp_schema::{
     schema_utils::CallToolError, CallToolRequest, CallToolResult, JsonrpcErrorError,
     ListToolsRequest, ListToolsResult,
 };
-use rust_mcp_sdk::{mcp_server::ServerHandler, MCPServer};
+use rust_mcp_sdk::{mcp_server::ServerHandler, McpServer};
 
 use crate::tools::GreetingTools;
 
@@ -20,12 +20,12 @@ impl ServerHandler for MyServerHandler {
     async fn handle_list_tools_request(
         &self,
         request: ListToolsRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<ListToolsResult, JsonrpcErrorError> {
         Ok(ListToolsResult {
             meta: None,
             next_cursor: None,
-            tools: GreetingTools::get_tools(),
+            tools: GreetingTools::tools(),
         })
     }
 
@@ -33,7 +33,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_call_tool_request(
         &self,
         request: CallToolRequest,
-        runtime: &dyn MCPServer,
+        runtime: &dyn McpServer,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         // Attempt to convert request parameters into GreetingTools enum
         let tool_params: GreetingTools =

--- a/examples/hello-world-mcp-server/src/main.rs
+++ b/examples/hello-world-mcp-server/src/main.rs
@@ -10,7 +10,7 @@ use rust_mcp_schema::{
 use rust_mcp_sdk::{
     error::SdkResult,
     mcp_server::{server_runtime, ServerRuntime},
-    MCPServer,
+    McpServer,
 };
 
 use rust_mcp_transport::{StdioTransport, TransportOptions};

--- a/examples/simple-mcp-client-core/src/handler.rs
+++ b/examples/simple-mcp-client-core/src/handler.rs
@@ -3,7 +3,7 @@ use rust_mcp_schema::{
     schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient},
     JsonrpcErrorError,
 };
-use rust_mcp_sdk::{mcp_client::ClientHandlerCore, MCPClient};
+use rust_mcp_sdk::{mcp_client::ClientHandlerCore, McpClient};
 pub struct MyClientHandler;
 
 // To check out a list of all the methods in the trait that you can override, take a look at
@@ -14,7 +14,7 @@ impl ClientHandlerCore for MyClientHandler {
     async fn handle_request(
         &self,
         request: RequestFromServer,
-        _runtime: &dyn MCPClient,
+        _runtime: &dyn McpClient,
     ) -> std::result::Result<ResultFromClient, JsonrpcErrorError> {
         match request {
             RequestFromServer::ServerRequest(server_request) => match server_request {
@@ -39,7 +39,7 @@ impl ClientHandlerCore for MyClientHandler {
     async fn handle_notification(
         &self,
         _notification: NotificationFromServer,
-        _runtime: &dyn MCPClient,
+        _runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Err(JsonrpcErrorError::internal_error()
             .with_message("handle_notification() Not implemented".to_string()))
@@ -48,7 +48,7 @@ impl ClientHandlerCore for MyClientHandler {
     async fn handle_error(
         &self,
         _error: JsonrpcErrorError,
-        _runtime: &dyn MCPClient,
+        _runtime: &dyn McpClient,
     ) -> std::result::Result<(), JsonrpcErrorError> {
         Err(JsonrpcErrorError::internal_error()
             .with_message("handle_error() Not implemented".to_string()))

--- a/examples/simple-mcp-client-core/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-core/src/inquiry_utils.rs
@@ -2,7 +2,7 @@
 
 use colored::Colorize;
 use rust_mcp_schema::CallToolRequestParams;
-use rust_mcp_sdk::MCPClient;
+use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::ClientRuntime};
 use serde_json::json;
 use std::io::Write;
@@ -33,7 +33,7 @@ impl InquiryUtils {
 
     pub fn print_server_info(&self) {
         self.print_header("Server info");
-        let server_version = self.client.get_server_version().unwrap();
+        let server_version = self.client.server_version().unwrap();
         println!("{} {}", "Server name:".bold(), server_version.name.cyan());
         println!(
             "{} {}",

--- a/examples/simple-mcp-client-core/src/main.rs
+++ b/examples/simple-mcp-client-core/src/main.rs
@@ -7,7 +7,7 @@ use inquiry_utils::InquiryUtils;
 use rust_mcp_schema::{
     ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
 };
-use rust_mcp_sdk::MCPClient;
+use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::client_runtime_core};
 use rust_mcp_transport::{StdioTransport, TransportOptions};
 use std::sync::Arc;

--- a/examples/simple-mcp-client/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client/src/inquiry_utils.rs
@@ -2,7 +2,7 @@
 
 use colored::Colorize;
 use rust_mcp_schema::CallToolRequestParams;
-use rust_mcp_sdk::MCPClient;
+use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::ClientRuntime};
 use serde_json::json;
 use std::io::Write;
@@ -33,7 +33,7 @@ impl InquiryUtils {
 
     pub fn print_server_info(&self) {
         self.print_header("Server info");
-        let server_version = self.client.get_server_version().unwrap();
+        let server_version = self.client.server_version().unwrap();
         println!("{} {}", "Server name:".bold(), server_version.name.cyan());
         println!(
             "{} {}",

--- a/examples/simple-mcp-client/src/main.rs
+++ b/examples/simple-mcp-client/src/main.rs
@@ -9,7 +9,7 @@ use rust_mcp_schema::{
 };
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime;
-use rust_mcp_sdk::MCPClient;
+use rust_mcp_sdk::McpClient;
 use rust_mcp_transport::{StdioTransport, TransportOptions};
 use std::sync::Arc;
 


### PR DESCRIPTION
### 📌 Summary

* Mostly resolves naming issues.

* `McpSdkError::AnyError` (vs `McpSdkError::AnyErrorStatic`) had `+ 'static`. I believe this was a copypasta oversight and removed it.


* Cleaned up `Cargo.toml`s and reduced dependency versions to *major*. This way dependent crates can pick up latest, non-API breaking versions, according to semver.

### 🔍 Related Issues

- Fixes (parts of) #7.

### ✨ Changes Made

Made `type` & getter names adhere to official Rust API guidelines.

### 🛠️ Testing Steps

Ran `cargo test`/`cargo test --all-features`; all green.