### PR TITLE
feat: update to latest version of rust-mcp-schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "async-trait",
  "futures",
  "rust-mcp-macros",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.3.0",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",
@@ -193,7 +193,7 @@ dependencies = [
  "async-trait",
  "futures",
  "rust-mcp-macros",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.3.0",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",
@@ -326,7 +326,7 @@ version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.2.2",
  "serde",
  "serde_json",
  "syn",
@@ -343,13 +343,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-mcp-schema"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec89fb6e23c83d24643baa0002dd1f465f6951d46322e18c6f8e41aac270327"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rust-mcp-sdk"
 version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
  "rust-mcp-macros",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.3.0",
  "rust-mcp-transport",
  "serde",
  "serde_json",
@@ -363,7 +373,7 @@ version = "0.1.1"
 dependencies = [
  "async-trait",
  "futures",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.3.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -436,7 +446,7 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.3.0",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",
@@ -452,7 +462,7 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.3.0",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ rust-mcp-sdk = { path = "crates/rust-mcp-sdk" }
 rust-mcp-macros = { version = "0.1", path = "crates/rust-mcp-macros" }
 
 # External crates
-rust-mcp-schema = { version = "0.3.0" }
+rust-mcp-schema = { version = "0.3" }
 futures = { version = "0.3" }
-tokio = { version = "1.44.1", features = ["full"] }
-serde = { version = "1.0.219", features = ["derive", "serde_derive"] }
-serde_json = { version = "1.0.140" }
-async-trait = { version = "0.1.88" }
-strum = { version = "0.27.0", features = ["derive"] }
-thiserror = { version = "2.0.12" }
-tokio-stream = { version = "0.1.17" }
+tokio = { version = "1.4", features = ["full"] }
+serde = { version = "1.0", features = ["derive", "serde_derive"] }
+serde_json = { version = "1.0" }
+async-trait = { version = "0.1" }
+strum = { version = "0.27", features = ["derive"] }
+thiserror = { version = "2.0" }
+tokio-stream = { version = "0.1" }
 
 
 # [workspace.dependencies.windows]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.1.1", path = "crates/rust-mcp-transport" }
+rust-mcp-transport = { version = "0.1", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk" }
-rust-mcp-macros = { version = "0.1.2", path = "crates/rust-mcp-macros" }
+rust-mcp-macros = { version = "0.1", path = "crates/rust-mcp-macros" }
 
 # External crates
-rust-mcp-schema = { version = "0.2.2" }
+rust-mcp-schema = { version = "0.3.0" }
 futures = { version = "0.3" }
 tokio = { version = "1.44.1", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive", "serde_derive"] }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pub struct MyServerHandler;
 #[async_trait]
 impl ServerHandler for MyServerHandler {
     // Handle ListToolsRequest, return list of available tools as ListToolsResult
-    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn MCPServer) -> Result<ListToolsResult, JsonrpcErrorError> {
+    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn MCPServer) -> Result<ListToolsResult, RpcError> {
 
         Ok(ListToolsResult {
             tools: vec![SayHelloTool::get_tool()],

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -70,7 +70,7 @@ pub struct MyServerHandler;
 #[async_trait]
 impl ServerHandler for MyServerHandler {
     // Handle ListToolsRequest, return list of available tools as ListToolsResult
-    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn MCPServer) -> Result<ListToolsResult, JsonrpcErrorError> {
+    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn MCPServer) -> Result<ListToolsResult, RpcError> {
 
         Ok(ListToolsResult {
             tools: vec![SayHelloTool::get_tool()],

--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -1,4 +1,4 @@
-use rust_mcp_schema::JsonrpcErrorError;
+use rust_mcp_schema::RpcError;
 use rust_mcp_transport::error::TransportError;
 use thiserror::Error;
 
@@ -7,7 +7,7 @@ pub type SdkResult<T> = core::result::Result<T, MCPSdkError>;
 #[derive(Debug, Error)]
 pub enum MCPSdkError {
     #[error("{0}")]
-    JsonrpcErrorError(#[from] JsonrpcErrorError),
+    RpcError(#[from] RpcError),
     #[error("{0}")]
     IoError(#[from] std::io::Error),
     #[error("{0}")]

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
 use rust_mcp_schema::{
-    CancelledNotification, CreateMessageRequest, CreateMessageResult, JsonrpcErrorError,
-    ListRootsRequest, ListRootsResult, LoggingMessageNotification, PingRequest,
-    ProgressNotification, PromptListChangedNotification, ResourceListChangedNotification,
-    ResourceUpdatedNotification, Result, ToolListChangedNotification,
+    CancelledNotification, CreateMessageRequest, CreateMessageResult, ListRootsRequest,
+    ListRootsResult, LoggingMessageNotification, PingRequest, ProgressNotification,
+    PromptListChangedNotification, ResourceListChangedNotification, ResourceUpdatedNotification,
+    Result, RpcError, ToolListChangedNotification,
 };
 use serde_json::Value;
 
@@ -22,7 +22,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         request: PingRequest,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<Result, JsonrpcErrorError> {
+    ) -> std::result::Result<Result, RpcError> {
         Ok(Result::default())
     }
 
@@ -30,9 +30,9 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         request: CreateMessageRequest,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<CreateMessageResult, JsonrpcErrorError> {
+    ) -> std::result::Result<CreateMessageResult, RpcError> {
         runtime.assert_client_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -42,9 +42,9 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         request: ListRootsRequest,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<ListRootsResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListRootsResult, RpcError> {
         runtime.assert_client_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -54,8 +54,8 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         request: Value,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<ListRootsResult, JsonrpcErrorError> {
-        Err(JsonrpcErrorError::method_not_found()
+    ) -> std::result::Result<ListRootsResult, RpcError> {
+        Err(RpcError::method_not_found()
             .with_message("No handler is implemented for custom requests.".to_string()))
     }
 
@@ -67,7 +67,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: CancelledNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -75,7 +75,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: ProgressNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -83,7 +83,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: ResourceListChangedNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -91,7 +91,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: ResourceUpdatedNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -99,7 +99,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: PromptListChangedNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -107,7 +107,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: ToolListChangedNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -115,7 +115,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: LoggingMessageNotification,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -123,7 +123,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         notification: Value,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -132,9 +132,9 @@ pub trait ClientHandler: Send + Sync + 'static {
     //********************//
     async fn handle_error(
         &self,
-        error: JsonrpcErrorError,
+        error: RpcError,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -142,7 +142,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         &self,
         error_message: String,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
             eprintln!("Process error: {}", error_message);
         }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
@@ -20,7 +20,7 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
         &self,
         request: RequestFromServer,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<ResultFromClient, JsonrpcErrorError>;
+    ) -> std::result::Result<ResultFromClient, RpcError>;
 
     /// Asynchronously handles an incoming notification from the server.
     ///
@@ -30,7 +30,7 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
         &self,
         notification: NotificationFromServer,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError>;
+    ) -> std::result::Result<(), RpcError>;
 
     /// Asynchronously handles an error received from the server.
     ///
@@ -38,15 +38,15 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
     /// - `error` – The error data received from the MCP server.
     async fn handle_error(
         &self,
-        error: JsonrpcErrorError,
+        error: RpcError,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError>;
+    ) -> std::result::Result<(), RpcError>;
 
     async fn handle_process_error(
         &self,
         error_message: String,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
             eprintln!("Process error: {}", error_message);
         }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -30,10 +30,10 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         initialize_request: InitializeRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<InitializeResult, JsonrpcErrorError> {
+    ) -> std::result::Result<InitializeResult, RpcError> {
         runtime
             .set_client_details(initialize_request.params.clone())
-            .map_err(|err| JsonrpcErrorError::internal_error().with_message(format!("{}", err)))?;
+            .map_err(|err| RpcError::internal_error().with_message(format!("{}", err)))?;
 
         Ok(runtime.get_server_info().to_owned())
     }
@@ -47,7 +47,7 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         _: PingRequest,
         _: &dyn MCPServer,
-    ) -> std::result::Result<Result, JsonrpcErrorError> {
+    ) -> std::result::Result<Result, RpcError> {
         Ok(Result::default())
     }
 
@@ -59,9 +59,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: ListResourcesRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ListResourcesResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListResourcesResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -75,9 +75,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: ListResourceTemplatesRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ListResourceTemplatesResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListResourceTemplatesResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -91,9 +91,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: ReadResourceRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ReadResourceResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ReadResourceResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -107,9 +107,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: SubscribeRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<Result, JsonrpcErrorError> {
+    ) -> std::result::Result<Result, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -123,9 +123,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: UnsubscribeRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<Result, JsonrpcErrorError> {
+    ) -> std::result::Result<Result, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -139,9 +139,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: ListPromptsRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ListPromptsResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListPromptsResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -155,9 +155,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: GetPromptRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<GetPromptResult, JsonrpcErrorError> {
+    ) -> std::result::Result<GetPromptResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -171,9 +171,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: ListToolsRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ListToolsResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListToolsResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -202,9 +202,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: SetLevelRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<Result, JsonrpcErrorError> {
+    ) -> std::result::Result<Result, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -218,9 +218,9 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: CompleteRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<CompleteResult, JsonrpcErrorError> {
+    ) -> std::result::Result<CompleteResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
-        Err(JsonrpcErrorError::method_not_found().with_message(format!(
+        Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
             request.method(),
         )))
@@ -234,8 +234,8 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         request: Value,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<Value, JsonrpcErrorError> {
-        Err(JsonrpcErrorError::method_not_found()
+    ) -> std::result::Result<Value, RpcError> {
+        Err(RpcError::method_not_found()
             .with_message("No handler is implemented for custom requests.".to_string()))
     }
 
@@ -247,7 +247,7 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         notification: InitializedNotification,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -257,7 +257,7 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         notification: CancelledNotification,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -267,7 +267,7 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         notification: ProgressNotification,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -277,7 +277,7 @@ pub trait ServerHandler: Send + Sync + 'static {
         &self,
         notification: RootsListChangedNotification,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -286,7 +286,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_custom_notification(
         &self,
         notification: Value,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
@@ -300,9 +300,9 @@ pub trait ServerHandler: Send + Sync + 'static {
     /// Customize this function in your specific handler to implement behavior tailored to your MCP server's capabilities and requirements.
     async fn handle_error(
         &self,
-        error: JsonrpcErrorError,
+        error: RpcError,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
@@ -27,7 +27,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
         &self,
         request: RequestFromClient,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ResultFromServer, JsonrpcErrorError>;
+    ) -> std::result::Result<ResultFromServer, RpcError>;
 
     /// Asynchronously handles an incoming notification from the client.
     ///
@@ -37,7 +37,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
         &self,
         notification: NotificationFromClient,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError>;
+    ) -> std::result::Result<(), RpcError>;
 
     /// Asynchronously handles an error received from the client.
     ///
@@ -45,9 +45,9 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     /// - `error` – The error data received from the MCP client.
     async fn handle_error(
         &self,
-        error: JsonrpcErrorError,
+        error: RpcError,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError>;
+    ) -> std::result::Result<(), RpcError>;
     async fn on_server_started(&self, runtime: &dyn MCPServer) {
         let _ = runtime
             .stderr_message("Server started successfully".into())

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -7,7 +7,7 @@ use futures::StreamExt;
 use rust_mcp_schema::schema_utils::{self, MessageFromClient, ServerMessage};
 use rust_mcp_schema::{
     InitializeRequest, InitializeRequestParams, InitializeResult, InitializedNotification,
-    JsonrpcErrorError, ServerResult,
+    RpcError, ServerResult,
 };
 use rust_mcp_transport::{IOStream, MCPDispatch, MessageDispatcher, Transport};
 use std::sync::{Arc, RwLock};
@@ -63,7 +63,7 @@ impl ClientRuntime {
             self.send_notification(InitializedNotification::new(None).into())
                 .await?;
         } else {
-            return Err(JsonrpcErrorError::invalid_params()
+            return Err(RpcError::invalid_params()
                 .with_message("Incorrect response to InitializeRequest!".into())
                 .into());
         }
@@ -182,7 +182,7 @@ impl MCPClient for ClientRuntime {
                 Ok(())
             }
             // Failed to acquire read lock, likely due to PoisonError from a thread panic. Returning None.
-            Err(_) => Err(JsonrpcErrorError::internal_error()
+            Err(_) => Err(RpcError::internal_error()
                 .with_message("Internal Error: Failed to acquire write lock.".to_string())
                 .into()),
         }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime.rs
@@ -6,7 +6,7 @@ use rust_mcp_schema::{
         MessageFromClient, NotificationFromServer, RequestFromServer, ResultFromClient,
         ServerMessage,
     },
-    InitializeRequestParams, JsonrpcErrorError,
+    InitializeRequestParams, RpcError,
 };
 use rust_mcp_transport::Transport;
 
@@ -70,7 +70,7 @@ impl MCPClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
         &self,
         server_jsonrpc_request: RequestFromServer,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<ResultFromClient, JsonrpcErrorError> {
+    ) -> std::result::Result<ResultFromClient, RpcError> {
         match server_jsonrpc_request {
             RequestFromServer::ServerRequest(request) => match request {
                 rust_mcp_schema::ServerRequest::PingRequest(ping_request) => self
@@ -102,7 +102,7 @@ impl MCPClientHandler for ClientInternalHandler<Box<dyn ClientHandler>> {
     /// Handles errors received from the server by passing the request to self.handler
     async fn handle_error(
         &self,
-        jsonrpc_error: JsonrpcErrorError,
+        jsonrpc_error: RpcError,
         runtime: &dyn MCPClient,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime_core.rs
@@ -6,7 +6,7 @@ use rust_mcp_schema::{
         MessageFromClient, NotificationFromServer, RequestFromServer, ResultFromClient,
         ServerMessage,
     },
-    InitializeRequestParams, JsonrpcErrorError,
+    InitializeRequestParams, RpcError,
 };
 use rust_mcp_transport::Transport;
 
@@ -67,7 +67,7 @@ impl MCPClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> 
         &self,
         server_jsonrpc_request: RequestFromServer,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<ResultFromClient, JsonrpcErrorError> {
+    ) -> std::result::Result<ResultFromClient, RpcError> {
         // handle request and get the result
         self.handler
             .handle_request(server_jsonrpc_request, runtime)
@@ -76,7 +76,7 @@ impl MCPClientHandler for ClientCoreInternalHandler<Box<dyn ClientHandlerCore>> 
 
     async fn handle_error(
         &self,
-        jsonrpc_error: JsonrpcErrorError,
+        jsonrpc_error: RpcError,
         runtime: &dyn MCPClient,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -4,9 +4,7 @@ pub mod mcp_server_runtime_core;
 use async_trait::async_trait;
 use futures::StreamExt;
 use rust_mcp_schema::schema_utils::MessageFromServer;
-use rust_mcp_schema::{
-    self, schema_utils, InitializeRequestParams, InitializeResult, JsonrpcErrorError,
-};
+use rust_mcp_schema::{self, schema_utils, InitializeRequestParams, InitializeResult, RpcError};
 use rust_mcp_transport::{IOStream, MCPDispatch, MessageDispatcher, Transport};
 use schema_utils::ClientMessage;
 use std::pin::Pin;
@@ -42,7 +40,7 @@ impl MCPServer for ServerRuntime {
                 Ok(())
             }
             // Failed to acquire read lock, likely due to PoisonError from a thread panic. Returning None.
-            Err(_) => Err(JsonrpcErrorError::internal_error()
+            Err(_) => Err(RpcError::internal_error()
                 .with_message("Internal Error: Failed to acquire write lock.".to_string())
                 .into()),
         }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -4,7 +4,7 @@ use rust_mcp_schema::{
         CallToolError, ClientMessage, MessageFromServer, NotificationFromClient, RequestFromClient,
         ResultFromServer,
     },
-    CallToolResult, InitializeResult, JsonrpcErrorError,
+    CallToolResult, InitializeResult, RpcError,
 };
 use rust_mcp_transport::Transport;
 
@@ -61,7 +61,7 @@ impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
         &self,
         client_jsonrpc_request: RequestFromClient,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ResultFromServer, JsonrpcErrorError> {
+    ) -> std::result::Result<ResultFromServer, RpcError> {
         match client_jsonrpc_request {
             rust_mcp_schema::schema_utils::RequestFromClient::ClientRequest(client_request) => {
                 match client_request {
@@ -158,7 +158,7 @@ impl MCPServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
 
     async fn handle_error(
         &self,
-        jsonrpc_error: JsonrpcErrorError,
+        jsonrpc_error: RpcError,
         runtime: &dyn MCPServer,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
@@ -3,7 +3,7 @@ use rust_mcp_schema::schema_utils::{
     self, ClientMessage, MessageFromServer, NotificationFromClient, RequestFromClient,
     ResultFromServer,
 };
-use rust_mcp_schema::{InitializeResult, JsonrpcErrorError};
+use rust_mcp_schema::{InitializeResult, RpcError};
 use rust_mcp_transport::Transport;
 
 use crate::error::SdkResult;
@@ -59,7 +59,7 @@ impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
         &self,
         client_jsonrpc_request: RequestFromClient,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ResultFromServer, JsonrpcErrorError> {
+    ) -> std::result::Result<ResultFromServer, RpcError> {
         // store the client details if the request is a client initialization request
         if let schema_utils::RequestFromClient::ClientRequest(
             rust_mcp_schema::ClientRequest::InitializeRequest(initialize_request),
@@ -68,9 +68,7 @@ impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
             // keep a copy of the InitializeRequestParams which includes client_info and capabilities
             runtime
                 .set_client_details(initialize_request.params.clone())
-                .map_err(|err| {
-                    JsonrpcErrorError::internal_error().with_message(format!("{}", err))
-                })?;
+                .map_err(|err| RpcError::internal_error().with_message(format!("{}", err)))?;
         }
 
         // handle request and get the result
@@ -80,7 +78,7 @@ impl MCPServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
     }
     async fn handle_error(
         &self,
-        jsonrpc_error: JsonrpcErrorError,
+        jsonrpc_error: RpcError,
         runtime: &dyn MCPServer,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_client.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_client.rs
@@ -8,13 +8,13 @@ use rust_mcp_schema::{
     },
     CallToolRequest, CallToolRequestParams, CallToolResult, CompleteRequest, CompleteRequestParams,
     CreateMessageRequest, GetPromptRequest, GetPromptRequestParams, Implementation,
-    InitializeRequestParams, InitializeResult, JsonrpcErrorError, ListPromptsRequest,
-    ListPromptsRequestParams, ListResourceTemplatesRequest, ListResourceTemplatesRequestParams,
-    ListResourcesRequest, ListResourcesRequestParams, ListRootsRequest, ListToolsRequest,
-    ListToolsRequestParams, LoggingLevel, PingRequest, ReadResourceRequest,
-    ReadResourceRequestParams, RootsListChangedNotification, RootsListChangedNotificationParams,
-    ServerCapabilities, SetLevelRequest, SetLevelRequestParams, SubscribeRequest,
-    SubscribeRequestParams, UnsubscribeRequest, UnsubscribeRequestParams,
+    InitializeRequestParams, InitializeResult, ListPromptsRequest, ListPromptsRequestParams,
+    ListResourceTemplatesRequest, ListResourceTemplatesRequestParams, ListResourcesRequest,
+    ListResourcesRequestParams, ListRootsRequest, ListToolsRequest, ListToolsRequestParams,
+    LoggingLevel, PingRequest, ReadResourceRequest, ReadResourceRequestParams,
+    RootsListChangedNotification, RootsListChangedNotificationParams, RpcError, ServerCapabilities,
+    SetLevelRequest, SetLevelRequestParams, SubscribeRequest, SubscribeRequestParams,
+    UnsubscribeRequest, UnsubscribeRequestParams,
 };
 use rust_mcp_transport::{MCPDispatch, MessageDispatcher};
 
@@ -157,7 +157,7 @@ pub trait MCPClient: Sync + Send {
             .await?;
 
         let server_message = response.ok_or_else(|| {
-            JsonrpcErrorError::internal_error()
+            RpcError::internal_error()
                 .with_message("An empty response was received from the server.".to_string())
         })?;
 
@@ -315,13 +315,12 @@ pub trait MCPClient: Sync + Send {
     fn assert_server_capabilities(&self, request_method: &String) -> SdkResult<()> {
         let entity = "Server";
 
-        let capabilities = self.get_server_capabilities().ok_or::<JsonrpcErrorError>(
-            JsonrpcErrorError::internal_error()
-                .with_message("Server is not initialized!".to_string()),
+        let capabilities = self.get_server_capabilities().ok_or::<RpcError>(
+            RpcError::internal_error().with_message("Server is not initialized!".to_string()),
         )?;
 
         if *request_method == SetLevelRequest::method_name() && capabilities.logging.is_none() {
-            return Err(JsonrpcErrorError::internal_error()
+            return Err(RpcError::internal_error()
                 .with_message(format_assertion_message(entity, "logging", request_method))
                 .into());
         }
@@ -333,7 +332,7 @@ pub trait MCPClient: Sync + Send {
         .contains(request_method)
             && capabilities.prompts.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error()
+            return Err(RpcError::internal_error()
                 .with_message(format_assertion_message(entity, "prompts", request_method))
                 .into());
         }
@@ -348,7 +347,7 @@ pub trait MCPClient: Sync + Send {
         .contains(request_method)
             && capabilities.resources.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error()
+            return Err(RpcError::internal_error()
                 .with_message(format_assertion_message(
                     entity,
                     "resources",
@@ -364,7 +363,7 @@ pub trait MCPClient: Sync + Send {
         .contains(request_method)
             && capabilities.tools.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error()
+            return Err(RpcError::internal_error()
                 .with_message(format_assertion_message(entity, "tools", request_method))
                 .into());
         }
@@ -375,20 +374,20 @@ pub trait MCPClient: Sync + Send {
     fn assert_client_notification_capabilities(
         &self,
         notification_method: &String,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         let entity = "Client";
         let capabilities = &self.get_client_info().capabilities;
 
         if *notification_method == RootsListChangedNotification::method_name()
             && capabilities.roots.is_some()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
                     entity,
                     "roots list changed notifications",
                     notification_method,
-                ),
-            ));
+                )),
+            );
         }
 
         Ok(())
@@ -397,21 +396,29 @@ pub trait MCPClient: Sync + Send {
     fn assert_client_request_capabilities(
         &self,
         request_method: &String,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         let entity = "Client";
         let capabilities = &self.get_client_info().capabilities;
 
         if *request_method == CreateMessageRequest::method_name() && capabilities.sampling.is_some()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(entity, "sampling capability", request_method),
-            ));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "sampling capability",
+                    request_method,
+                )),
+            );
         }
 
         if *request_method == ListRootsRequest::method_name() && capabilities.roots.is_some() {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(entity, "roots capability", request_method),
-            ));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "roots capability",
+                    request_method,
+                )),
+            );
         }
 
         Ok(())

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
@@ -4,7 +4,7 @@ use rust_mcp_schema::{
         NotificationFromClient, NotificationFromServer, RequestFromClient, RequestFromServer,
         ResultFromClient, ResultFromServer,
     },
-    JsonrpcErrorError,
+    RpcError,
 };
 
 use crate::error::SdkResult;
@@ -18,12 +18,9 @@ pub trait MCPServerHandler: Send + Sync {
         &self,
         client_jsonrpc_request: RequestFromClient,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ResultFromServer, JsonrpcErrorError>;
-    async fn handle_error(
-        &self,
-        jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPServer,
-    ) -> SdkResult<()>;
+    ) -> std::result::Result<ResultFromServer, RpcError>;
+    async fn handle_error(&self, jsonrpc_error: RpcError, runtime: &dyn MCPServer)
+        -> SdkResult<()>;
     async fn handle_notification(
         &self,
         client_jsonrpc_notification: NotificationFromClient,
@@ -37,12 +34,9 @@ pub trait MCPClientHandler: Send + Sync {
         &self,
         server_jsonrpc_request: RequestFromServer,
         runtime: &dyn MCPClient,
-    ) -> std::result::Result<ResultFromClient, JsonrpcErrorError>;
-    async fn handle_error(
-        &self,
-        jsonrpc_error: JsonrpcErrorError,
-        runtime: &dyn MCPClient,
-    ) -> SdkResult<()>;
+    ) -> std::result::Result<ResultFromClient, RpcError>;
+    async fn handle_error(&self, jsonrpc_error: RpcError, runtime: &dyn MCPClient)
+        -> SdkResult<()>;
     async fn handle_notification(
         &self,
         server_jsonrpc_notification: NotificationFromServer,

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
@@ -5,13 +5,13 @@ use rust_mcp_schema::{
         ResultFromClient,
     },
     CallToolRequest, CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult,
-    GetPromptRequest, Implementation, InitializeRequestParams, InitializeResult, JsonrpcErrorError,
+    GetPromptRequest, Implementation, InitializeRequestParams, InitializeResult,
     ListPromptsRequest, ListResourceTemplatesRequest, ListResourcesRequest, ListRootsRequest,
     ListRootsRequestParams, ListRootsResult, ListToolsRequest, LoggingMessageNotification,
     LoggingMessageNotificationParams, PingRequest, PromptListChangedNotification,
     PromptListChangedNotificationParams, ReadResourceRequest, ResourceListChangedNotification,
     ResourceListChangedNotificationParams, ResourceUpdatedNotification,
-    ResourceUpdatedNotificationParams, ServerCapabilities, SetLevelRequest,
+    ResourceUpdatedNotificationParams, RpcError, ServerCapabilities, SetLevelRequest,
     ToolListChangedNotification, ToolListChangedNotificationParams,
 };
 use rust_mcp_transport::{MCPDispatch, MessageDispatcher};
@@ -62,7 +62,7 @@ pub trait MCPServer: Sync + Send {
             .send(MessageFromServer::RequestFromServer(request), None)
             .await?;
         let client_message = response.ok_or_else(|| {
-            JsonrpcErrorError::internal_error()
+            RpcError::internal_error()
                 .with_message("An empty response was received from the client.".to_string())
         })?;
 
@@ -249,20 +249,29 @@ pub trait MCPServer: Sync + Send {
     fn assert_client_capabilities(
         &self,
         request_method: &String,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         let entity = "Client";
         if *request_method == CreateMessageRequest::method_name()
             && !self.client_supports_sampling().unwrap_or(false)
         {
-            return Err(JsonrpcErrorError::internal_error()
-                .with_message(format_assertion_message(entity, "sampling", request_method)));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "sampling",
+                    request_method,
+                )),
+            );
         }
         if *request_method == ListRootsRequest::method_name()
             && !self.client_supports_root_list().unwrap_or(false)
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(entity, "listing roots", request_method),
-            ));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "listing roots",
+                    request_method,
+                )),
+            );
         }
         Ok(())
     }
@@ -270,7 +279,7 @@ pub trait MCPServer: Sync + Send {
     fn assert_server_notification_capabilities(
         &self,
         notification_method: &String,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         let entity = "Server";
 
         let capabilities = &self.get_server_info().capabilities;
@@ -278,38 +287,46 @@ pub trait MCPServer: Sync + Send {
         if *notification_method == LoggingMessageNotification::method_name()
             && capabilities.logging.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(entity, "logging", notification_method),
-            ));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "logging",
+                    notification_method,
+                )),
+            );
         }
         if *notification_method == ResourceUpdatedNotification::method_name()
             && capabilities.resources.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(entity, "notifying about resources", notification_method),
-            ));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "notifying about resources",
+                    notification_method,
+                )),
+            );
         }
         if *notification_method == ToolListChangedNotification::method_name()
             && capabilities.tools.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
                     entity,
                     "notifying of tool list changes",
                     notification_method,
-                ),
-            ));
+                )),
+            );
         }
         if *notification_method == PromptListChangedNotification::method_name()
             && capabilities.prompts.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
                     entity,
                     "notifying of prompt list changes",
                     notification_method,
-                ),
-            ));
+                )),
+            );
         }
 
         Ok(())
@@ -318,13 +335,18 @@ pub trait MCPServer: Sync + Send {
     fn assert_server_request_capabilities(
         &self,
         request_method: &String,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         let entity = "Server";
         let capabilities = &self.get_server_info().capabilities;
 
         if *request_method == SetLevelRequest::method_name() && capabilities.logging.is_none() {
-            return Err(JsonrpcErrorError::internal_error()
-                .with_message(format_assertion_message(entity, "logging", request_method)));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "logging",
+                    request_method,
+                )),
+            );
         }
         if [
             GetPromptRequest::method_name(),
@@ -333,8 +355,13 @@ pub trait MCPServer: Sync + Send {
         .contains(request_method)
             && capabilities.prompts.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error()
-                .with_message(format_assertion_message(entity, "prompts", request_method)));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "prompts",
+                    request_method,
+                )),
+            );
         }
         if [
             ListResourcesRequest::method_name(),
@@ -344,9 +371,13 @@ pub trait MCPServer: Sync + Send {
         .contains(request_method)
             && capabilities.resources.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error().with_message(
-                format_assertion_message(entity, "resources", request_method),
-            ));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "resources",
+                    request_method,
+                )),
+            );
         }
         if [
             CallToolRequest::method_name(),
@@ -355,8 +386,13 @@ pub trait MCPServer: Sync + Send {
         .contains(request_method)
             && capabilities.tools.is_none()
         {
-            return Err(JsonrpcErrorError::internal_error()
-                .with_message(format_assertion_message(entity, "tools", request_method)));
+            return Err(
+                RpcError::internal_error().with_message(format_assertion_message(
+                    entity,
+                    "tools",
+                    request_method,
+                )),
+            );
         }
         Ok(())
     }

--- a/crates/rust-mcp-transport/src/error.rs
+++ b/crates/rust-mcp-transport/src/error.rs
@@ -1,4 +1,4 @@
-use rust_mcp_schema::{schema_utils::SdkError, JsonrpcErrorError};
+use rust_mcp_schema::{schema_utils::SdkError, RpcError};
 use thiserror::Error;
 
 use core::fmt;
@@ -86,7 +86,7 @@ pub enum TransportError {
     #[error("Send Error: {0}")]
     StdioError(#[from] std::io::Error),
     #[error("{0}")]
-    JsonrpcError(#[from] JsonrpcErrorError),
+    JsonrpcError(#[from] RpcError),
     #[error("{0}")]
     SdkError(#[from] SdkError),
     #[error("Process error{0}")]

--- a/crates/rust-mcp-transport/src/mcp_stream.rs
+++ b/crates/rust-mcp-transport/src/mcp_stream.rs
@@ -4,7 +4,7 @@ use crate::{
     IOStream,
 };
 use futures::Stream;
-use rust_mcp_schema::{schema_utils::RPCMessage, JsonrpcErrorError, RequestId};
+use rust_mcp_schema::{schema_utils::RPCMessage, RequestId, RpcError};
 use std::{
     collections::HashMap,
     pin::Pin,
@@ -98,7 +98,7 @@ impl MCPStream {
                                             // deserialize and send it to the stream
                                             let message: R = serde_json::from_str(&line).map_err(|_| {
                                                 crate::error::TransportError::JsonrpcError(
-                                                    JsonrpcErrorError::parse_error(),
+                                                    RpcError::parse_error(),
                                                 )
                                             })?;
 
@@ -109,7 +109,7 @@ impl MCPStream {
                                                     if let Some(tx_response) = pending_requests.remove(request_id) {
                                                         tx_response.send(message).map_err(|_| {
                                                             crate::error::TransportError::JsonrpcError(
-                                                                JsonrpcErrorError::internal_error(),
+                                                                RpcError::internal_error(),
                                                             )
                                                         })?;
                                                     } else if message.is_error() {

--- a/crates/rust-mcp-transport/src/message_dispatcher.rs
+++ b/crates/rust-mcp-transport/src/message_dispatcher.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use rust_mcp_schema::schema_utils::{
     ClientMessage, FromMessage, MCPMessage, MessageFromClient, MessageFromServer, ServerMessage,
 };
-use rust_mcp_schema::{JsonrpcErrorError, RequestId};
+use rust_mcp_schema::{RequestId, RpcError};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
@@ -138,9 +138,8 @@ impl MCPDispatch<ServerMessage, MessageFromClient> for MessageDispatcher<ServerM
         let mpc_message: ClientMessage = ClientMessage::from_message(message, outgoing_request_id)?;
 
         //serialize the message and write it to the writable_std
-        let message_str = serde_json::to_string(&mpc_message).map_err(|_| {
-            crate::error::TransportError::JsonrpcError(JsonrpcErrorError::parse_error())
-        })?;
+        let message_str = serde_json::to_string(&mpc_message)
+            .map_err(|_| crate::error::TransportError::JsonrpcError(RpcError::parse_error()))?;
 
         writable_std.write_all(message_str.as_bytes()).await?;
         writable_std.write_all(b"\n").await?; // new line
@@ -206,9 +205,8 @@ impl MCPDispatch<ClientMessage, MessageFromServer> for MessageDispatcher<ClientM
         let mpc_message: ServerMessage = ServerMessage::from_message(message, outgoing_request_id)?;
 
         //serialize the message and write it to the writable_std
-        let message_str = serde_json::to_string(&mpc_message).map_err(|_| {
-            crate::error::TransportError::JsonrpcError(JsonrpcErrorError::parse_error())
-        })?;
+        let message_str = serde_json::to_string(&mpc_message)
+            .map_err(|_| crate::error::TransportError::JsonrpcError(RpcError::parse_error()))?;
 
         writable_std.write_all(message_str.as_bytes()).await?;
         writable_std.write_all(b"\n").await?; // new line

--- a/doc/getting-started-mcp-server.md
+++ b/doc/getting-started-mcp-server.md
@@ -145,7 +145,7 @@ Here is the code for `handler.rs` :
 
 use async_trait::async_trait;
 use rust_mcp_schema::{
-    schema_utils::CallToolError, CallToolRequest, CallToolResult, JsonrpcErrorError,
+    schema_utils::CallToolError, CallToolRequest, CallToolResult, RpcError,
     ListToolsRequest, ListToolsResult,
 };
 use rust_mcp_sdk::{mcp_server::ServerHandler, MCPServer};
@@ -162,7 +162,7 @@ impl ServerHandler for MyServerHandler {
         &self,
         request: ListToolsRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ListToolsResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListToolsResult, RpcError> {
         Ok(ListToolsResult {
             meta: None,
             next_cursor: None,

--- a/examples/hello-world-mcp-server-core/src/handler.rs
+++ b/examples/hello-world-mcp-server-core/src/handler.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use rust_mcp_schema::{
     schema_utils::{CallToolError, NotificationFromClient, RequestFromClient, ResultFromServer},
-    ClientRequest, JsonrpcErrorError, ListToolsResult,
+    ClientRequest, ListToolsResult, RpcError,
 };
 use rust_mcp_sdk::{mcp_server::ServerHandlerCore, MCPServer};
 
@@ -20,7 +20,7 @@ impl ServerHandlerCore for MyServerHandler {
         &self,
         request: RequestFromClient,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ResultFromServer, JsonrpcErrorError> {
+    ) -> std::result::Result<ResultFromServer, RpcError> {
         let method_name = &request.method().to_owned();
         match request {
             //Handle client requests according to their specific type.
@@ -50,12 +50,12 @@ impl ServerHandlerCore for MyServerHandler {
                     let result = match tool_params {
                         GreetingTools::SayHelloTool(say_hello_tool) => {
                             say_hello_tool.call_tool().map_err(|err| {
-                                JsonrpcErrorError::internal_error().with_message(err.to_string())
+                                RpcError::internal_error().with_message(err.to_string())
                             })?
                         }
                         GreetingTools::SayGoodbyeTool(say_goodbye_tool) => {
                             say_goodbye_tool.call_tool().map_err(|err| {
-                                JsonrpcErrorError::internal_error().with_message(err.to_string())
+                                RpcError::internal_error().with_message(err.to_string())
                             })?
                         }
                     };
@@ -63,11 +63,11 @@ impl ServerHandlerCore for MyServerHandler {
                 }
 
                 // Return Method not found for any other requests
-                _ => Err(JsonrpcErrorError::method_not_found()
+                _ => Err(RpcError::method_not_found()
                     .with_message(format!("No handler is implemented for '{}'.", method_name,))),
             },
             // Handle custom requests
-            RequestFromClient::CustomRequest(_) => Err(JsonrpcErrorError::method_not_found()
+            RequestFromClient::CustomRequest(_) => Err(RpcError::method_not_found()
                 .with_message("No handler is implemented for custom requests.".to_string())),
         }
     }
@@ -77,16 +77,16 @@ impl ServerHandlerCore for MyServerHandler {
         &self,
         notification: NotificationFromClient,
         _: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 
     // Process incoming client errors
     async fn handle_error(
         &self,
-        error: JsonrpcErrorError,
+        error: RpcError,
         _: &dyn MCPServer,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
+    ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
 }

--- a/examples/hello-world-mcp-server/src/handler.rs
+++ b/examples/hello-world-mcp-server/src/handler.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use rust_mcp_schema::{
-    schema_utils::CallToolError, CallToolRequest, CallToolResult, JsonrpcErrorError,
-    ListToolsRequest, ListToolsResult,
+    schema_utils::CallToolError, CallToolRequest, CallToolResult, ListToolsRequest,
+    ListToolsResult, RpcError,
 };
 use rust_mcp_sdk::{mcp_server::ServerHandler, MCPServer};
 
@@ -21,7 +21,7 @@ impl ServerHandler for MyServerHandler {
         &self,
         request: ListToolsRequest,
         runtime: &dyn MCPServer,
-    ) -> std::result::Result<ListToolsResult, JsonrpcErrorError> {
+    ) -> std::result::Result<ListToolsResult, RpcError> {
         Ok(ListToolsResult {
             meta: None,
             next_cursor: None,

--- a/examples/simple-mcp-client-core/src/handler.rs
+++ b/examples/simple-mcp-client-core/src/handler.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use rust_mcp_schema::{
     schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient},
-    JsonrpcErrorError,
+    RpcError,
 };
 use rust_mcp_sdk::{mcp_client::ClientHandlerCore, MCPClient};
 pub struct MyClientHandler;
@@ -15,23 +15,23 @@ impl ClientHandlerCore for MyClientHandler {
         &self,
         request: RequestFromServer,
         _runtime: &dyn MCPClient,
-    ) -> std::result::Result<ResultFromClient, JsonrpcErrorError> {
+    ) -> std::result::Result<ResultFromClient, RpcError> {
         match request {
             RequestFromServer::ServerRequest(server_request) => match server_request {
                 rust_mcp_schema::ServerRequest::PingRequest(_) => {
                     return Ok(rust_mcp_schema::Result::default().into());
                 }
                 rust_mcp_schema::ServerRequest::CreateMessageRequest(_create_message_request) => {
-                    Err(JsonrpcErrorError::internal_error().with_message(
+                    Err(RpcError::internal_error().with_message(
                         "CreateMessageRequest handler is not implemented".to_string(),
                     ))
                 }
                 rust_mcp_schema::ServerRequest::ListRootsRequest(_list_roots_request) => {
-                    Err(JsonrpcErrorError::internal_error()
+                    Err(RpcError::internal_error()
                         .with_message("ListRootsRequest handler is not implemented".to_string()))
                 }
             },
-            RequestFromServer::CustomRequest(_value) => Err(JsonrpcErrorError::internal_error()
+            RequestFromServer::CustomRequest(_value) => Err(RpcError::internal_error()
                 .with_message("CustomRequest handler is not implemented".to_string())),
         }
     }
@@ -40,17 +40,16 @@ impl ClientHandlerCore for MyClientHandler {
         &self,
         _notification: NotificationFromServer,
         _runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
-        Err(JsonrpcErrorError::internal_error()
+    ) -> std::result::Result<(), RpcError> {
+        Err(RpcError::internal_error()
             .with_message("handle_notification() Not implemented".to_string()))
     }
 
     async fn handle_error(
         &self,
-        _error: JsonrpcErrorError,
+        _error: RpcError,
         _runtime: &dyn MCPClient,
-    ) -> std::result::Result<(), JsonrpcErrorError> {
-        Err(JsonrpcErrorError::internal_error()
-            .with_message("handle_error() Not implemented".to_string()))
+    ) -> std::result::Result<(), RpcError> {
+        Err(RpcError::internal_error().with_message("handle_error() Not implemented".to_string()))
     }
 }


### PR DESCRIPTION
### 📌 Summary
Updated to be compatible with latest version of `rust-mcp-schema`.

### ✨ Changes Made

- updated `rust-mcp-schema` to  `0.3.0`
- refactored code to use `RpcError`, replacing the deprecated ~~`JsonRpcErrorError`~~. 

### 🛠️ Testing Steps
```sh
cargo make test
```
