### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,9 +1,9 @@
 {
-    "crates/rust-mcp-sdk": "0.1.3",
-    "crates/rust-mcp-macros": "0.1.2",
-    "crates/rust-mcp-transport": "0.1.2",
-    "examples/hello-world-mcp-server": "0.1.4",
-    "examples/hello-world-mcp-server-core": "0.1.4",
-    "examples/simple-mcp-client": "0.1.4",
-    "examples/simple-mcp-client-core": "0.1.4"
+    "crates/rust-mcp-sdk": "0.2.0",
+    "crates/rust-mcp-macros": "0.2.0",
+    "crates/rust-mcp-transport": "0.2.0",
+    "examples/hello-world-mcp-server": "0.1.5",
+    "examples/hello-world-mcp-server-core": "0.1.5",
+    "examples/simple-mcp-client": "0.1.5",
+    "examples/simple-mcp-client-core": "0.1.5"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "futures",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "futures",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "colored",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.1", path = "crates/rust-mcp-transport" }
+rust-mcp-transport = { version = "0.2.0", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk" }
-rust-mcp-macros = { version = "0.1", path = "crates/rust-mcp-macros" }
+rust-mcp-macros = { version = "0.2.0", path = "crates/rust-mcp-macros" }
 
 # External crates
 rust-mcp-schema = { version = "0.3" }

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.2...rust-mcp-macros-v0.2.0) (2025-04-16)
+
+
+### ⚠ BREAKING CHANGES
+
+* naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8))
+
+### 🚜 Code Refactoring
+
+* Naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8)) ([2aa469b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2aa469b1f7f53f6cda23141c961467ece738047e))
+
 ## [0.1.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.1...rust-mcp-macros-v0.1.2) (2025-03-30)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.3...rust-mcp-sdk-v0.2.0) (2025-04-16)
+
+
+### ⚠ BREAKING CHANGES
+
+* naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8))
+
+### 🚜 Code Refactoring
+
+* Naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8)) ([2aa469b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2aa469b1f7f53f6cda23141c961467ece738047e))
+
 ## [0.1.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.2...rust-mcp-sdk-v0.1.3) (2025-04-05)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.2...rust-mcp-transport-v0.2.0) (2025-04-16)
+
+
+### ⚠ BREAKING CHANGES
+
+* naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8))
+
+### 🚜 Code Refactoring
+
+* Naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8)) ([2aa469b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2aa469b1f7f53f6cda23141c961467ece738047e))
+
 ## [0.1.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.1...rust-mcp-transport-v0.1.2) (2025-04-05)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.5</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.5</summary>

### Dependencies


</details>

<details><summary>rust-mcp-macros: 0.2.0</summary>

## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.2...rust-mcp-macros-v0.2.0) (2025-04-16)


### ⚠ BREAKING CHANGES

* naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8))

### 🚜 Code Refactoring

* Naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8)) ([2aa469b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2aa469b1f7f53f6cda23141c961467ece738047e))
</details>

<details><summary>rust-mcp-sdk: 0.2.0</summary>

## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.3...rust-mcp-sdk-v0.2.0) (2025-04-16)


### ⚠ BREAKING CHANGES

* naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8))

### 🚜 Code Refactoring

* Naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8)) ([2aa469b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2aa469b1f7f53f6cda23141c961467ece738047e))
</details>

<details><summary>rust-mcp-transport: 0.2.0</summary>

## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.2...rust-mcp-transport-v0.2.0) (2025-04-16)


### ⚠ BREAKING CHANGES

* naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8))

### 🚜 Code Refactoring

* Naming & less constrained dependencies ([#8](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/8)) ([2aa469b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2aa469b1f7f53f6cda23141c961467ece738047e))
</details>

<details><summary>simple-mcp-client: 0.1.5</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.5</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).