### PR TITLE
chore: deprecate renamed functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "async-trait",
  "futures",
  "rust-mcp-macros",
- "rust-mcp-schema 0.3.0",
+ "rust-mcp-schema",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",
@@ -193,7 +193,7 @@ dependencies = [
  "async-trait",
  "futures",
  "rust-mcp-macros",
- "rust-mcp-schema 0.3.0",
+ "rust-mcp-schema",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",
@@ -326,20 +326,10 @@ version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-mcp-schema 0.2.2",
+ "rust-mcp-schema",
  "serde",
  "serde_json",
  "syn",
-]
-
-[[package]]
-name = "rust-mcp-schema"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce760adb906bf71ea5f0f613b671935af2553ab7092d7a668e0e1d39f8f6e9"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -359,7 +349,7 @@ dependencies = [
  "async-trait",
  "futures",
  "rust-mcp-macros",
- "rust-mcp-schema 0.3.0",
+ "rust-mcp-schema",
  "rust-mcp-transport",
  "serde",
  "serde_json",
@@ -373,7 +363,7 @@ version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
- "rust-mcp-schema 0.3.0",
+ "rust-mcp-schema",
  "serde",
  "serde_json",
  "thiserror",
@@ -446,7 +436,7 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema 0.3.0",
+ "rust-mcp-schema",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",
@@ -462,7 +452,7 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema 0.3.0",
+ "rust-mcp-schema",
  "rust-mcp-sdk",
  "rust-mcp-transport",
  "serde",

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn MCPServer) -> Result<ListToolsResult, RpcError> {
 
         Ok(ListToolsResult {
-            tools: vec![SayHelloTool::get_tool()],
+            tools: vec![SayHelloTool::tool()],
             meta: None,
             next_cursor: None,
         })
@@ -160,7 +160,7 @@ async fn main() -> SdkResult<()> {
     // STEP 7: use client methods to communicate with the MCP Server as you wish
 
     // Retrieve and display the list of tools available on the server
-    let server_version = client.get_server_version().unwrap();
+    let server_version = client.server_version().unwrap();
     let tools = client.list_tools(None).await?.tools;
 
     println!("List of tools for {}@{}", server_version.name, server_version.version);

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-rust-mcp-schema = { version = "0.2.1" }
+rust-mcp-schema = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -19,3 +19,6 @@ pub enum McpSdkError {
     #[error("{0}")]
     SdkError(#[from] rust_mcp_schema::schema_utils::SdkError),
 }
+
+#[deprecated(since = "0.2.0", note = "Use `McpSdkError` instead.")]
+pub type MCPSdkError = McpSdkError;

--- a/crates/rust-mcp-sdk/src/mcp_macros/tool_box.rs
+++ b/crates/rust-mcp-sdk/src/mcp_macros/tool_box.rs
@@ -57,6 +57,15 @@ macro_rules! tool_box {
                     )*
                 ]
             }
+
+            #[deprecated(since = "0.2.0", note = "Use `tools()` instead.")]
+            pub fn get_tools() -> Vec<rust_mcp_schema::Tool> {
+                vec![
+                    $(
+                        $tool::tool(),
+                    )*
+                ]
+            }
         }
 
 

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_client.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_client.rs
@@ -35,6 +35,16 @@ pub trait McpClient: Sync + Send {
     fn client_info(&self) -> &InitializeRequestParams;
     fn server_info(&self) -> Option<InitializeResult>;
 
+    #[deprecated(since = "0.2.0", note = "Use `client_info()` instead.")]
+    fn get_client_info(&self) -> &InitializeRequestParams {
+        self.client_info()
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `server_info()` instead.")]
+    fn get_server_info(&self) -> Option<InitializeResult> {
+        self.server_info()
+    }
+
     /// Checks whether the server has been initialized with client
     fn is_initialized(&self) -> bool {
         self.server_info().is_some()
@@ -47,9 +57,20 @@ pub trait McpClient: Sync + Send {
             .map(|server_details| server_details.server_info)
     }
 
+    #[deprecated(since = "0.2.0", note = "Use `server_version()` instead.")]
+    fn get_server_version(&self) -> Option<Implementation> {
+        self.server_info()
+            .map(|server_details| server_details.server_info)
+    }
+
     /// Returns the server's capabilities.
     /// After initialization has completed, this will be populated with the server's reported capabilities.
     fn server_capabilities(&self) -> Option<ServerCapabilities> {
+        self.server_info().map(|item| item.capabilities)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `server_capabilities()` instead.")]
+    fn get_server_capabilities(&self) -> Option<ServerCapabilities> {
         self.server_info().map(|item| item.capabilities)
     }
 
@@ -135,6 +156,10 @@ pub trait McpClient: Sync + Send {
         self.server_info()
             .map(|server_details| server_details.capabilities.logging.is_some())
     }
+    #[deprecated(since = "0.2.0", note = "Use `instructions()` instead.")]
+    fn get_instructions(&self) -> Option<String> {
+        self.server_info()?.instructions
+    }
 
     fn instructions(&self) -> Option<String> {
         self.server_info()?.instructions
@@ -216,7 +241,7 @@ pub trait McpClient: Sync + Send {
         Ok(response.try_into()?)
     }
 
-    async fn prompt(
+    async fn get_prompt(
         &self,
         params: GetPromptRequestParams,
     ) -> SdkResult<rust_mcp_schema::GetPromptResult> {

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
@@ -26,6 +26,16 @@ pub trait McpServer: Sync + Send {
     fn server_info(&self) -> &InitializeResult;
     fn client_info(&self) -> Option<InitializeRequestParams>;
 
+    #[deprecated(since = "0.2.0", note = "Use `client_info()` instead.")]
+    fn get_client_info(&self) -> Option<InitializeRequestParams> {
+        self.client_info()
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `server_info()` instead.")]
+    fn get_server_info(&self) -> &InitializeResult {
+        self.server_info()
+    }
+
     async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<ClientMessage>>>
     where
         MessageDispatcher<ClientMessage>: McpDispatch<ClientMessage, MessageFromServer>;

--- a/doc/getting-started-mcp-server.md
+++ b/doc/getting-started-mcp-server.md
@@ -166,7 +166,7 @@ impl ServerHandler for MyServerHandler {
         Ok(ListToolsResult {
             meta: None,
             next_cursor: None,
-            tools: GreetingTools::get_tools(),
+            tools: GreetingTools::tools(),
         })
     }
 


### PR DESCRIPTION
### 📌 Summary
Deprecating renamed functions in v2.0.0, to minimize disruption for developers using this crate in their ongoing projects.

### ✨ Changes Made
- Deprecated `MCPSdkError i`n favor of `McpSdkError`
- Deprecated `get_tools()` in favor of `tools()`
- Deprecated `get_client_info()` in favor of `client_info()`
- Deprecated `get_server_info()` in favor of `server_info()`
- Deprecated `get_server_version()` in favor of `server_version()`
- Deprecated `get_server_capabilities()` in favor of `server_capabilities()`
- Deprecated `get_instructions()` in favor of `instructions()`
- Deprecated `get_client_info()` in favor of `client_info()`
- Deprecated `get_server_info()` in favor of `server_info()`


### 💡 Additional Notes
This reduces disruption for developers updating to version 2.0.0, though breaking changes may occur, which could be resolved by simply renaming the affected trait object to match its new name.
