### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,9 +1,9 @@
 {
-    "crates/rust-mcp-sdk": "0.2.0",
+    "crates/rust-mcp-sdk": "0.2.1",
     "crates/rust-mcp-macros": "0.2.0",
     "crates/rust-mcp-transport": "0.2.0",
-    "examples/hello-world-mcp-server": "0.1.5",
-    "examples/hello-world-mcp-server-core": "0.1.5",
-    "examples/simple-mcp-client": "0.1.5",
-    "examples/simple-mcp-client-core": "0.1.5"
+    "examples/hello-world-mcp-server": "0.1.6",
+    "examples/hello-world-mcp-server-core": "0.1.6",
+    "examples/simple-mcp-client": "0.1.6",
+    "examples/simple-mcp-client-core": "0.1.6"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "colored",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.0...rust-mcp-sdk-v0.2.1) (2025-04-20)
+
+
+### 🚀 Features
+
+* Introduce Cargo features to isolate client and server code ([#18](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/18)) ([1fa9a6f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1fa9a6f60ec2ece34b68e49855c13489a0889d48))
+
+
+### 📚 Documentation
+
+* Add projects list to readme ([#16](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/16)) ([deee010](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/deee010c84228c00a7f4426d560f7ceb5d2d274f))
+
 ## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.1.3...rust-mcp-sdk-v0.2.0) (2025-04-16)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.6</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.6</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.2.1</summary>

## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.0...rust-mcp-sdk-v0.2.1) (2025-04-20)


### 🚀 Features

* Introduce Cargo features to isolate client and server code ([#18](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/18)) ([1fa9a6f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1fa9a6f60ec2ece34b68e49855c13489a0889d48))


### 📚 Documentation

* Add projects list to readme ([#16](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/16)) ([deee010](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/deee010c84228c00a7f4426d560f7ceb5d2d274f))
</details>

<details><summary>simple-mcp-client: 0.1.6</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.6</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).