### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,9 +1,9 @@
 {
-    "crates/rust-mcp-sdk": "0.2.1",
+    "crates/rust-mcp-sdk": "0.2.2",
     "crates/rust-mcp-macros": "0.2.0",
-    "crates/rust-mcp-transport": "0.2.0",
-    "examples/hello-world-mcp-server": "0.1.6",
-    "examples/hello-world-mcp-server-core": "0.1.6",
-    "examples/simple-mcp-client": "0.1.6",
-    "examples/simple-mcp-client-core": "0.1.6"
+    "crates/rust-mcp-transport": "0.2.1",
+    "examples/hello-world-mcp-server": "0.1.7",
+    "examples/hello-world-mcp-server-core": "0.1.7",
+    "examples/simple-mcp-client": "0.1.7",
+    "examples/simple-mcp-client-core": "0.1.7"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "futures",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "futures",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "colored",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.2.0", path = "crates/rust-mcp-transport" }
+rust-mcp-transport = { version = "0.2.1", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.2.0", path = "crates/rust-mcp-macros" }
 

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.1...rust-mcp-sdk-v0.2.2) (2025-04-26)
+
+
+### 🚀 Features
+
+* Upgrade to rust-mcp-schema v0.4.0 ([#21](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/21)) ([819d113](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/819d1135b469e4aa8e857c81e25c81c331084fb1))
+
+
+### 🐛 Bug Fixes
+
+* Capture launch errors in client-runtime ([#19](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/19)) ([c0d05ab](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c0d05ab73b1ac7edc7c410f2f14f0b86d4343c1d))
+
 ## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.0...rust-mcp-sdk-v0.2.1) (2025-04-20)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.0...rust-mcp-transport-v0.2.1) (2025-04-26)
+
+
+### 🚀 Features
+
+* Upgrade to rust-mcp-schema v0.4.0 ([#21](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/21)) ([819d113](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/819d1135b469e4aa8e857c81e25c81c331084fb1))
+
+
+### 🐛 Bug Fixes
+
+* Capture launch errors in client-runtime ([#19](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/19)) ([c0d05ab](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c0d05ab73b1ac7edc7c410f2f14f0b86d4343c1d))
+
 ## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.1.2...rust-mcp-transport-v0.2.0) (2025-04-16)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.7</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.7</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.2.2</summary>

## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.1...rust-mcp-sdk-v0.2.2) (2025-04-26)


### 🚀 Features

* Upgrade to rust-mcp-schema v0.4.0 ([#21](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/21)) ([819d113](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/819d1135b469e4aa8e857c81e25c81c331084fb1))


### 🐛 Bug Fixes

* Capture launch errors in client-runtime ([#19](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/19)) ([c0d05ab](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c0d05ab73b1ac7edc7c410f2f14f0b86d4343c1d))
</details>

<details><summary>rust-mcp-transport: 0.2.1</summary>

## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.0...rust-mcp-transport-v0.2.1) (2025-04-26)


### 🚀 Features

* Upgrade to rust-mcp-schema v0.4.0 ([#21](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/21)) ([819d113](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/819d1135b469e4aa8e857c81e25c81c331084fb1))


### 🐛 Bug Fixes

* Capture launch errors in client-runtime ([#19](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/19)) ([c0d05ab](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c0d05ab73b1ac7edc7c410f2f14f0b86d4343c1d))
</details>

<details><summary>simple-mcp-client: 0.1.7</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.7</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).