### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,9 +1,9 @@
 {
-    "crates/rust-mcp-sdk": "0.2.2",
-    "crates/rust-mcp-macros": "0.2.0",
+    "crates/rust-mcp-sdk": "0.2.3",
+    "crates/rust-mcp-macros": "0.2.1",
     "crates/rust-mcp-transport": "0.2.1",
-    "examples/hello-world-mcp-server": "0.1.7",
-    "examples/hello-world-mcp-server-core": "0.1.7",
-    "examples/simple-mcp-client": "0.1.7",
-    "examples/simple-mcp-client-core": "0.1.7"
+    "examples/hello-world-mcp-server": "0.1.8",
+    "examples/hello-world-mcp-server-core": "0.1.8",
+    "examples/simple-mcp-client": "0.1.8",
+    "examples/simple-mcp-client-core": "0.1.8"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "futures",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "futures",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "colored",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 # Workspace member crates
 rust-mcp-transport = { version = "0.2.1", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "0.2.0", path = "crates/rust-mcp-macros" }
+rust-mcp-macros = { version = "0.2.1", path = "crates/rust-mcp-macros" }
 
 # External crates
 rust-mcp-schema = { version = "0.4" }

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.2.0...rust-mcp-macros-v0.2.1) (2025-05-01)
+
+
+### 🚀 Features
+
+* Concat support for mcp_tool macro ([#23](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/23)) ([f8bb8f2](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f8bb8f2563cb0f1c8c693aa7ff400bf137da09d8))
+
 ## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.1.2...rust-mcp-macros-v0.2.0) (2025-04-16)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.2...rust-mcp-sdk-v0.2.3) (2025-05-01)
+
+
+### 🐛 Bug Fixes
+
+* Remove unnecessary error wrapper ([#24](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/24)) ([b919fba](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b919fbabd143125df35486f9fd0d5af0c156a2d8))
+
 ## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.1...rust-mcp-sdk-v0.2.2) (2025-04-26)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.8</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.8</summary>

### Dependencies


</details>

<details><summary>rust-mcp-macros: 0.2.1</summary>

## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.2.0...rust-mcp-macros-v0.2.1) (2025-05-01)


### 🚀 Features

* Concat support for mcp_tool macro ([#23](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/23)) ([f8bb8f2](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f8bb8f2563cb0f1c8c693aa7ff400bf137da09d8))
</details>

<details><summary>rust-mcp-sdk: 0.2.3</summary>

## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.2...rust-mcp-sdk-v0.2.3) (2025-05-01)


### 🐛 Bug Fixes

* Remove unnecessary error wrapper ([#24](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/24)) ([b919fba](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b919fbabd143125df35486f9fd0d5af0c156a2d8))
</details>

<details><summary>simple-mcp-client: 0.1.8</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.8</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).