### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,9 +1,9 @@
 {
-    "crates/rust-mcp-sdk": "0.2.3",
+    "crates/rust-mcp-sdk": "0.2.4",
     "crates/rust-mcp-macros": "0.2.1",
     "crates/rust-mcp-transport": "0.2.1",
-    "examples/hello-world-mcp-server": "0.1.8",
-    "examples/hello-world-mcp-server-core": "0.1.8",
-    "examples/simple-mcp-client": "0.1.8",
-    "examples/simple-mcp-client-core": "0.1.8"
+    "examples/hello-world-mcp-server": "0.1.9",
+    "examples/hello-world-mcp-server-core": "0.1.9",
+    "examples/simple-mcp-client": "0.1.9",
+    "examples/simple-mcp-client-core": "0.1.9"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "futures",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "futures",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "colored",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.3...rust-mcp-sdk-v0.2.4) (2025-05-01)
+
+
+### 📚 Documentation
+
+* Update documentation ([#26](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/26)) ([4cf3cb1](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4cf3cb1db8effe10632adb32e7a350cdcdedd69b))
+
 ## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.2...rust-mcp-sdk-v0.2.3) (2025-05-01)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.9</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.9</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.2.4</summary>

## [0.2.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.3...rust-mcp-sdk-v0.2.4) (2025-05-01)


### 📚 Documentation

* Update documentation ([#26](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/26)) ([4cf3cb1](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4cf3cb1db8effe10632adb32e7a350cdcdedd69b))
</details>

<details><summary>simple-mcp-client: 0.1.9</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.9</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).