### PR TITLE
Fix kill on drop on Windows

### DIFF
--- a/crates/rust-mcp-transport/src/stdio.rs
+++ b/crates/rust-mcp-transport/src/stdio.rs
@@ -94,20 +94,9 @@ impl StdioTransport {
     /// # Returns
     /// A tuple of the command string and its arguments.
     fn launch_commands(&self) -> (String, Vec<std::string::String>) {
-        #[cfg(windows)]
-        {
-            let command = "cmd.exe".to_string();
-            let mut command_args = vec!["/c".to_string(), self.command.clone().unwrap_or_default()];
-            command_args.extend(self.args.clone().unwrap_or_default());
-            (command, command_args)
-        }
-
-        #[cfg(unix)]
-        {
-            let command = self.command.clone().unwrap_or_default();
-            let command_args = self.args.clone().unwrap_or_default();
-            (command, command_args)
-        }
+        let command = self.command.clone().unwrap_or_default();
+        let command_args = self.args.clone().unwrap_or_default();
+        (command, command_args)
     }
 }
 


### PR DESCRIPTION
### 📌 Summary
When a `StdioTransport` is dropped, it's child process is meant to be killed along with it. However this does not work on Windows, allowing for zombie stdio processes to stay alive in the background.

### ✨ Changes Made
Seems the code had separate sections for spawning in the child process on both Windows and Unix.

Fix was simple, instead of spawning a "cmd.exe" process and running the command on that:
```rust
let command = "cmd.exe".to_string();
let mut command_args = vec!["/c".to_string(), self.command.clone().unwrap_or_default()];
command_args.extend(self.args.clone().unwrap_or_default());
```

Just run the command directly (as in the Unix case):
```rust
let command = self.command.clone().unwrap_or_default();
let command_args = self.args.clone().unwrap_or_default();
```

In practice, this just meant removing the Windows specific code, and using the Unix specific code for both.

### 🛠️ Testing Steps
Try running a stdio mcp server that does not terminate upon the server closing (e.g. if it's a Typescript server add a setInterval). The Rust program will hang because of the zombie process.

### 💡 Additional Notes
I imagine this bug is a result of development/testing happening on Unix rather than Windows. I am currently developing on Windows so I was able to catch it. Other than this bug, everything else seems to work perfectly. 👍
