### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.2.5",
+    "crates/rust-mcp-sdk": "0.2.6",
     "crates/rust-mcp-macros": "0.2.1",
-    "crates/rust-mcp-transport": "0.2.2",
-    "examples/hello-world-mcp-server": "0.1.10",
-    "examples/hello-world-mcp-server-core": "0.1.1",
-    "examples/simple-mcp-client": "0.1.10",
-    "examples/simple-mcp-client-core": "0.1.10",
-    "examples/hello-world-server-core-sse": "0.1.1",
-    "examples/hello-world-server-sse": "0.1.10",
-    "examples/simple-mcp-client-core-sse": "0.1.1",
-    "examples/simple-mcp-client-sse": "0.1.1"
+    "crates/rust-mcp-transport": "0.2.3",
+    "examples/hello-world-mcp-server": "0.1.11",
+    "examples/hello-world-mcp-server-core": "0.1.2",
+    "examples/simple-mcp-client": "0.1.11",
+    "examples/simple-mcp-client-core": "0.1.11",
+    "examples/hello-world-server-core-sse": "0.1.2",
+    "examples/hello-world-server-sse": "0.1.11",
+    "examples/simple-mcp-client-core-sse": "0.1.2",
+    "examples/simple-mcp-client-sse": "0.1.2"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "colored",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "colored",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "colored",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.2.2", path = "crates/rust-mcp-transport" }
+rust-mcp-transport = { version = "0.2.3", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.2.1", path = "crates/rust-mcp-macros" }
 

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.2.6](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.5...rust-mcp-sdk-v0.2.6) (2025-05-20)
+
 ## [0.2.5](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.4...rust-mcp-sdk-v0.2.5) (2025-05-20)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.2...rust-mcp-transport-v0.2.3) (2025-05-20)
+
+
+### 🐛 Bug Fixes
+
+* Crate packaging issue caused by stray Cargo.toml ([5475b1b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/5475b1bb31b5ec2c211bd49f940be38db17d0d65))
+
 ## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.1...rust-mcp-transport-v0.2.2) (2025-05-20)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.11</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.2</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.2</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.11</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.2.6</summary>

## [0.2.6](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.5...rust-mcp-sdk-v0.2.6) (2025-05-20)
</details>

<details><summary>rust-mcp-transport: 0.2.3</summary>

## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.2...rust-mcp-transport-v0.2.3) (2025-05-20)


### 🐛 Bug Fixes

* Crate packaging issue caused by stray Cargo.toml ([5475b1b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/5475b1bb31b5ec2c211bd49f940be38db17d0d65))
</details>

<details><summary>simple-mcp-client: 0.1.11</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.11</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.2</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.2</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).