### PR TITLE
feat!: update crates to default to the latest MCP schema version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "axum-server",
  "futures",
  "hyper 1.6.0",
+ "reqwest",
  "rust-mcp-macros",
  "rust-mcp-schema",
  "rust-mcp-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -257,9 +257,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -400,9 +400,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -984,9 +984,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -1614,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868d31d0ae0376ba45786eac9058771da06839e83bb961ac7e5997ab3910f086"
+checksum = "49212f1da431236217031807377e6296db06a270224698c426afa94e5dacd8e7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.2.1", path = "crates/rust-mcp-macros" }
 
 # External crates
-rust-mcp-schema = { version = "0.4" }
+rust-mcp-schema = { version = "0.5" }
 futures = { version = "0.3" }
 tokio = { version = "1.4", features = ["full"] }
 serde = { version = "1.0", features = ["derive", "serde_derive"] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,7 +8,7 @@ args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 command = "cargo"
-args = ["clippy", "--workspace", "--all-targets", "--all-features"]
+args = ["clippy", "--workspace", "--all-targets"]
 
 [tasks.test]
 install_crate = "nextest"

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -28,3 +28,16 @@ workspace = true
 
 [lib]
 proc-macro = true
+
+
+[features]
+# defalt features
+default = ["2025_03_26"] # Default features
+
+# activates the latest MCP schema version, this will be updated once a new version of schema is published
+latest = ["2025_03_26"]
+
+# enabled mcp schema version 2025_03_26
+2025_03_26 = ["rust-mcp-schema/2025_03_26"]
+# enabled mcp schema version 2024_11_05
+2024_11_05 = ["rust-mcp-schema/2024_11_05"]

--- a/crates/rust-mcp-macros/README.md
+++ b/crates/rust-mcp-macros/README.md
@@ -19,6 +19,10 @@ The `mcp_tool` macro generates an implementation for the annotated struct that i
 #[mcp_tool(
    name = "write_file",
    description = "Create a new file or completely overwrite an existing file with new content."
+   destructive_hint = false
+   idempotent_hint = false
+   open_world_hint = false
+   read_only_hint = false
 )]
 #[derive(rust_mcp_macros::JsonSchema)]
 pub struct WriteFileTool {
@@ -60,3 +64,11 @@ fn main() {
 <img align="top" src="assets/rust-mcp-stack-icon.png" width="24" style="border-radius:0.2rem;"> Check out [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) , a high-performance, asynchronous toolkit for building MCP servers and clients. Focus on your app's logic while [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) takes care of the rest!
 
 ---
+
+
+**Note**: The following attributes are available only in version `2025_03_26` and later of the MCP Schema, and their values will be used in the [annotations](https://github.com/rust-mcp-stack/rust-mcp-schema/blob/main/src/generated_schema/2025_03_26/mcp_schema.rs#L5557) attribute of the *[Tool struct](https://github.com/rust-mcp-stack/rust-mcp-schema/blob/main/src/generated_schema/2025_03_26/mcp_schema.rs#L5554-L5566).
+
+- `destructive_hint`
+- `idempotent_hint`
+- `open_world_hint`
+- `read_only_hint`

--- a/crates/rust-mcp-macros/tests/macro_test.rs
+++ b/crates/rust-mcp-macros/tests/macro_test.rs
@@ -31,3 +31,58 @@ fn test_rename() {
     let properties = schema.get("properties").unwrap().as_object().unwrap();
     assert_eq!(properties.len(), 2);
 }
+
+#[test]
+#[cfg(feature = "2025_03_26")]
+fn test_mcp_tool() {
+    #[rust_mcp_macros::mcp_tool(
+        name = "example_tool",
+        description = "An example tool",
+        idempotent_hint = true,
+        destructive_hint = true,
+        open_world_hint = true,
+        read_only_hint = true
+    )]
+    #[derive(rust_mcp_macros::JsonSchema)]
+    #[allow(unused)]
+    struct ExampleTool {
+        field1: String,
+        field2: i32,
+    }
+
+    assert_eq!(ExampleTool::tool_name(), "example_tool");
+    let tool: rust_mcp_schema::Tool = ExampleTool::tool();
+    assert_eq!(tool.name, "example_tool");
+    assert_eq!(tool.description.unwrap(), "An example tool");
+    assert!(tool.annotations.as_ref().unwrap().idempotent_hint.unwrap(),);
+    assert!(tool.annotations.as_ref().unwrap().destructive_hint.unwrap(),);
+    assert!(tool.annotations.as_ref().unwrap().open_world_hint.unwrap(),);
+    assert!(tool.annotations.as_ref().unwrap().read_only_hint.unwrap(),);
+
+    let schema_properties = tool.input_schema.properties.unwrap();
+    assert_eq!(schema_properties.len(), 2);
+    assert!(schema_properties.contains_key("field1"));
+    assert!(schema_properties.contains_key("field2"));
+}
+
+#[test]
+#[cfg(feature = "2024_11_05")]
+fn test_mcp_tool() {
+    #[rust_mcp_macros::mcp_tool(name = "example_tool", description = "An example tool")]
+    #[derive(rust_mcp_macros::JsonSchema)]
+    #[allow(unused)]
+    struct ExampleTool {
+        field1: String,
+        field2: i32,
+    }
+
+    assert_eq!(ExampleTool::tool_name(), "example_tool");
+    let tool: rust_mcp_schema::Tool = ExampleTool::tool();
+    assert_eq!(tool.name, "example_tool");
+    assert_eq!(tool.description.unwrap(), "An example tool");
+
+    let schema_properties = tool.input_schema.properties.unwrap();
+    assert_eq!(schema_properties.len(), 2);
+    assert!(schema_properties.contains_key("field1"));
+    assert!(schema_properties.contains_key("field2"));
+}

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 hyper = { version = "1.6.0" }
 
 [dev-dependencies]
+reqwest = { workspace = true, features = ["stream"] }
 tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "std",

--- a/crates/rust-mcp-sdk/src/hyper_servers.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers.rs
@@ -2,6 +2,7 @@ mod app_state;
 pub mod error;
 pub mod hyper_server;
 pub mod hyper_server_core;
+mod middlewares;
 mod routes;
 mod server;
 mod session_store;

--- a/crates/rust-mcp-sdk/src/hyper_servers/app_state.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/app_state.rs
@@ -18,5 +18,6 @@ pub struct AppState {
     pub server_details: Arc<InitializeResult>,
     pub handler: Arc<dyn McpServerHandler>,
     pub ping_interval: Duration,
+    pub sse_message_endpoint: String,
     pub transport_options: Arc<TransportOptions>,
 }

--- a/crates/rust-mcp-sdk/src/hyper_servers/middlewares.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/middlewares.rs
@@ -1,0 +1,1 @@
+pub(crate) mod session_id_gen;

--- a/crates/rust-mcp-sdk/src/hyper_servers/middlewares/session_id_gen.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/middlewares/session_id_gen.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+use hyper::StatusCode;
+use rust_mcp_transport::SessionId;
+
+use crate::hyper_servers::app_state::AppState;
+
+// Middleware to generate and attach a session ID
+pub async fn generate_session_id(
+    State(state): State<Arc<AppState>>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let session_id: SessionId = state.id_generator.generate();
+    request.extensions_mut().insert(session_id);
+    // Proceed to the next middleware or handler
+    Ok(next.run(request).await)
+}

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/messages_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/messages_routes.rs
@@ -1,6 +1,9 @@
-use crate::hyper_servers::{
-    app_state::AppState,
-    error::{TransportServerError, TransportServerResult},
+use crate::{
+    hyper_servers::{
+        app_state::AppState,
+        error::{TransportServerError, TransportServerResult},
+    },
+    utils::remove_query_and_hash,
 };
 use axum::{
     extract::{Query, State},
@@ -11,10 +14,11 @@ use axum::{
 use std::{collections::HashMap, sync::Arc};
 use tokio::io::AsyncWriteExt;
 
-const SSE_MESSAGES_PATH: &str = "/messages";
-
-pub fn routes(_state: Arc<AppState>) -> Router<Arc<AppState>> {
-    Router::new().route(SSE_MESSAGES_PATH, post(handle_messages))
+pub fn routes(state: Arc<AppState>) -> Router<Arc<AppState>> {
+    Router::new().route(
+        remove_query_and_hash(&state.sse_message_endpoint).as_str(),
+        post(handle_messages),
+    )
 }
 
 pub async fn handle_messages(

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
@@ -27,7 +27,6 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 
-const SSE_MESSAGES_PATH: &str = "/messages";
 const CLIENT_PING_TIMEOUT: Duration = Duration::from_secs(2);
 
 const DUPLEX_BUFFER_SIZE: usize = 8192;

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
@@ -1,21 +1,25 @@
 use crate::{
     error::McpSdkError,
-    hyper_servers::{app_state::AppState, error::TransportServerResult},
+    hyper_servers::{
+        app_state::AppState, error::TransportServerResult,
+        middlewares::session_id_gen::generate_session_id,
+    },
     mcp_server::{server_runtime, ServerRuntime},
     mcp_traits::mcp_handler::McpServerHandler,
     McpServer,
 };
 use axum::{
     extract::State,
+    middleware,
     response::{
         sse::{Event, KeepAlive},
         IntoResponse, Sse,
     },
     routing::get,
-    Router,
+    Extension, Router,
 };
 use futures::stream::{self};
-use rust_mcp_transport::{error::TransportError, SseTransport};
+use rust_mcp_transport::{error::TransportError, SessionId, SseTransport};
 use std::{convert::Infallible, sync::Arc, time::Duration};
 use tokio::{
     io::{duplex, AsyncBufReadExt, BufReader},
@@ -37,10 +41,8 @@ const DUPLEX_BUFFER_SIZE: usize = 8192;
 ///
 /// # Returns
 /// * `Result<Event, Infallible>` - The constructed SSE event, infallible
-fn initial_event(session_id: &str) -> Result<Event, Infallible> {
-    Ok(Event::default()
-        .event("endpoint")
-        .data(format!("{SSE_MESSAGES_PATH}?sessionId={session_id}")))
+fn initial_event(endpoint: &str) -> Result<Event, Infallible> {
+    Ok(Event::default().event("endpoint").data(endpoint))
 }
 
 /// Configures the SSE routes for the application
@@ -53,8 +55,13 @@ fn initial_event(session_id: &str) -> Result<Event, Infallible> {
 ///
 /// # Returns
 /// * `Router<Arc<AppState>>` - An Axum router configured with the SSE route
-pub fn routes(_state: Arc<AppState>, sse_endpoint: &str) -> Router<Arc<AppState>> {
-    Router::new().route(sse_endpoint, get(handle_sse))
+pub fn routes(state: Arc<AppState>, sse_endpoint: &str) -> Router<Arc<AppState>> {
+    Router::new()
+        .route(sse_endpoint, get(handle_sse))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            generate_session_id,
+        ))
 }
 
 /// Handles Server-Sent Events (SSE) connections
@@ -68,15 +75,17 @@ pub fn routes(_state: Arc<AppState>, sse_endpoint: &str) -> Router<Arc<AppState>
 /// # Returns
 /// * `TransportServerResult<impl IntoResponse>` - The SSE response stream or an error
 pub async fn handle_sse(
+    Extension(session_id): Extension<SessionId>,
     State(state): State<Arc<AppState>>,
 ) -> TransportServerResult<impl IntoResponse> {
+    let messages_endpoint =
+        SseTransport::message_endpoint(&state.sse_message_endpoint, &session_id);
+
     // readable stream of string to be used in transport
     let (read_tx, read_rx) = duplex(DUPLEX_BUFFER_SIZE);
     // writable stream to deliver message to the client
     let (write_tx, write_rx) = duplex(DUPLEX_BUFFER_SIZE);
 
-    // generate a session id, and keep it in the server state
-    let session_id = state.id_generator.generate();
     state
         .session_store
         .set(session_id.to_owned(), read_tx)
@@ -140,7 +149,7 @@ pub async fn handle_sse(
     });
 
     // Initial SSE message to inform the client about the server's endpoint
-    let initial_event = stream::once(async move { initial_event(&session_id) });
+    let initial_event = stream::once(async move { initial_event(&messages_endpoint) });
 
     // Construct SSE stream for sending MCP messages to the server
     let reader = BufReader::new(write_rx);

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -23,6 +23,8 @@ const DEFAULT_CLIENT_PING_INTERVAL: Duration = Duration::from_secs(12);
 
 // Default Server-Sent Events (SSE) endpoint path
 const DEFAULT_SSE_ENDPOINT: &str = "/sse";
+// Default MCP Messages endpoint path
+const DEFAULT_MESSAGES_ENDPOINT: &str = "/messages";
 
 /// Configuration struct for the Hyper server
 /// Used to configure the HyperServer instance.
@@ -31,9 +33,10 @@ pub struct HyperServerOptions {
     pub host: String,
     /// Hostname or IP address the server will bind to (default: "localhost")
     pub port: u16,
-    /// Optional custom path for the Server-Sent Events (SSE) endpoint.
-    /// If `None`, the default path `/sse` will be used.
+    /// Optional custom path for the Server-Sent Events (SSE) endpoint (default: `/sse`)
     pub custom_sse_endpoint: Option<String>,
+    /// Optional custom path for the MCP messages endpoint (default: `/messages`)
+    pub custom_messages_endpoint: Option<String>,
     /// Interval between automatic ping messages sent to clients to detect disconnects
     pub ping_interval: Duration,
     /// Enables SSL/TLS if set to `true`
@@ -121,6 +124,12 @@ impl HyperServerOptions {
             .as_deref()
             .unwrap_or(DEFAULT_SSE_ENDPOINT)
     }
+
+    pub fn sse_messages_endpoint(&self) -> &str {
+        self.custom_messages_endpoint
+            .as_deref()
+            .unwrap_or(DEFAULT_MESSAGES_ENDPOINT)
+    }
 }
 
 /// Default implementation for HyperServerOptions
@@ -133,6 +142,7 @@ impl Default for HyperServerOptions {
             host: "127.0.0.1".to_string(),
             port: 8080,
             custom_sse_endpoint: None,
+            custom_messages_endpoint: None,
             ping_interval: DEFAULT_CLIENT_PING_INTERVAL,
             transport_options: Default::default(),
             enable_ssl: false,
@@ -172,6 +182,7 @@ impl HyperServer {
             server_details: Arc::new(server_details),
             handler,
             ping_interval: server_options.ping_interval,
+            sse_message_endpoint: server_options.sse_messages_endpoint().to_owned(),
             transport_options: Arc::clone(&server_options.transport_options),
         });
         let app = app_routes(Arc::clone(&state), &server_options);

--- a/crates/rust-mcp-sdk/src/hyper_servers/session_store.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/session_store.rs
@@ -3,14 +3,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 pub use in_memory::*;
+use rust_mcp_transport::SessionId;
 use tokio::{io::DuplexStream, sync::Mutex};
 use uuid::Uuid;
 
 // Type alias for the server-side duplex stream used in sessions
 pub type TxServer = DuplexStream;
-
-// Type alias for session identifier, represented as a String
-pub type SessionId = String;
 
 /// Trait defining the interface for session storage operations
 ///

--- a/crates/rust-mcp-sdk/src/hyper_servers/session_store.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/session_store.rs
@@ -37,6 +37,10 @@ pub trait SessionStore: Send + Sync {
     async fn delete(&self, key: &SessionId);
     /// Clears all sessions from the store
     async fn clear(&self);
+
+    async fn keys(&self) -> Vec<SessionId>;
+
+    async fn values(&self) -> Vec<Arc<Mutex<DuplexStream>>>;
 }
 
 /// Trait for generating session identifiers

--- a/crates/rust-mcp-sdk/src/hyper_servers/session_store/in_memory.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/session_store/in_memory.rs
@@ -3,6 +3,7 @@ use super::{SessionStore, TxServer};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::io::DuplexStream;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
@@ -53,5 +54,13 @@ impl SessionStore for InMemorySessionStore {
     async fn clear(&self) {
         let mut store = self.store.write().await;
         store.clear();
+    }
+    async fn keys(&self) -> Vec<SessionId> {
+        let store = self.store.read().await;
+        store.keys().cloned().collect::<Vec<_>>()
+    }
+    async fn values(&self) -> Vec<Arc<Mutex<DuplexStream>>> {
+        let store = self.store.read().await;
+        store.values().cloned().collect::<Vec<_>>()
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -12,10 +12,10 @@ use std::sync::{Arc, RwLock};
 use tokio::io::AsyncWriteExt;
 
 use crate::error::SdkResult;
-#[cfg(feature = "hyper-server")]
-use crate::hyper_servers::SessionId;
 use crate::mcp_traits::mcp_handler::McpServerHandler;
 use crate::mcp_traits::mcp_server::McpServer;
+#[cfg(feature = "hyper-server")]
+use rust_mcp_transport::SessionId;
 
 /// Struct representing the runtime core of the MCP server, handling transport and client details
 pub struct ServerRuntime {

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -12,7 +12,7 @@ use rust_mcp_transport::Transport;
 
 use super::ServerRuntime;
 #[cfg(feature = "hyper-server")]
-use crate::hyper_servers::SessionId;
+use rust_mcp_transport::SessionId;
 
 use crate::{
     error::SdkResult,

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -31,6 +31,7 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
 /// # Returns
 /// A String containing the base path without query parameters or fragment
 /// ```
+#[allow(unused)]
 pub(crate) fn remove_query_and_hash(endpoint: &str) -> String {
     // Split off fragment (if any) and take the first part
     let without_fragment = endpoint.split_once('#').map_or(endpoint, |(path, _)| path);

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -22,3 +22,36 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
         entity, capability, method_name
     )
 }
+
+/// Removes query string and hash fragment from a URL, returning the base path.
+///
+/// # Arguments
+/// * `endpoint` - The URL or endpoint to process (e.g., "/messages?foo=bar#section1")
+///
+/// # Returns
+/// A String containing the base path without query parameters or fragment
+///
+/// # Examples
+/// ```
+/// assert_eq!(remove_query_and_hash("/messages"), "/messages");
+/// assert_eq!(remove_query_and_hash("/messages?foo=bar&baz=qux"), "/messages");
+/// assert_eq!(remove_query_and_hash("/messages#section1"), "/messages");
+/// assert_eq!(remove_query_and_hash("/messages?key=value#section2"), "/messages");
+/// assert_eq!(remove_query_and_hash("/"), "/");
+/// ```
+pub fn remove_query_and_hash(endpoint: &str) -> String {
+    // Split off fragment (if any) and take the first part
+    let without_fragment = endpoint.split_once('#').map_or(endpoint, |(path, _)| path);
+
+    // Split off query string (if any) and take the first part
+    let without_query = without_fragment
+        .split_once('?')
+        .map_or(without_fragment, |(path, _)| path);
+
+    // Return the base path
+    if without_query.is_empty() {
+        "/".to_string()
+    } else {
+        without_query.to_string()
+    }
+}

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -30,16 +30,8 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
 ///
 /// # Returns
 /// A String containing the base path without query parameters or fragment
-///
-/// # Examples
 /// ```
-/// assert_eq!(remove_query_and_hash("/messages"), "/messages");
-/// assert_eq!(remove_query_and_hash("/messages?foo=bar&baz=qux"), "/messages");
-/// assert_eq!(remove_query_and_hash("/messages#section1"), "/messages");
-/// assert_eq!(remove_query_and_hash("/messages?key=value#section2"), "/messages");
-/// assert_eq!(remove_query_and_hash("/"), "/");
-/// ```
-pub fn remove_query_and_hash(endpoint: &str) -> String {
+pub(crate) fn remove_query_and_hash(endpoint: &str) -> String {
     // Split off fragment (if any) and take the first part
     let without_fragment = endpoint.split_once('#').map_or(endpoint, |(path, _)| path);
 
@@ -53,5 +45,24 @@ pub fn remove_query_and_hash(endpoint: &str) -> String {
         "/".to_string()
     } else {
         without_query.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn tets_remove_query_and_hash() {
+        assert_eq!(remove_query_and_hash("/messages"), "/messages");
+        assert_eq!(
+            remove_query_and_hash("/messages?foo=bar&baz=qux"),
+            "/messages"
+        );
+        assert_eq!(remove_query_and_hash("/messages#section1"), "/messages");
+        assert_eq!(
+            remove_query_and_hash("/messages?key=value#section2"),
+            "/messages"
+        );
+        assert_eq!(remove_query_and_hash("/"), "/");
     }
 }

--- a/crates/rust-mcp-sdk/tests/common/common.rs
+++ b/crates/rust-mcp-sdk/tests/common/common.rs
@@ -1,8 +1,10 @@
+mod test_server;
 use async_trait::async_trait;
 use rust_mcp_schema::{
     ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
 };
 use rust_mcp_sdk::mcp_client::ClientHandler;
+pub use test_server::*;
 
 pub const NPX_SERVER_EVERYTHING: &str = "@modelcontextprotocol/server-everything";
 
@@ -24,3 +26,11 @@ pub struct TestClientHandler;
 
 #[async_trait]
 impl ClientHandler for TestClientHandler {}
+
+pub fn sse_event(sse_raw: &str) -> String {
+    sse_raw.replace("event: ", "")
+}
+
+pub fn sse_data(sse_raw: &str) -> String {
+    sse_raw.replace("data: ", "")
+}

--- a/crates/rust-mcp-sdk/tests/common/test_server.rs
+++ b/crates/rust-mcp-sdk/tests/common/test_server.rs
@@ -1,0 +1,118 @@
+use async_trait::async_trait;
+use tokio_stream::StreamExt;
+
+use rust_mcp_schema::{
+    Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
+    LATEST_PROTOCOL_VERSION,
+};
+use rust_mcp_sdk::{
+    mcp_server::{hyper_server, HyperServer, HyperServerOptions, IdGenerator, ServerHandler},
+    McpServer, SessionId,
+};
+use std::sync::RwLock;
+use std::time::Duration;
+use tokio::time::timeout;
+
+pub const INITIALIZE_REQUEST: &str = r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2.0","capabilities":{"sampling":{},"roots":{"listChanged":true}},"clientInfo":{"name":"reqwest-test","version":"0.1.0"}}}"#;
+pub const PING_REQUEST: &str = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+
+pub fn test_server_details() -> InitializeResult {
+    InitializeResult {
+        // server name and version
+        server_info: Implementation {
+            name: "Test MCP Server".to_string(),
+            version: "0.1.0".to_string(),
+        },
+        capabilities: ServerCapabilities {
+            // indicates that server support mcp tools
+            tools: Some(ServerCapabilitiesTools { list_changed: None }),
+            ..Default::default() // Using default values for other fields
+        },
+        meta: None,
+        instructions: Some("server instructions...".to_string()),
+        protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
+    }
+}
+
+pub struct TestServerHandler;
+
+#[async_trait]
+impl ServerHandler for TestServerHandler {
+    async fn on_server_started(&self, runtime: &dyn McpServer) {
+        let _ = runtime
+            .stderr_message("Server started successfully".into())
+            .await;
+    }
+}
+
+pub fn create_test_server(options: HyperServerOptions) -> HyperServer {
+    hyper_server::create_server(test_server_details(), TestServerHandler {}, options)
+}
+
+// Tests the session ID generator, ensuring it returns a sequence of predefined session IDs.
+pub struct TestIdGenerator {
+    constant_ids: Vec<SessionId>,
+    generated: RwLock<usize>,
+}
+
+impl TestIdGenerator {
+    pub fn new(constant_ids: Vec<SessionId>) -> Self {
+        TestIdGenerator {
+            constant_ids,
+            generated: RwLock::new(0),
+        }
+    }
+}
+
+impl IdGenerator for TestIdGenerator {
+    fn generate(&self) -> SessionId {
+        let mut lock = self.generated.write().unwrap();
+        *lock += 1;
+        if *lock > self.constant_ids.len() {
+            *lock = 1;
+        }
+        self.constant_ids[*lock - 1].to_owned()
+    }
+}
+
+pub async fn collect_sse_lines(
+    response: reqwest::Response,
+    line_count: usize,
+    read_timeout: Duration,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut collected_lines = Vec::new();
+    let mut stream = response.bytes_stream();
+
+    let result = timeout(read_timeout, async {
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+            let chunk_str = String::from_utf8_lossy(&chunk);
+
+            // Split the chunk into lines
+            let lines: Vec<&str> = chunk_str.lines().collect();
+
+            // Add each line to the collected_lines vector
+            for line in lines {
+                collected_lines.push(line.to_string());
+
+                // Check if we have collected 5 lines
+                if collected_lines.len() >= line_count {
+                    return Ok(collected_lines);
+                }
+            }
+        }
+        // If the stream ends before collecting 5 lines, return what we have
+        Ok(collected_lines)
+    })
+    .await;
+
+    // Handle timeout or stream result
+    match result {
+        Ok(Ok(lines)) => Ok(lines),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "Timed out waiting for 5 lines",
+        ))),
+    }
+}

--- a/crates/rust-mcp-sdk/tests/test_client_runtime.rs
+++ b/crates/rust-mcp-sdk/tests/test_client_runtime.rs
@@ -1,8 +1,7 @@
-use common::{test_client_info, TestClientHandler, NPX_SERVER_EVERYTHING};
-use rust_mcp_sdk::{mcp_client::client_runtime, McpClient, StdioTransport, TransportOptions};
-
 #[cfg(unix)]
 use common::UVX_SERVER_GIT;
+use common::{test_client_info, TestClientHandler, NPX_SERVER_EVERYTHING};
+use rust_mcp_sdk::{mcp_client::client_runtime, McpClient, StdioTransport, TransportOptions};
 
 #[path = "common/common.rs"]
 pub mod common;

--- a/crates/rust-mcp-sdk/tests/test_server_sse.rs
+++ b/crates/rust-mcp-sdk/tests/test_server_sse.rs
@@ -1,5 +1,194 @@
+use std::{sync::Arc, time::Duration};
+
+use common::{
+    collect_sse_lines, create_test_server, sse_data, sse_event, TestIdGenerator, INITIALIZE_REQUEST,
+};
+use reqwest::Client;
+use rust_mcp_schema::{
+    schema_utils::{ResultFromServer, ServerMessage},
+    ServerResult,
+};
+use rust_mcp_sdk::mcp_server::HyperServerOptions;
+use tokio::time::sleep;
+
 #[path = "common/common.rs"]
 pub mod common;
 
 #[tokio::test]
-async fn tets_server_sse() {}
+async fn tets_sse_endpoint_event_default() {
+    let server_options = HyperServerOptions {
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        ..Default::default()
+    };
+
+    let base_url = format!("http://{}:{}", server_options.host, server_options.port);
+
+    let server_endpoint = format!("{}{}", base_url, server_options.sse_endpoint());
+
+    tokio::spawn(async move {
+        let server = create_test_server(server_options);
+        server.start().await.unwrap();
+    });
+
+    sleep(Duration::from_millis(750)).await;
+
+    let client = Client::new();
+    println!("connecting to : {}", server_endpoint);
+    // Act: Connect to the SSE endpoint and read the event stream
+    let response = client
+        .get(server_endpoint)
+        .header("Accept", "text/event-stream")
+        .send()
+        .await
+        .expect("Failed to connect to SSE endpoint");
+
+    assert_eq!(
+        response.headers().get("content-type").map(|v| v.as_bytes()),
+        Some(b"text/event-stream" as &[u8]),
+        "Response content-type should be text/event-stream"
+    );
+
+    let lines = collect_sse_lines(response, 2, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    assert_eq!(sse_event(&lines[0]), "endpoint");
+    assert_eq!(sse_data(&lines[1]), "/messages?sessionId=AAA-BBB-CCC");
+
+    let message_endpoint = format!("{}{}", base_url, sse_data(&lines[1]));
+    let res = client
+        .post(message_endpoint)
+        .header("Content-Type", "application/json")
+        .body(INITIALIZE_REQUEST.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert!(res.status().is_success());
+}
+
+#[tokio::test]
+async fn tets_sse_message_endpoint_query_hash() {
+    let server_options = HyperServerOptions {
+        custom_messages_endpoint: Some(
+            "/custom-msg-endpoint?something=true&otherthing=false#section-59".to_string(),
+        ),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        ..Default::default()
+    };
+
+    let base_url = format!("http://{}:{}", server_options.host, server_options.port);
+
+    let server_endpoint = format!("{}{}", base_url, server_options.sse_endpoint());
+
+    tokio::spawn(async move {
+        let server = create_test_server(server_options);
+        server.start().await.unwrap();
+    });
+
+    sleep(Duration::from_millis(750)).await;
+
+    let client = Client::new();
+    println!("connecting to : {}", server_endpoint);
+    // Act: Connect to the SSE endpoint and read the event stream
+    let response = client
+        .get(server_endpoint)
+        .header("Accept", "text/event-stream")
+        .send()
+        .await
+        .expect("Failed to connect to SSE endpoint");
+
+    assert_eq!(
+        response.headers().get("content-type").map(|v| v.as_bytes()),
+        Some(b"text/event-stream" as &[u8]),
+        "Response content-type should be text/event-stream"
+    );
+
+    let lines = collect_sse_lines(response, 2, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    assert_eq!(sse_event(&lines[0]), "endpoint");
+    assert_eq!(
+        sse_data(&lines[1]),
+        "/custom-msg-endpoint?something=true&otherthing=false&sessionId=AAA-BBB-CCC#section-59"
+    );
+
+    let message_endpoint = format!("{}{}", base_url, sse_data(&lines[1]));
+    let res = client
+        .post(message_endpoint)
+        .header("Content-Type", "application/json")
+        .body(INITIALIZE_REQUEST.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert!(res.status().is_success());
+}
+
+#[tokio::test]
+async fn tets_sse_custom_message_endpoint() {
+    let server_options = HyperServerOptions {
+        custom_messages_endpoint: Some(
+            "/custom-msg-endpoint?something=true&otherthing=false#section-59".to_string(),
+        ),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        ..Default::default()
+    };
+
+    let base_url = format!("http://{}:{}", server_options.host, server_options.port);
+
+    let server_endpoint = format!("{}{}", base_url, server_options.sse_endpoint());
+
+    tokio::spawn(async move {
+        let server = create_test_server(server_options);
+        server.start().await.unwrap();
+    });
+
+    sleep(Duration::from_millis(750)).await;
+
+    let client = Client::new();
+    println!("connecting to : {}", server_endpoint);
+    // Act: Connect to the SSE endpoint and read the event stream
+    let response = client
+        .get(server_endpoint)
+        .header("Accept", "text/event-stream")
+        .send()
+        .await
+        .expect("Failed to connect to SSE endpoint");
+
+    assert_eq!(
+        response.headers().get("content-type").map(|v| v.as_bytes()),
+        Some(b"text/event-stream" as &[u8]),
+        "Response content-type should be text/event-stream"
+    );
+
+    let message_endpoint = format!(
+        "{}{}",
+        base_url,
+        "/custom-msg-endpoint?something=true&otherthing=false&sessionId=AAA-BBB-CCC#section-59"
+    );
+    let res = client
+        .post(message_endpoint)
+        .header("Content-Type", "application/json")
+        .body(INITIALIZE_REQUEST.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert!(res.status().is_success());
+
+    let lines = collect_sse_lines(response, 5, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    let init_response = sse_data(&lines[3]);
+    let result = serde_json::from_str::<ServerMessage>(&init_response).unwrap();
+
+    assert!(matches!(result, ServerMessage::Response(response)
+        if matches!(&response.result, ResultFromServer::ServerResult(server_result)
+        if matches!(server_result, ServerResult::InitializeResult(init_result) if init_result.server_info.name == "Test MCP Server".to_string()))));
+}

--- a/crates/rust-mcp-sdk/tests/test_server_sse.rs
+++ b/crates/rust-mcp-sdk/tests/test_server_sse.rs
@@ -1,0 +1,5 @@
+#[path = "common/common.rs"]
+pub mod common;
+
+#[tokio::test]
+async fn tets_server_sse() {}

--- a/crates/rust-mcp-transport/src/lib.rs
+++ b/crates/rust-mcp-transport/src/lib.rs
@@ -16,3 +16,6 @@ pub use message_dispatcher::*;
 pub use sse::*;
 pub use stdio::*;
 pub use transport::*;
+
+// Type alias for session identifier, represented as a String
+pub type SessionId = String;

--- a/crates/rust-mcp-transport/src/sse.rs
+++ b/crates/rust-mcp-transport/src/sse.rs
@@ -12,8 +12,8 @@ use crate::error::{TransportError, TransportResult};
 use crate::mcp_stream::MCPStream;
 use crate::message_dispatcher::MessageDispatcher;
 use crate::transport::Transport;
-use crate::utils::CancellationTokenSource;
-use crate::{IoStream, McpDispatch, TransportOptions};
+use crate::utils::{endpoint_with_session_id, CancellationTokenSource};
+use crate::{IoStream, McpDispatch, SessionId, TransportOptions};
 
 pub struct SseTransport {
     shutdown_source: tokio::sync::RwLock<Option<CancellationTokenSource>>,
@@ -46,6 +46,10 @@ impl SseTransport {
             shutdown_source: tokio::sync::RwLock::new(None),
             is_shut_down: Mutex::new(false),
         })
+    }
+
+    pub fn message_endpoint(endpoint: &str, session_id: &SessionId) -> String {
+        endpoint_with_session_id(endpoint, session_id)
     }
 }
 

--- a/crates/rust-mcp-transport/src/utils.rs
+++ b/crates/rust-mcp-transport/src/utils.rs
@@ -53,16 +53,7 @@ pub fn extract_origin(url: &str) -> Option<String> {
 /// # Returns
 /// A String containing the endpoint with the session ID added as a query parameter
 ///
-/// # Examples
-/// ```
-/// assert_eq!(endpoint_with_session_id("/messages", "AAA"), "/messages?sessionId=AAA");
-/// assert_eq!(endpoint_with_session_id("/messages?foo=bar&baz=qux", "AAA"), "/messages?foo=bar&baz=qux&sessionId=AAA");
-/// assert_eq!(endpoint_with_session_id("/messages#section1", "AAA"), "/messages?sessionId=AAA#section1");
-/// assert_eq!(endpoint_with_session_id("/messages?key=value#section2", "AAA"), "/messages?key=value&sessionId=AAA#section2");
-/// assert_eq!(endpoint_with_session_id("/", "AAA"), "/?sessionId=AAA");
-/// assert_eq!(endpoint_with_session_id("", "AAA"), "/?sessionId=AAA");
-/// ```
-pub fn endpoint_with_session_id(endpoint: &str, session_id: &SessionId) -> String {
+pub(crate) fn endpoint_with_session_id(endpoint: &str, session_id: &SessionId) -> String {
     // Handle empty endpoint
     let base = if endpoint.is_empty() { "/" } else { endpoint };
 
@@ -130,5 +121,31 @@ mod tests {
     #[test]
     fn test_extract_origin_empty_string() {
         assert_eq!(extract_origin(""), None);
+    }
+
+    #[test]
+    fn test_endpoint_with_session_id() {
+        let session_id: SessionId = "AAA".to_string();
+        assert_eq!(
+            endpoint_with_session_id("/messages", &session_id),
+            "/messages?sessionId=AAA"
+        );
+        assert_eq!(
+            endpoint_with_session_id("/messages?foo=bar&baz=qux", &session_id),
+            "/messages?foo=bar&baz=qux&sessionId=AAA"
+        );
+        assert_eq!(
+            endpoint_with_session_id("/messages#section1", &session_id),
+            "/messages?sessionId=AAA#section1"
+        );
+        assert_eq!(
+            endpoint_with_session_id("/messages?key=value#section2", &session_id),
+            "/messages?key=value&sessionId=AAA#section2"
+        );
+        assert_eq!(
+            endpoint_with_session_id("/", &session_id),
+            "/?sessionId=AAA"
+        );
+        assert_eq!(endpoint_with_session_id("", &session_id), "/?sessionId=AAA");
     }
 }

--- a/crates/rust-mcp-transport/src/utils/readable_channel.rs
+++ b/crates/rust-mcp-transport/src/utils/readable_channel.rs
@@ -26,7 +26,6 @@ impl AsyncRead for ReadableChannel {
     ///
     /// # Returns
     /// * `Poll<tokio::io::Result<()>>` - Ready with Ok if data is read, Ready with Err if the channel is closed, or Pending if no data is available
-
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/examples/hello-world-mcp-server/src/tools.rs
+++ b/examples/hello-world-mcp-server/src/tools.rs
@@ -9,7 +9,11 @@ use rust_mcp_sdk::{
 //****************//
 #[mcp_tool(
     name = "say_hello",
-    description = "Accepts a person's name and says a personalized \"Hello\" to that person"
+    description = "Accepts a person's name and says a personalized \"Hello\" to that person",
+    idempotent_hint = false,
+    destructive_hint = false,
+    open_world_hint = false,
+    read_only_hint = false
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
 pub struct SayHelloTool {
@@ -29,7 +33,11 @@ impl SayHelloTool {
 //******************//
 #[mcp_tool(
     name = "say_goodbye",
-    description = "Accepts a person's name and says a personalized \"Goodbye\" to that person."
+    description = "Accepts a person's name and says a personalized \"Goodbye\" to that person.",
+    idempotent_hint = false,
+    destructive_hint = false,
+    open_world_hint = false,
+    read_only_hint = false
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
 pub struct SayGoodbyeTool {


### PR DESCRIPTION
### 📌 Summary
Updated `rust-mcp-macros` to support schema version `2025_03_26`, also  improved `sse` and HyperServer architecture

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Updated `rust-mcp-macros` and `rust-mcp-sdk` to default to the latest MCP schema version. 
- Improved `sse` support and architecture
- Improved HyperServer with graceful shutdown
