### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.2.6",
-    "crates/rust-mcp-macros": "0.2.1",
-    "crates/rust-mcp-transport": "0.2.3",
-    "examples/hello-world-mcp-server": "0.1.11",
-    "examples/hello-world-mcp-server-core": "0.1.2",
-    "examples/simple-mcp-client": "0.1.11",
-    "examples/simple-mcp-client-core": "0.1.11",
-    "examples/hello-world-server-core-sse": "0.1.2",
-    "examples/hello-world-server-sse": "0.1.11",
-    "examples/simple-mcp-client-core-sse": "0.1.2",
-    "examples/simple-mcp-client-sse": "0.1.2"
+    "crates/rust-mcp-sdk": "0.3.0",
+    "crates/rust-mcp-macros": "0.3.0",
+    "crates/rust-mcp-transport": "0.3.0",
+    "examples/hello-world-mcp-server": "0.1.12",
+    "examples/hello-world-mcp-server-core": "0.1.3",
+    "examples/simple-mcp-client": "0.1.12",
+    "examples/simple-mcp-client-core": "0.1.12",
+    "examples/hello-world-server-core-sse": "0.1.3",
+    "examples/hello-world-server-sse": "0.1.12",
+    "examples/simple-mcp-client-core-sse": "0.1.3",
+    "examples/simple-mcp-client-sse": "0.1.3"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "futures",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "futures",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "colored",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "colored",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "colored",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.2.3", path = "crates/rust-mcp-transport" }
+rust-mcp-transport = { version = "0.3.0", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "0.2.1", path = "crates/rust-mcp-macros" }
+rust-mcp-macros = { version = "0.3.0", path = "crates/rust-mcp-macros" }
 
 # External crates
 rust-mcp-schema = { version = "0.5" }

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.2.1...rust-mcp-macros-v0.3.0) (2025-05-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35))
+
+### 🚀 Features
+
+* Update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35)) ([6cbc3da](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6cbc3da9d99d62723643000de74c4bd9e48fa4b4))
+
 ## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.2.0...rust-mcp-macros-v0.2.1) (2025-05-01)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.6...rust-mcp-sdk-v0.3.0) (2025-05-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35))
+
+### 🚀 Features
+
+* Update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35)) ([6cbc3da](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6cbc3da9d99d62723643000de74c4bd9e48fa4b4))
+
 ## [0.2.6](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.5...rust-mcp-sdk-v0.2.6) (2025-05-20)
 
 ## [0.2.5](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.4...rust-mcp-sdk-v0.2.5) (2025-05-20)

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.3...rust-mcp-transport-v0.3.0) (2025-05-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35))
+
+### 🚀 Features
+
+* Update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35)) ([6cbc3da](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6cbc3da9d99d62723643000de74c4bd9e48fa4b4))
+
 ## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.2...rust-mcp-transport-v0.2.3) (2025-05-20)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---



<details><summary>hello-world-mcp-server: 0.1.12</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.3</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.3</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.12</summary>

### Dependencies


</details>

<details><summary>rust-mcp-macros: 0.3.0</summary>

## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.2.1...rust-mcp-macros-v0.3.0) (2025-05-23)


### ⚠ BREAKING CHANGES

* update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35))

### 🚀 Features

* Update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35)) ([6cbc3da](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6cbc3da9d99d62723643000de74c4bd9e48fa4b4))
</details>

<details><summary>rust-mcp-sdk: 0.3.0</summary>

## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.6...rust-mcp-sdk-v0.3.0) (2025-05-23)


### ⚠ BREAKING CHANGES

* update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35))

### 🚀 Features

* Update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35)) ([6cbc3da](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6cbc3da9d99d62723643000de74c4bd9e48fa4b4))
</details>

<details><summary>rust-mcp-transport: 0.3.0</summary>

## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.3...rust-mcp-transport-v0.3.0) (2025-05-23)


### ⚠ BREAKING CHANGES

* update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35))

### 🚀 Features

* Update crates to default to the latest MCP schema version. ([#35](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/35)) ([6cbc3da](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6cbc3da9d99d62723643000de74c4bd9e48fa4b4))
</details>

<details><summary>simple-mcp-client: 0.1.12</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.12</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.3</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.3</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).