### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.3.0",
+    "crates/rust-mcp-sdk": "0.3.1",
     "crates/rust-mcp-macros": "0.3.0",
-    "crates/rust-mcp-transport": "0.3.0",
-    "examples/hello-world-mcp-server": "0.1.12",
-    "examples/hello-world-mcp-server-core": "0.1.3",
-    "examples/simple-mcp-client": "0.1.12",
-    "examples/simple-mcp-client-core": "0.1.12",
-    "examples/hello-world-server-core-sse": "0.1.3",
-    "examples/hello-world-server-sse": "0.1.12",
-    "examples/simple-mcp-client-core-sse": "0.1.3",
-    "examples/simple-mcp-client-sse": "0.1.3"
+    "crates/rust-mcp-transport": "0.3.1",
+    "examples/hello-world-mcp-server": "0.1.13",
+    "examples/hello-world-mcp-server-core": "0.1.4",
+    "examples/simple-mcp-client": "0.1.13",
+    "examples/simple-mcp-client-core": "0.1.13",
+    "examples/hello-world-server-core-sse": "0.1.4",
+    "examples/hello-world-server-sse": "0.1.13",
+    "examples/simple-mcp-client-core-sse": "0.1.4",
+    "examples/simple-mcp-client-sse": "0.1.4"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "futures",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "futures",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "colored",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "colored",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "colored",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.3.0", path = "crates/rust-mcp-transport" }
+rust-mcp-transport = { version = "0.3.1", path = "crates/rust-mcp-transport" }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.3.0", path = "crates/rust-mcp-macros" }
 

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.3.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.3.0...rust-mcp-sdk-v0.3.1) (2025-05-24)
+
 ## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.2.6...rust-mcp-sdk-v0.3.0) (2025-05-23)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.3.0...rust-mcp-transport-v0.3.1) (2025-05-24)
+
+
+### 🐛 Bug Fixes
+
+* Ensure server resilience against malformed client requests ([95aed88](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/95aed8873e234b4d7d2e0027d2c43be0b0dcc1ab))
+
 ## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.2.3...rust-mcp-transport-v0.3.0) (2025-05-23)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.13</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.4</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.4</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.13</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.3.1</summary>

## [0.3.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.3.0...rust-mcp-sdk-v0.3.1) (2025-05-24)
</details>

<details><summary>rust-mcp-transport: 0.3.1</summary>

## [0.3.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.3.0...rust-mcp-transport-v0.3.1) (2025-05-24)


### 🐛 Bug Fixes

* Ensure server resilience against malformed client requests ([95aed88](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/95aed8873e234b4d7d2e0027d2c43be0b0dcc1ab))
</details>

<details><summary>simple-mcp-client: 0.1.13</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.13</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.4</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.4</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).