### PR TITLE
fix: prevent termination caused by client using older mcp schema versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ async fn main() -> SdkResult<()> {
             name: "simple-rust-mcp-client".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     };
 
     // Step3 : Create a transport, with options to launch @modelcontextprotocol/server-everything MCP Server

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -212,7 +212,7 @@ async fn main() -> SdkResult<()> {
             name: "simple-rust-mcp-client".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     };
 
     // Step3 : Create a transport, with options to launch @modelcontextprotocol/server-everything MCP Server

--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -22,7 +22,7 @@ pub enum McpSdkError {
     #[cfg(feature = "hyper-server")]
     #[error("{0}")]
     TransportServerError(#[from] TransportServerError),
-    #[error("Incompatible mcp protocl version!\n client:{0}\nserver:{1}")]
+    #[error("Incompatible mcp protocol version!\n client:{0}\nserver:{1}")]
     IncompatibleProtocolVersion(String, String),
 }
 

--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -16,14 +16,14 @@ pub enum McpSdkError {
     #[error("{0}")]
     TransportError(#[from] TransportError),
     #[error("{0}")]
-    AnyErrorStatic(Box<(dyn std::error::Error + Send + Sync + 'static)>),
-    #[error("{0}")]
     AnyError(Box<(dyn std::error::Error + Send + Sync)>),
     #[error("{0}")]
     SdkError(#[from] rust_mcp_schema::schema_utils::SdkError),
     #[cfg(feature = "hyper-server")]
     #[error("{0}")]
     TransportServerError(#[from] TransportServerError),
+    #[error("Incompatible mcp protocl version!\n client:{0}\nserver:{1}")]
+    IncompatibleProtocolVersion(String, String),
 }
 
 #[deprecated(since = "0.2.0", note = "Use `McpSdkError` instead.")]

--- a/crates/rust-mcp-sdk/src/lib.rs
+++ b/crates/rust-mcp-sdk/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mcp_client {
     pub use super::mcp_runtimes::client_runtime::mcp_client_runtime as client_runtime;
     pub use super::mcp_runtimes::client_runtime::mcp_client_runtime_core as client_runtime_core;
     pub use super::mcp_runtimes::client_runtime::ClientRuntime;
+    pub use super::utils::ensure_server_protocole_compability;
 }
 
 #[cfg(feature = "server")]
@@ -75,6 +76,7 @@ pub mod mcp_server {
     pub use super::hyper_servers::hyper_server_core;
     #[cfg(feature = "hyper-server")]
     pub use super::hyper_servers::*;
+    pub use super::utils::enforce_compatible_protocol_version;
 }
 
 #[cfg(feature = "client")]

--- a/crates/rust-mcp-sdk/src/lib.rs
+++ b/crates/rust-mcp-sdk/src/lib.rs
@@ -36,7 +36,7 @@ pub mod mcp_client {
     pub use super::mcp_runtimes::client_runtime::mcp_client_runtime as client_runtime;
     pub use super::mcp_runtimes::client_runtime::mcp_client_runtime_core as client_runtime_core;
     pub use super::mcp_runtimes::client_runtime::ClientRuntime;
-    pub use super::utils::ensure_server_protocole_compability;
+    pub use super::utils::ensure_server_protocole_compatibility;
 }
 
 #[cfg(feature = "server")]

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -17,6 +17,7 @@ use tokio::sync::Mutex;
 use crate::error::{McpSdkError, SdkResult};
 use crate::mcp_traits::mcp_client::McpClient;
 use crate::mcp_traits::mcp_handler::McpClientHandler;
+use crate::utils::ensure_server_protocole_compability;
 
 pub struct ClientRuntime {
     // The transport interface for handling messages between client and server
@@ -57,6 +58,11 @@ impl ClientRuntime {
         let result: ServerResult = self.request(request.into(), None).await?.try_into()?;
 
         if let ServerResult::InitializeResult(initialize_result) = result {
+            ensure_server_protocole_compability(
+                &self.client_details.protocol_version,
+                &initialize_result.protocol_version,
+            )?;
+
             // store server details
             self.set_server_details(initialize_result)?;
             // send a InitializedNotification to the server

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -17,7 +17,7 @@ use tokio::sync::Mutex;
 use crate::error::{McpSdkError, SdkResult};
 use crate::mcp_traits::mcp_client::McpClient;
 use crate::mcp_traits::mcp_handler::McpClientHandler;
-use crate::utils::ensure_server_protocole_compability;
+use crate::utils::ensure_server_protocole_compatibility;
 
 pub struct ClientRuntime {
     // The transport interface for handling messages between client and server
@@ -58,7 +58,7 @@ impl ClientRuntime {
         let result: ServerResult = self.request(request.into(), None).await?.try_into()?;
 
         if let ServerResult::InitializeResult(initialize_result) = result {
-            ensure_server_protocole_compability(
+            ensure_server_protocole_compatibility(
                 &self.client_details.protocol_version,
                 &initialize_result.protocol_version,
             )?;

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -1,3 +1,7 @@
+use std::cmp::Ordering;
+
+use crate::error::{McpSdkError, SdkResult};
+
 /// Formats an assertion error message for unsupported capabilities.
 ///
 /// Constructs a string describing that a specific entity (e.g., server or client) lacks
@@ -21,6 +25,128 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
         "{} does not support {} (required for {})",
         entity, capability, method_name
     )
+}
+
+/// Checks if the client and server protocol versions are compatible by ensuring they are equal.
+///
+/// This function compares the provided client and server protocol versions. If they are equal,
+/// it returns `Ok(())`, indicating compatibility. If they differ (either the client version is
+/// lower or higher than the server version), it returns an error with details about the
+/// incompatible versions.
+///
+/// # Arguments
+///
+/// * `client_protocol_version` - A string slice representing the client's protocol version.
+/// * `server_protocol_version` - A string slice representing the server's protocol version.
+///
+/// # Returns
+///
+/// * `Ok(())` if the versions are equal.
+/// * `Err(McpSdkError::IncompatibleProtocolVersion)` if the versions differ, containing the
+///   client and server versions as strings.
+///
+/// # Examples
+///
+/// ```
+/// use rust_mcp_sdk::mcp_client::ensure_server_protocole_compability;
+/// use rust_mcp_sdk::error::McpSdkError;
+///
+/// // Compatible versions
+/// let result = ensure_server_protocole_compability("2024_11_05", "2024_11_05");
+/// assert!(result.is_ok());
+///
+/// // Incompatible versions (client < server)
+/// let result = ensure_server_protocole_compability("2024_11_05", "2025_03_26");
+/// assert!(matches!(
+///     result,
+///     Err(McpSdkError::IncompatibleProtocolVersion(client, server))
+///     if client == "2024_11_05" && server == "2025_03_26"
+/// ));
+///
+/// // Incompatible versions (client > server)
+/// let result = ensure_server_protocole_compability("2025_03_26", "2024_11_05");
+/// assert!(matches!(
+///     result,
+///     Err(McpSdkError::IncompatibleProtocolVersion(client, server))
+///     if client == "2025_03_26" && server == "2024_11_05"
+/// ));
+/// ```
+pub fn ensure_server_protocole_compability(
+    client_protocol_version: &str,
+    server_protocol_version: &str,
+) -> SdkResult<()> {
+    match client_protocol_version.cmp(server_protocol_version) {
+        Ordering::Less | Ordering::Greater => {
+            return Err(McpSdkError::IncompatibleProtocolVersion(
+                client_protocol_version.to_string(),
+                server_protocol_version.to_string(),
+            ));
+        }
+        Ordering::Equal => Ok(()),
+    }
+}
+
+/// Enforces protocol version compatibility on for MCP Server , allowing the client to use a lower or equal version.
+///
+/// This function compares the client and server protocol versions. If the client version is
+/// higher than the server version, it returns an error indicating incompatibility. If the
+/// versions are equal, it returns `Ok(None)`, indicating no downgrade is needed. If the client
+/// version is lower, it returns `Ok(Some(client_protocol_version))`, suggesting the server
+/// can use the client's version for compatibility.
+///
+/// # Arguments
+///
+/// * `client_protocol_version` - The client's protocol version.
+/// * `server_protocol_version` - The server's protocol version.
+///
+/// # Returns
+///
+/// * `Ok(None)` if the versions are equal, indicating no downgrade is needed.
+/// * `Ok(Some(client_protocol_version))` if the client version is lower, returning the client
+///   version to use for compatibility.
+/// * `Err(McpSdkError::IncompatibleProtocolVersion)` if the client version is higher, containing
+///   the client and server versions as strings.
+///
+/// # Examples
+///
+/// ```
+/// use rust_mcp_sdk::mcp_server::enforce_compatible_protocol_version;
+/// use rust_mcp_sdk::error::McpSdkError;
+///
+/// // Equal versions
+/// let result = enforce_compatible_protocol_version("2024_11_05", "2024_11_05");
+/// assert!(matches!(result, Ok(None)));
+///
+/// // Client version lower (downgrade allowed)
+/// let result = enforce_compatible_protocol_version("2024_11_05", "2025_03_26");
+/// assert!(matches!(result, Ok(Some(ref v)) if v == "2024_11_05"));
+///
+/// // Client version higher (incompatible)
+/// let result = enforce_compatible_protocol_version("2025_03_26", "2024_11_05");
+/// assert!(matches!(
+///     result,
+///     Err(McpSdkError::IncompatibleProtocolVersion(client, server))
+///     if client == "2025_03_26" && server == "2024_11_05"
+/// ));
+/// ```
+pub fn enforce_compatible_protocol_version(
+    client_protocol_version: &str,
+    server_protocol_version: &str,
+) -> SdkResult<Option<String>> {
+    match client_protocol_version.cmp(server_protocol_version) {
+        // if client protocol version is higher
+        Ordering::Greater => {
+            return Err(McpSdkError::IncompatibleProtocolVersion(
+                client_protocol_version.to_string(),
+                server_protocol_version.to_string(),
+            ));
+        }
+        Ordering::Equal => Ok(None),
+        Ordering::Less => {
+            // return the same version that was received from the client
+            Ok(Some(client_protocol_version.to_string()))
+        }
+    }
 }
 
 /// Removes query string and hash fragment from a URL, returning the base path.

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -48,15 +48,15 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
 /// # Examples
 ///
 /// ```
-/// use rust_mcp_sdk::mcp_client::ensure_server_protocole_compability;
+/// use rust_mcp_sdk::mcp_client::ensure_server_protocole_compatibility;
 /// use rust_mcp_sdk::error::McpSdkError;
 ///
 /// // Compatible versions
-/// let result = ensure_server_protocole_compability("2024_11_05", "2024_11_05");
+/// let result = ensure_server_protocole_compatibility("2024_11_05", "2024_11_05");
 /// assert!(result.is_ok());
 ///
 /// // Incompatible versions (client < server)
-/// let result = ensure_server_protocole_compability("2024_11_05", "2025_03_26");
+/// let result = ensure_server_protocole_compatibility("2024_11_05", "2025_03_26");
 /// assert!(matches!(
 ///     result,
 ///     Err(McpSdkError::IncompatibleProtocolVersion(client, server))
@@ -64,14 +64,14 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
 /// ));
 ///
 /// // Incompatible versions (client > server)
-/// let result = ensure_server_protocole_compability("2025_03_26", "2024_11_05");
+/// let result = ensure_server_protocole_compatibility("2025_03_26", "2024_11_05");
 /// assert!(matches!(
 ///     result,
 ///     Err(McpSdkError::IncompatibleProtocolVersion(client, server))
 ///     if client == "2025_03_26" && server == "2024_11_05"
 /// ));
 /// ```
-pub fn ensure_server_protocole_compability(
+pub fn ensure_server_protocole_compatibility(
     client_protocol_version: &str,
     server_protocol_version: &str,
 ) -> SdkResult<()> {

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -76,12 +76,10 @@ pub fn ensure_server_protocole_compability(
     server_protocol_version: &str,
 ) -> SdkResult<()> {
     match client_protocol_version.cmp(server_protocol_version) {
-        Ordering::Less | Ordering::Greater => {
-            return Err(McpSdkError::IncompatibleProtocolVersion(
-                client_protocol_version.to_string(),
-                server_protocol_version.to_string(),
-            ));
-        }
+        Ordering::Less | Ordering::Greater => Err(McpSdkError::IncompatibleProtocolVersion(
+            client_protocol_version.to_string(),
+            server_protocol_version.to_string(),
+        )),
         Ordering::Equal => Ok(()),
     }
 }
@@ -135,12 +133,10 @@ pub fn enforce_compatible_protocol_version(
 ) -> SdkResult<Option<String>> {
     match client_protocol_version.cmp(server_protocol_version) {
         // if client protocol version is higher
-        Ordering::Greater => {
-            return Err(McpSdkError::IncompatibleProtocolVersion(
-                client_protocol_version.to_string(),
-                server_protocol_version.to_string(),
-            ));
-        }
+        Ordering::Greater => Err(McpSdkError::IncompatibleProtocolVersion(
+            client_protocol_version.to_string(),
+            server_protocol_version.to_string(),
+        )),
         Ordering::Equal => Ok(None),
         Ordering::Less => {
             // return the same version that was received from the client

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -71,6 +71,7 @@ pub fn format_assertion_message(entity: &str, capability: &str, method_name: &st
 ///     if client == "2025_03_26" && server == "2024_11_05"
 /// ));
 /// ```
+#[allow(unused)]
 pub fn ensure_server_protocole_compatibility(
     client_protocol_version: &str,
     server_protocol_version: &str,
@@ -127,6 +128,7 @@ pub fn ensure_server_protocole_compatibility(
 ///     if client == "2025_03_26" && server == "2024_11_05"
 /// ));
 /// ```
+#[allow(unused)]
 pub fn enforce_compatible_protocol_version(
     client_protocol_version: &str,
     server_protocol_version: &str,

--- a/crates/rust-mcp-sdk/tests/common/common.rs
+++ b/crates/rust-mcp-sdk/tests/common/common.rs
@@ -1,7 +1,7 @@
 mod test_server;
 use async_trait::async_trait;
 use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
+    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
 };
 use rust_mcp_sdk::mcp_client::ClientHandler;
 pub use test_server::*;
@@ -18,7 +18,7 @@ pub fn test_client_info() -> InitializeRequestParams {
             name: "test-rust-mcp-client".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     }
 }
 

--- a/crates/rust-mcp-sdk/tests/common/test_server.rs
+++ b/crates/rust-mcp-sdk/tests/common/test_server.rs
@@ -8,7 +8,10 @@ pub mod test_server_common {
         LATEST_PROTOCOL_VERSION,
     };
     use rust_mcp_sdk::{
-        mcp_server::{hyper_server, HyperServer, HyperServerOptions, IdGenerator, ServerHandler},
+        mcp_server::{
+            hyper_server, HyperServer, HyperServerOptions, IdGenerator, ServerHandler,
+            ServerHandlerCore,
+        },
         McpServer, SessionId,
     };
     use std::sync::RwLock;
@@ -32,7 +35,7 @@ pub mod test_server_common {
             },
             meta: None,
             instructions: Some("server instructions...".to_string()),
-            protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
+            protocol_version: "2025-03-26".to_string(),
         }
     }
 

--- a/crates/rust-mcp-sdk/tests/common/test_server.rs
+++ b/crates/rust-mcp-sdk/tests/common/test_server.rs
@@ -5,13 +5,9 @@ pub mod test_server_common {
 
     use rust_mcp_schema::{
         Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
-        LATEST_PROTOCOL_VERSION,
     };
     use rust_mcp_sdk::{
-        mcp_server::{
-            hyper_server, HyperServer, HyperServerOptions, IdGenerator, ServerHandler,
-            ServerHandlerCore,
-        },
+        mcp_server::{hyper_server, HyperServer, HyperServerOptions, IdGenerator, ServerHandler},
         McpServer, SessionId,
     };
     use std::sync::RwLock;

--- a/crates/rust-mcp-sdk/tests/test_protocol_compability.rs
+++ b/crates/rust-mcp-sdk/tests/test_protocol_compability.rs
@@ -2,10 +2,9 @@
 pub mod common;
 
 mod protocol_compability_on_server {
-    use std::result;
 
     use rust_mcp_schema::{InitializeRequest, InitializeResult, RpcError, INTERNAL_ERROR};
-    use rust_mcp_sdk::{error::McpSdkError, mcp_server::ServerHandler};
+    use rust_mcp_sdk::mcp_server::ServerHandler;
 
     use crate::common::{
         test_client_info,

--- a/crates/rust-mcp-sdk/tests/test_protocol_compability.rs
+++ b/crates/rust-mcp-sdk/tests/test_protocol_compability.rs
@@ -1,0 +1,60 @@
+#[path = "common/common.rs"]
+pub mod common;
+
+mod protocol_compability_on_server {
+    use std::result;
+
+    use rust_mcp_schema::{InitializeRequest, InitializeResult, RpcError, INTERNAL_ERROR};
+    use rust_mcp_sdk::{error::McpSdkError, mcp_server::ServerHandler};
+
+    use crate::common::{
+        test_client_info,
+        test_server_common::{test_server_details, TestServerHandler},
+    };
+
+    async fn handle_initialize_request(
+        client_protocol_version: &str,
+    ) -> Result<InitializeResult, RpcError> {
+        let handler = TestServerHandler {};
+
+        let mut initialize_request = test_client_info();
+        initialize_request.protocol_version = client_protocol_version.to_string();
+
+        let transport =
+            rust_mcp_sdk::StdioTransport::new(rust_mcp_sdk::TransportOptions::default()).unwrap();
+
+        // mock unused runtime
+        let runtime = rust_mcp_sdk::mcp_server::server_runtime::create_server(
+            test_server_details(),
+            transport,
+            TestServerHandler {},
+        );
+
+        handler
+            .handle_initialize_request(InitializeRequest::new(initialize_request), &runtime)
+            .await
+    }
+
+    #[tokio::test]
+    async fn tets_protocol_compability_equal() {
+        let result = handle_initialize_request("2025-03-26").await;
+        assert!(result.is_ok());
+        let protocol_version = result.unwrap().protocol_version;
+        assert_eq!(protocol_version, "2025-03-26");
+    }
+
+    #[tokio::test]
+    async fn tets_protocol_compability_downgrade() {
+        let result = handle_initialize_request("2024_11_05").await;
+        assert!(result.is_ok());
+        let protocol_version = result.unwrap().protocol_version;
+        assert_eq!(protocol_version, "2024_11_05");
+    }
+
+    #[tokio::test]
+    async fn tets_protocol_compability_unsupported() {
+        let result = handle_initialize_request("2034_11_05").await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(err) if err.code == INTERNAL_ERROR));
+    }
+}

--- a/crates/rust-mcp-sdk/tests/test_protocol_compatibility.rs
+++ b/crates/rust-mcp-sdk/tests/test_protocol_compatibility.rs
@@ -1,7 +1,7 @@
 #[path = "common/common.rs"]
 pub mod common;
 
-mod protocol_compability_on_server {
+mod protocol_compatibility_on_server {
 
     use rust_mcp_schema::{InitializeRequest, InitializeResult, RpcError, INTERNAL_ERROR};
     use rust_mcp_sdk::mcp_server::ServerHandler;
@@ -35,7 +35,7 @@ mod protocol_compability_on_server {
     }
 
     #[tokio::test]
-    async fn tets_protocol_compability_equal() {
+    async fn tets_protocol_compatibility_equal() {
         let result = handle_initialize_request("2025-03-26").await;
         assert!(result.is_ok());
         let protocol_version = result.unwrap().protocol_version;
@@ -43,7 +43,7 @@ mod protocol_compability_on_server {
     }
 
     #[tokio::test]
-    async fn tets_protocol_compability_downgrade() {
+    async fn tets_protocol_compatibility_downgrade() {
         let result = handle_initialize_request("2024_11_05").await;
         assert!(result.is_ok());
         let protocol_version = result.unwrap().protocol_version;
@@ -51,7 +51,7 @@ mod protocol_compability_on_server {
     }
 
     #[tokio::test]
-    async fn tets_protocol_compability_unsupported() {
+    async fn tets_protocol_compatibility_unsupported() {
         let result = handle_initialize_request("2034_11_05").await;
         assert!(result.is_err());
         assert!(matches!(result, Err(err) if err.code == INTERNAL_ERROR));

--- a/examples/hello-world-mcp-server-core/src/handler.rs
+++ b/examples/hello-world-mcp-server-core/src/handler.rs
@@ -4,7 +4,10 @@ use rust_mcp_schema::{
     schema_utils::{CallToolError, NotificationFromClient, RequestFromClient, ResultFromServer},
     ClientRequest, ListToolsResult, RpcError,
 };
-use rust_mcp_sdk::{mcp_server::ServerHandlerCore, McpServer};
+use rust_mcp_sdk::{
+    mcp_server::{enforce_compatible_protocol_version, ServerHandlerCore},
+    McpServer,
+};
 
 use crate::tools::GreetingTools;
 
@@ -26,7 +29,20 @@ impl ServerHandlerCore for MyServerHandler {
             //Handle client requests according to their specific type.
             RequestFromClient::ClientRequest(client_request) => match client_request {
                 // Handle the initialization request
-                ClientRequest::InitializeRequest(_) => Ok(runtime.server_info().to_owned().into()),
+                ClientRequest::InitializeRequest(initialize_request) => {
+                    let mut server_info = runtime.server_info().to_owned();
+
+                    if let Some(updated_protocol_version) = enforce_compatible_protocol_version(
+                        &initialize_request.params.protocol_version,
+                        &server_info.protocol_version,
+                    )
+                    .map_err(|err| RpcError::internal_error().with_message(err.to_string()))?
+                    {
+                        server_info.protocol_version = initialize_request.params.protocol_version;
+                    }
+
+                    return Ok(server_info.into());
+                }
 
                 // Handle ListToolsRequest, return list of available tools
                 ClientRequest::ListToolsRequest(_) => Ok(ListToolsResult {

--- a/examples/hello-world-server-core-sse/src/handler.rs
+++ b/examples/hello-world-server-core-sse/src/handler.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use async_trait::async_trait;
 
 use rust_mcp_schema::{

--- a/examples/simple-mcp-client-core-sse/src/main.rs
+++ b/examples/simple-mcp-client-core-sse/src/main.rs
@@ -5,7 +5,7 @@ use handler::MyClientHandler;
 
 use inquiry_utils::InquiryUtils;
 use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
+    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
 };
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime_core;
@@ -33,7 +33,7 @@ async fn main() -> SdkResult<()> {
             name: "simple-rust-mcp-client-core-sse".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     };
 
     // Step2 : Create a transport, with options to launch/connect to a MCP Server

--- a/examples/simple-mcp-client-core/src/main.rs
+++ b/examples/simple-mcp-client-core/src/main.rs
@@ -5,7 +5,7 @@ use handler::MyClientHandler;
 
 use inquiry_utils::InquiryUtils;
 use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
+    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
 };
 use rust_mcp_sdk::{error::SdkResult, mcp_client::client_runtime_core};
 use rust_mcp_sdk::{McpClient, StdioTransport, TransportOptions};
@@ -22,7 +22,7 @@ async fn main() -> SdkResult<()> {
             name: "simple-rust-mcp-client-core".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     };
 
     // Step2 : Create a transport, with options to launch/connect to a MCP Server

--- a/examples/simple-mcp-client-sse/src/main.rs
+++ b/examples/simple-mcp-client-sse/src/main.rs
@@ -5,7 +5,7 @@ use handler::MyClientHandler;
 
 use inquiry_utils::InquiryUtils;
 use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
+    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
 };
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime;
@@ -33,7 +33,7 @@ async fn main() -> SdkResult<()> {
             name: "simple-rust-mcp-client-sse".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     };
 
     // Step2 : Create a transport, with options to launch/connect to a MCP Server

--- a/examples/simple-mcp-client/src/main.rs
+++ b/examples/simple-mcp-client/src/main.rs
@@ -5,7 +5,7 @@ use handler::MyClientHandler;
 
 use inquiry_utils::InquiryUtils;
 use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, JSONRPC_VERSION,
+    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
 };
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime;
@@ -23,7 +23,7 @@ async fn main() -> SdkResult<()> {
             name: "simple-rust-mcp-client".into(),
             version: "0.1.0".into(),
         },
-        protocol_version: JSONRPC_VERSION.into(),
+        protocol_version: LATEST_PROTOCOL_VERSION.into(),
     };
 
     // Step2 : Create a transport, with options to launch/connect to a MCP Server


### PR DESCRIPTION
### 📌 Summary

Fixed a bug that caused clients using the older MCP schema version 2024_11_05 to crash the MCP server built with rust-mcp-sdk.  MCP Servers now supports clients using both 2024_11_05 and 2025_03_26 schema versions.