### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.3.2",
+    "crates/rust-mcp-sdk": "0.3.3",
     "crates/rust-mcp-macros": "0.3.0",
     "crates/rust-mcp-transport": "0.3.2",
-    "examples/hello-world-mcp-server": "0.1.14",
-    "examples/hello-world-mcp-server-core": "0.1.5",
-    "examples/simple-mcp-client": "0.1.14",
-    "examples/simple-mcp-client-core": "0.1.14",
-    "examples/hello-world-server-core-sse": "0.1.5",
-    "examples/hello-world-server-sse": "0.1.14",
-    "examples/simple-mcp-client-core-sse": "0.1.5",
-    "examples/simple-mcp-client-sse": "0.1.5"
+    "examples/hello-world-mcp-server": "0.1.15",
+    "examples/hello-world-mcp-server-core": "0.1.6",
+    "examples/simple-mcp-client": "0.1.15",
+    "examples/simple-mcp-client-core": "0.1.15",
+    "examples/hello-world-server-core-sse": "0.1.6",
+    "examples/hello-world-server-sse": "0.1.15",
+    "examples/simple-mcp-client-core-sse": "0.1.6",
+    "examples/simple-mcp-client-sse": "0.1.6"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "futures",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "futures",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "colored",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "colored",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "colored",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.3.2...rust-mcp-sdk-v0.3.3) (2025-05-25)
+
+
+### 🐛 Bug Fixes
+
+* Prevent termination caused by client using older mcp schema versions ([#40](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/40)) ([084d9d3](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/084d9d36c37c135256873bffd46d2ca03a1fb330))
+
 ## [0.3.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.3.1...rust-mcp-sdk-v0.3.2) (2025-05-25)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.15</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.6</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.6</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.15</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.3.3</summary>

## [0.3.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.3.2...rust-mcp-sdk-v0.3.3) (2025-05-25)


### 🐛 Bug Fixes

* Prevent termination caused by client using older mcp schema versions ([#40](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/40)) ([084d9d3](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/084d9d36c37c135256873bffd46d2ca03a1fb330))
</details>

<details><summary>simple-mcp-client: 0.1.15</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.15</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.6</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.6</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).