### PR TITLE
feat!: make rust-mcp-sdk the sole dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,6 @@ version = "0.1.15"
 dependencies = [
  "async-trait",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -696,7 +695,6 @@ version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -709,7 +707,6 @@ version = "0.1.6"
 dependencies = [
  "async-trait",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -724,7 +721,6 @@ version = "0.1.15"
 dependencies = [
  "async-trait",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -1890,7 +1886,6 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -1905,7 +1900,6 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -1920,7 +1914,6 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",
@@ -1937,7 +1930,6 @@ dependencies = [
  "async-trait",
  "colored",
  "futures",
- "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,22 +912,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1069,6 +1075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,9 +1139,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -1531,9 +1547,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "2bf597b113be201cb2269b4c39b39a804d01b99ee95a4278f0ed04e45cff1c71"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1556,23 +1572,22 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -1609,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fc3768cfcc6756ebc6c91f5d52abcfacac20cb953010483d52524ed7f08eaf"
+checksum = "4c9966340f5104a8d22b6c2db8901f8626a0f737820a385db3ffbb29b1f6ae0f"
 dependencies = [
  "serde",
  "serde_json",
@@ -1956,9 +1971,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2188,6 +2203,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,16 +27,13 @@ args = ["nextest", "run", "--no-tests=pass"]
 [tasks.doc-test]
 workspace = false
 command = "cargo"
-args = [
-    "test",
-    "--doc",
-    "-p",
-    "rust-mcp-macros",
-    "-p",
-    "rust-mcp-sdk",
-    "-p",
-    "rust-mcp-transport",
-]
+args = ["test", "--doc", "-p", "rust-mcp-sdk", "-p", "rust-mcp-transport"]
+dependencies = ["doc-test-macros"]
+
+[tasks.doc-test-macros]
+workspace = false
+command = "cargo"
+args = ["test", "--doc", "-p", "rust-mcp-macros"]
 
 
 [tasks.check]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,7 +8,16 @@ args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 command = "cargo"
-args = ["clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]
+args = [
+    "clippy",
+    "--workspace",
+    "--lib",
+    "--bins",
+    "--examples",
+    "--",
+    "-D",
+    "warnings",
+]
 
 [tasks.test]
 install_crate = "nextest"

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -41,3 +41,4 @@ latest = ["2025_03_26"]
 2025_03_26 = ["rust-mcp-schema/2025_03_26"]
 # enabled mcp schema version 2024_11_05
 2024_11_05 = ["rust-mcp-schema/2024_11_05"]
+sdk = []

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 rust-mcp-schema = { workspace = true }
 rust-mcp-transport = { workspace = true, default-features = false, optional = true }
-rust-mcp-macros = { workspace = true, optional = true }
+rust-mcp-macros = { workspace = true, optional = true, features = ["sdk"] }
 
 tokio.workspace = true
 serde = { workspace = true }
@@ -57,7 +57,7 @@ hyper-server = [
     "rust-mcp-transport/sse",
 ]
 ssl = ["axum-server/tls-rustls"]
-macros = ["rust-mcp-macros"]
+macros = ["rust-mcp-macros/sdk"]
 
 [lints]
 workspace = true

--- a/crates/rust-mcp-sdk/src/lib.rs
+++ b/crates/rust-mcp-sdk/src/lib.rs
@@ -92,3 +92,7 @@ pub use rust_mcp_transport::*;
 pub mod macros {
     pub use rust_mcp_macros::*;
 }
+
+pub mod schema {
+    pub use rust_mcp_schema::*;
+}

--- a/crates/rust-mcp-sdk/src/mcp_macros/tool_box.rs
+++ b/crates/rust-mcp-sdk/src/mcp_macros/tool_box.rs
@@ -50,7 +50,7 @@ macro_rules! tool_box {
             }
 
             /// Returns a vector containing instances of all supported tools
-            pub fn tools() -> Vec<rust_mcp_schema::Tool> {
+            pub fn tools() -> Vec<rust_mcp_sdk::schema::Tool> {
                 vec![
                     $(
                         $tool::tool(),
@@ -59,7 +59,7 @@ macro_rules! tool_box {
             }
 
             #[deprecated(since = "0.2.0", note = "Use `tools()` instead.")]
-            pub fn get_tools() -> Vec<rust_mcp_schema::Tool> {
+            pub fn get_tools() -> Vec<rust_mcp_sdk::schema::Tool> {
                 vec![
                     $(
                         $tool::tool(),
@@ -71,22 +71,22 @@ macro_rules! tool_box {
 
 
 
-        impl TryFrom<rust_mcp_schema::CallToolRequestParams> for $enum_name {
-            type Error = rust_mcp_schema::schema_utils::CallToolError;
+        impl TryFrom<rust_mcp_sdk::schema::CallToolRequestParams> for $enum_name {
+            type Error = rust_mcp_sdk::schema::schema_utils::CallToolError;
 
             /// Attempts to convert a tool request into the appropriate tool variant
-            fn try_from(value: rust_mcp_schema::CallToolRequestParams) -> Result<Self, Self::Error> {
+            fn try_from(value: rust_mcp_sdk::schema::CallToolRequestParams) -> Result<Self, Self::Error> {
                 let v = serde_json::to_value(value.arguments.unwrap())
-                .map_err(rust_mcp_schema::schema_utils::CallToolError::new)?;
+                .map_err(rust_mcp_sdk::schema::schema_utils::CallToolError::new)?;
                     match value.name {
                         $(
                             name if name == $tool::tool_name().as_str() => {
-                                Ok(Self::$tool(serde_json::from_value(v).map_err(rust_mcp_schema::schema_utils::CallToolError::new)?))
+                                Ok(Self::$tool(serde_json::from_value(v).map_err(rust_mcp_sdk::schema::schema_utils::CallToolError::new)?))
                             }
                         )*
                         _ => {
                                Err(
-                                rust_mcp_schema::schema_utils::CallToolError::unknown_tool(value.name.to_string())
+                                rust_mcp_sdk::schema::schema_utils::CallToolError::unknown_tool(value.name.to_string())
                               )
                         }
                     }

--- a/doc/getting-started-mcp-server.md
+++ b/doc/getting-started-mcp-server.md
@@ -20,11 +20,11 @@ cd hello-world-mcp-server
 
 ## Step 2: Add Dependencies
 
-Next, we’ll add the Rust MCP dependencies for the toolkit, schema, and runtime support. We’ll also include `tokio` and `async-trait` for async functionality, plus `serde` and `serde_json` to enable [rust-mcp-macros](https://crates.io/crates/rust-mcp-macros) for MCP tool development.
+Next, we’ll add the `rust-mcp-sdk` dependency , also include `tokio` and `async-trait` for async functionality, plus `serde` and `serde_json` to enable [rust-mcp-macros](https://crates.io/crates/rust-mcp-macros) for MCP tool development.
 
 ```sh
 # rust-mcp dependencies
-cargo add rust-mcp-sdk rust-mcp-schema
+cargo add rust-mcp-sdk
 
 # other required dependencies
 cargo add tokio async-trait serde serde_json
@@ -39,12 +39,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.88"
-rust-mcp-schema = "0.2.1"
-rust-mcp-sdk = "0.1.1"
-serde = "1.0.219"
-serde_json = "1.0.140"
-tokio = "1.44.1"
+async-trait = "0.1"
+rust-mcp-sdk = "0.4"
+serde = "1.0"
+serde_json = "1.0"
+tokio = "1.4"
 ```
 
 ## Step3: update the `main()` function
@@ -71,7 +70,7 @@ Create a new module in the project called `tools.rs` and include the definitions
 
 ```rust
 //src/tools.rs
-use rust_mcp_schema::{schema_utils::CallToolError, CallToolResult};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     tool_box,
@@ -144,7 +143,7 @@ Here is the code for `handler.rs` :
 // src/handler.rs
 
 use async_trait::async_trait;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     schema_utils::CallToolError, CallToolRequest, CallToolResult, RpcError,
     ListToolsRequest, ListToolsResult,
 };
@@ -207,7 +206,7 @@ Here is how final `main.rs` file looks like.
 mod handler;
 mod tools;
 use handler::MyServerHandler;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };

--- a/doc/getting-started-mcp-server.md
+++ b/doc/getting-started-mcp-server.md
@@ -36,7 +36,7 @@ This is what your Cargo.toml looks like after the dependencies are added:
 [package]
 name = "hello-world-mcp-server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 async-trait = "0.1"
@@ -267,12 +267,16 @@ Now we can use the binary like any other MCP Server in your desired environment.
 1- launch the mcp-inspector:
 
 ```sh
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector ./target/release/hello-world-mcp-server
 ```
 
-> you will get a message like: `MCP Inspector is up and running at http://localhost:5173` 🚀
+```
+Starting MCP inspector...
+⚙ Proxy server listening on port 6277
+🔍 MCP Inspector is up and running at http://127.0.0.1:6274 🚀
+```
 
-Open that address in a web browser:
+Open the address in a web browser:
 
 2- Select STDIO as the transport, enter your binary path in the Command section, and click the Connect button. You should see a message confirming that your server started successfully.
 

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -11,7 +11,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "server",
     "macros",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/hello-world-mcp-server-core/README.md
+++ b/examples/hello-world-mcp-server-core/README.md
@@ -1,11 +1,11 @@
 # Hello World MCP Server (Core)
 
-A basic MCP server implementation featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) and [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk)
+A basic MCP server implementation featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk)
 
 ## Overview
 
 This project showcases a fundamental MCP server implementation, highlighting the capabilities of
-[rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) and [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) and with these features:
+[rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) with these features:
 
 - Standard I/O transport
 - Custom server handler

--- a/examples/hello-world-mcp-server-core/src/handler.rs
+++ b/examples/hello-world-mcp-server-core/src/handler.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     schema_utils::{CallToolError, NotificationFromClient, RequestFromClient, ResultFromServer},
     ClientRequest, ListToolsResult, RpcError,
 };

--- a/examples/hello-world-mcp-server-core/src/main.rs
+++ b/examples/hello-world-mcp-server-core/src/main.rs
@@ -2,7 +2,7 @@ mod handler;
 mod tools;
 
 use handler::MyServerHandler;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };

--- a/examples/hello-world-mcp-server-core/src/tools.rs
+++ b/examples/hello-world-mcp-server-core/src/tools.rs
@@ -1,4 +1,4 @@
-use rust_mcp_schema::{schema_utils::CallToolError, CallToolResult};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     tool_box,

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -13,7 +13,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "hyper-server",
     "ssl",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/hello-world-mcp-server/README.md
+++ b/examples/hello-world-mcp-server/README.md
@@ -1,10 +1,10 @@
 # Hello World MCP Server
 
-A basic MCP server implementation featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) and [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk)
+A basic MCP server implementation featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk)
 
 ## Overview
 
-This project showcases a fundamental MCP server implementation, highlighting the capabilities of [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) and [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) with these features:
+This project showcases a fundamental MCP server implementation, highlighting the capabilities of [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) with these features:
 
 - Standard I/O transport
 - Custom server handler

--- a/examples/hello-world-mcp-server/src/handler.rs
+++ b/examples/hello-world-mcp-server/src/handler.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     schema_utils::CallToolError, CallToolRequest, CallToolResult, ListToolsRequest,
     ListToolsResult, RpcError,
 };

--- a/examples/hello-world-mcp-server/src/main.rs
+++ b/examples/hello-world-mcp-server/src/main.rs
@@ -2,7 +2,7 @@ mod handler;
 mod tools;
 
 use handler::MyServerHandler;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };

--- a/examples/hello-world-mcp-server/src/tools.rs
+++ b/examples/hello-world-mcp-server/src/tools.rs
@@ -1,4 +1,4 @@
-use rust_mcp_schema::{schema_utils::CallToolError, CallToolResult};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     tool_box,

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -12,7 +12,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "macros",
     "hyper-server",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/hello-world-server-core-sse/README.md
+++ b/examples/hello-world-server-core-sse/README.md
@@ -1,11 +1,11 @@
 # Hello World MCP Server (Core) - SSE Transport
 
-A basic MCP server implementation featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) and [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) , using SSE transport
+A basic MCP server implementation featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) , using SSE transport
 
 ## Overview
 
 This project showcases a fundamental MCP server implementation, highlighting the capabilities of
-[rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) and [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) and with these features:
+[rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) with these features:
 
 - SSE transport
 - Custom server handler

--- a/examples/hello-world-server-core-sse/src/handler.rs
+++ b/examples/hello-world-server-core-sse/src/handler.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     schema_utils::{CallToolError, NotificationFromClient, RequestFromClient, ResultFromServer},
     ClientRequest, ListToolsResult, RpcError,
 };

--- a/examples/hello-world-server-core-sse/src/main.rs
+++ b/examples/hello-world-server-core-sse/src/main.rs
@@ -2,7 +2,7 @@ mod handler;
 mod tools;
 
 use handler::MyServerHandler;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };

--- a/examples/hello-world-server-core-sse/src/tools.rs
+++ b/examples/hello-world-server-core-sse/src/tools.rs
@@ -1,4 +1,4 @@
-use rust_mcp_schema::{schema_utils::CallToolError, CallToolResult};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     tool_box,

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -12,7 +12,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "macros",
     "hyper-server",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/hello-world-server-sse/README.md
+++ b/examples/hello-world-server-sse/README.md
@@ -1,10 +1,10 @@
 # Hello World MCP Server - SSE Transport
 
-A basic MCP server implementation using SSE transport, featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) and [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) , using SSE transport
+A basic MCP server implementation using SSE transport, featuring two custom tools: `Say Hello` and `Say Goodbye` , utilizing [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) , using SSE transport
 
 ## Overview
 
-This project showcases a fundamental MCP server implementation, highlighting the capabilities of [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) and [rust-mcp-schema](https://github.com/rust-mcp-stack/rust-mcp-schema) with these features:
+This project showcases a fundamental MCP server implementation, highlighting the capabilities of [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) with these features:
 
 - SSE transport
 - Custom server handler

--- a/examples/hello-world-server-sse/src/handler.rs
+++ b/examples/hello-world-server-sse/src/handler.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     schema_utils::CallToolError, CallToolRequest, CallToolResult, ListToolsRequest,
     ListToolsResult, RpcError,
 };

--- a/examples/hello-world-server-sse/src/main.rs
+++ b/examples/hello-world-server-sse/src/main.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use rust_mcp_sdk::mcp_server::{hyper_server, HyperServerOptions};
 
 use handler::MyServerHandler;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };

--- a/examples/hello-world-server-sse/src/tools.rs
+++ b/examples/hello-world-server-sse/src/tools.rs
@@ -1,4 +1,4 @@
-use rust_mcp_schema::{schema_utils::CallToolError, CallToolResult};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     tool_box,

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -11,7 +11,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/simple-mcp-client-core-sse/README.md
+++ b/examples/simple-mcp-client-core-sse/README.md
@@ -4,8 +4,7 @@ This is a simple MCP (Model Context Protocol) client implemented with the rust-m
 
 ## Overview
 
-This project demonstrates a basic MCP client implementation, showcasing the features of rust-mcp-schema and rust-mcp-sdk.
-
+This project demonstrates a basic MCP client implementation, showcasing the features of the [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk).
 
 This example connects to a running instance of the [@modelcontextprotocol/server-everything](https://www.npmjs.com/package/@modelcontextprotocol/server-everything) server, which has already been started with the sse flag.
 
@@ -27,6 +26,7 @@ cd rust-mcp-sdk
 ```bash
 npx @modelcontextprotocol/server-everything sse
 ```
+
 > It launches the server, making everything accessible via the SSE transport at http://localhost:3001/sse.
 
 2. Open a new terminal and run the project with:

--- a/examples/simple-mcp-client-core-sse/src/handler.rs
+++ b/examples/simple-mcp-client-core-sse/src/handler.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
+    self,
     schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient},
-    RpcError,
+    RpcError, ServerRequest,
 };
 use rust_mcp_sdk::{mcp_client::ClientHandlerCore, McpClient};
 pub struct MyClientHandler;
@@ -18,15 +19,15 @@ impl ClientHandlerCore for MyClientHandler {
     ) -> std::result::Result<ResultFromClient, RpcError> {
         match request {
             RequestFromServer::ServerRequest(server_request) => match server_request {
-                rust_mcp_schema::ServerRequest::PingRequest(_) => {
-                    return Ok(rust_mcp_schema::Result::default().into());
+                ServerRequest::PingRequest(_) => {
+                    return Ok(schema::Result::default().into());
                 }
-                rust_mcp_schema::ServerRequest::CreateMessageRequest(_create_message_request) => {
+                ServerRequest::CreateMessageRequest(_create_message_request) => {
                     Err(RpcError::internal_error().with_message(
                         "CreateMessageRequest handler is not implemented".to_string(),
                     ))
                 }
-                rust_mcp_schema::ServerRequest::ListRootsRequest(_list_roots_request) => {
+                ServerRequest::ListRootsRequest(_list_roots_request) => {
                     Err(RpcError::internal_error()
                         .with_message("ListRootsRequest handler is not implemented".to_string()))
                 }

--- a/examples/simple-mcp-client-core-sse/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-core-sse/src/inquiry_utils.rs
@@ -1,7 +1,7 @@
 //! This module contains utility functions for querying and displaying server capabilities.
 
 use colored::Colorize;
-use rust_mcp_schema::CallToolRequestParams;
+use rust_mcp_sdk::schema::CallToolRequestParams;
 use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::ClientRuntime};
 use serde_json::json;

--- a/examples/simple-mcp-client-core-sse/src/main.rs
+++ b/examples/simple-mcp-client-core-sse/src/main.rs
@@ -4,11 +4,12 @@ mod inquiry_utils;
 use handler::MyClientHandler;
 
 use inquiry_utils::InquiryUtils;
-use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
-};
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime_core;
+use rust_mcp_sdk::schema::{
+    ClientCapabilities, Implementation, InitializeRequestParams, LoggingLevel,
+    LATEST_PROTOCOL_VERSION,
+};
 use rust_mcp_sdk::{ClientSseTransport, ClientSseTransportOptions, McpClient};
 use std::sync::Arc;
 use tracing_subscriber::layer::SubscriberExt;
@@ -78,10 +79,7 @@ async fn main() -> SdkResult<()> {
     utils.call_add_tool(100, 25).await?;
 
     // Set the log level
-    utils
-        .client
-        .set_logging_level(rust_mcp_schema::LoggingLevel::Debug)
-        .await?;
+    utils.client.set_logging_level(LoggingLevel::Debug).await?;
 
     // Send 3 pings to the server, with a 2-second interval between each ping.
     utils.ping_n_times(3).await;

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -11,7 +11,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/simple-mcp-client-core/README.md
+++ b/examples/simple-mcp-client-core/README.md
@@ -4,7 +4,7 @@ This is a straightforward example of an MCP (Model Context Protocol) client impl
 
 ## Overview
 
-This project demonstrates a basic MCP client implementation, showcasing the features of rust-mcp-schema and rust-mcp-sdk.
+This project provides a simple implementation of an MCP client, highlighting the capabilities of the [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk).
 
 This example initiates and establishes a connection to the [@modelcontextprotocol/server-everything](https://www.npmjs.com/package/@modelcontextprotocol/server-everything) server, an MCP Server designed for experimenting with various capabilities of the MCP.
 

--- a/examples/simple-mcp-client-core/src/handler.rs
+++ b/examples/simple-mcp-client-core/src/handler.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
-use rust_mcp_schema::{
+use rust_mcp_sdk::schema::{
+    self,
     schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient},
-    RpcError,
+    RpcError, ServerRequest,
 };
 use rust_mcp_sdk::{mcp_client::ClientHandlerCore, McpClient};
 pub struct MyClientHandler;
@@ -18,15 +19,15 @@ impl ClientHandlerCore for MyClientHandler {
     ) -> std::result::Result<ResultFromClient, RpcError> {
         match request {
             RequestFromServer::ServerRequest(server_request) => match server_request {
-                rust_mcp_schema::ServerRequest::PingRequest(_) => {
-                    return Ok(rust_mcp_schema::Result::default().into());
+                ServerRequest::PingRequest(_) => {
+                    return Ok(schema::Result::default().into());
                 }
-                rust_mcp_schema::ServerRequest::CreateMessageRequest(_create_message_request) => {
+                ServerRequest::CreateMessageRequest(_create_message_request) => {
                     Err(RpcError::internal_error().with_message(
                         "CreateMessageRequest handler is not implemented".to_string(),
                     ))
                 }
-                rust_mcp_schema::ServerRequest::ListRootsRequest(_list_roots_request) => {
+                ServerRequest::ListRootsRequest(_list_roots_request) => {
                     Err(RpcError::internal_error()
                         .with_message("ListRootsRequest handler is not implemented".to_string()))
                 }

--- a/examples/simple-mcp-client-core/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-core/src/inquiry_utils.rs
@@ -1,7 +1,7 @@
 //! This module contains utility functions for querying and displaying server capabilities.
 
 use colored::Colorize;
-use rust_mcp_schema::CallToolRequestParams;
+use rust_mcp_sdk::schema::CallToolRequestParams;
 use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::ClientRuntime};
 use serde_json::json;

--- a/examples/simple-mcp-client-core/src/main.rs
+++ b/examples/simple-mcp-client-core/src/main.rs
@@ -2,10 +2,10 @@ mod handler;
 mod inquiry_utils;
 
 use handler::MyClientHandler;
-
 use inquiry_utils::InquiryUtils;
-use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
+use rust_mcp_sdk::schema::{
+    ClientCapabilities, Implementation, InitializeRequestParams, LoggingLevel,
+    LATEST_PROTOCOL_VERSION,
 };
 use rust_mcp_sdk::{error::SdkResult, mcp_client::client_runtime_core};
 use rust_mcp_sdk::{McpClient, StdioTransport, TransportOptions};
@@ -73,10 +73,7 @@ async fn main() -> SdkResult<()> {
     utils.call_add_tool(100, 25).await?;
 
     // Set the log level
-    utils
-        .client
-        .set_logging_level(rust_mcp_schema::LoggingLevel::Debug)
-        .await?;
+    utils.client.set_logging_level(LoggingLevel::Debug).await?;
 
     // Send 3 ping requests to the server, with a 2-second interval between each ping request.
     utils.ping_n_times(3).await;

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -11,7 +11,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/simple-mcp-client-sse/README.md
+++ b/examples/simple-mcp-client-sse/README.md
@@ -4,7 +4,7 @@ This is a simple MCP (Model Context Protocol) client implemented with the rust-m
 
 ## Overview
 
-This project demonstrates a basic MCP client implementation, showcasing the features of rust-mcp-schema and rust-mcp-sdk.
+This project demonstrates a basic MCP client implementation, showcasing the features of the [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk).
 
 This example connects to a running instance of the [@modelcontextprotocol/server-everything](https://www.npmjs.com/package/@modelcontextprotocol/server-everything) server, which has already been started with the sse flag.
 
@@ -26,6 +26,7 @@ cd rust-mcp-sdk
 ```bash
 npx @modelcontextprotocol/server-everything sse
 ```
+
 > It launches the server, making everything accessible via the SSE transport at http://localhost:3001/sse.
 
 2. Open a new terminal and run the project with:

--- a/examples/simple-mcp-client-sse/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-sse/src/inquiry_utils.rs
@@ -1,7 +1,7 @@
 //! This module contains utility functions for querying and displaying server capabilities.
 
 use colored::Colorize;
-use rust_mcp_schema::CallToolRequestParams;
+use rust_mcp_sdk::schema::CallToolRequestParams;
 use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::ClientRuntime};
 use serde_json::json;

--- a/examples/simple-mcp-client-sse/src/main.rs
+++ b/examples/simple-mcp-client-sse/src/main.rs
@@ -4,11 +4,12 @@ mod inquiry_utils;
 use handler::MyClientHandler;
 
 use inquiry_utils::InquiryUtils;
-use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
-};
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime;
+use rust_mcp_sdk::schema::{
+    ClientCapabilities, Implementation, InitializeRequestParams, LoggingLevel,
+    LATEST_PROTOCOL_VERSION,
+};
 use rust_mcp_sdk::{ClientSseTransport, ClientSseTransportOptions, McpClient};
 use std::sync::Arc;
 use tracing_subscriber::layer::SubscriberExt;
@@ -78,10 +79,7 @@ async fn main() -> SdkResult<()> {
     utils.call_add_tool(100, 25).await?;
 
     // Set the log level
-    utils
-        .client
-        .set_logging_level(rust_mcp_schema::LoggingLevel::Debug)
-        .await?;
+    utils.client.set_logging_level(LoggingLevel::Debug).await?;
 
     // Send 3 pings to the server, with a 2-second interval between each ping.
     utils.ping_n_times(3).await;

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -11,7 +11,6 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
 ] }
-rust-mcp-schema = { workspace = true }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/examples/simple-mcp-client/README.md
+++ b/examples/simple-mcp-client/README.md
@@ -4,7 +4,7 @@ This is a straightforward example of an MCP (Model Context Protocol) client impl
 
 ## Overview
 
-This project demonstrates a basic MCP client implementation, showcasing the features of rust-mcp-schema and rust-mcp-sdk.
+This project demonstrates a basic MCP client implementation, showcasing the features of the [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk).
 
 This example initiates and establishes a connection to the [@modelcontextprotocol/server-everything](https://www.npmjs.com/package/@modelcontextprotocol/server-everything) server, an MCP Server designed for experimenting with various capabilities of the MCP.
 
@@ -30,4 +30,3 @@ cargo run -p simple-mcp-client
 You can observe a sample output of the project; however, your results may vary slightly depending on the version of the MCP Server in use when you run it.
 
 <img src="../../assets/examples/mcp-client-output.jpg" width="640"/>
-

--- a/examples/simple-mcp-client/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client/src/inquiry_utils.rs
@@ -1,7 +1,7 @@
 //! This module contains utility functions for querying and displaying server capabilities.
 
 use colored::Colorize;
-use rust_mcp_schema::CallToolRequestParams;
+use rust_mcp_sdk::schema::CallToolRequestParams;
 use rust_mcp_sdk::McpClient;
 use rust_mcp_sdk::{error::SdkResult, mcp_client::ClientRuntime};
 use serde_json::json;

--- a/examples/simple-mcp-client/src/main.rs
+++ b/examples/simple-mcp-client/src/main.rs
@@ -2,13 +2,13 @@ mod handler;
 mod inquiry_utils;
 
 use handler::MyClientHandler;
-
 use inquiry_utils::InquiryUtils;
-use rust_mcp_schema::{
-    ClientCapabilities, Implementation, InitializeRequestParams, LATEST_PROTOCOL_VERSION,
-};
 use rust_mcp_sdk::error::SdkResult;
 use rust_mcp_sdk::mcp_client::client_runtime;
+use rust_mcp_sdk::schema::{
+    ClientCapabilities, Implementation, InitializeRequestParams, LoggingLevel,
+    LATEST_PROTOCOL_VERSION,
+};
 use rust_mcp_sdk::{McpClient, StdioTransport, TransportOptions};
 use std::sync::Arc;
 
@@ -74,10 +74,7 @@ async fn main() -> SdkResult<()> {
     utils.call_add_tool(100, 25).await?;
 
     // Set the log level
-    utils
-        .client
-        .set_logging_level(rust_mcp_schema::LoggingLevel::Debug)
-        .await?;
+    utils.client.set_logging_level(LoggingLevel::Debug).await?;
 
     // Send 3 pings to the server, with a 2-second interval between each ping.
     utils.ping_n_times(3).await;


### PR DESCRIPTION
### 📌 Summary
Make `rust-mcp-sdk` the sole dependency—no need to add `rust-mcp-schema` separately anymore.

This PR updates the `rust-mcp-sdk`  ecosystem to make `rust-mcp-sdk` the sole dependency required for users, eliminating the need to separately include `rust-mcp-schema`. 

Macro generation logic in `rust_mcp_macros` also updated  to adapt to the context of rust-mcp-sdk usage while maintaining compatibility for standalone `rust_mcp_macros` users with a new `sdk` cargo feature.

### ✨ Changes Made
- Added an `sdk` feature flag in rust_mcp_macros's Cargo.toml. Modified rust_mcp_macros to conditionally adapt its generated code based on the sdk feature, ensuring seamless integration with rust-mcp-sdk while keeping it compatible with rust-mcp-schema.
- Ensured rust-mcp-sdk re-exports rust-mcp-schema as `rust_mcp_sdk::schema` for ergonomic access to schema types (e.g., rust_mcp_sdk::schema::Tool);
- Updated documentation in READMEs to clarify dependency requirements and usage.
- Removed `rust-mcp-schema` dependency from examples and updated them to use re-exported  `rust_mcp_sdk::schema` instead
