### PR TITLE
feat: multi protocol version support - phase 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ members = [
 # Workspace member crates
 rust-mcp-transport = { version = "0.3.3", path = "crates/rust-mcp-transport", default-features = false }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "0.4.0", path = "crates/rust-mcp-macros" }
+rust-mcp-macros = { version = "0.4.0", path = "crates/rust-mcp-macros", default-features = false }
 
 # External crates
-rust-mcp-schema = { version = "0.5" }
+rust-mcp-schema = { version = "0.5", default-features = false  }
 futures = { version = "0.3" }
 tokio = { version = "1.4", features = ["full"] }
 serde = { version = "1.0", features = ["derive", "serde_derive"] }

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-rust-mcp-schema = { workspace = true }
+rust-mcp-schema = { workspace = true, default-features = false }
 
 [lints]
 workspace = true
@@ -38,7 +38,7 @@ default = ["2025_03_26"] # Default features
 latest = ["2025_03_26"]
 
 # enabled mcp schema version 2025_03_26
-2025_03_26 = ["rust-mcp-schema/2025_03_26"]
+2025_03_26 = ["rust-mcp-schema/2025_03_26","rust-mcp-schema/schema_utils"]
 # enabled mcp schema version 2024_11_05
-2024_11_05 = ["rust-mcp-schema/2024_11_05"]
+2024_11_05 = ["rust-mcp-schema/2024_11_05","rust-mcp-schema/schema_utils"]
 sdk = []

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -11,9 +11,9 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-rust-mcp-schema = { workspace = true }
+rust-mcp-schema = { workspace = true, default-features=false }
 rust-mcp-transport = { workspace = true, default-features = false, optional = true }
-rust-mcp-macros = { workspace = true, optional = true, features = ["sdk"] }
+rust-mcp-macros = { workspace = true, optional = true, default-features=false, feature=["sdk"] }
 
 tokio.workspace = true
 serde = { workspace = true }
@@ -46,6 +46,7 @@ default = [
     "macros",
     "hyper-server",
     "ssl",
+    "2025_03_26"
 ] # All features enabled by default
 server = ["rust-mcp-transport/stdio"] # Server feature
 client = ["rust-mcp-transport/stdio", "rust-mcp-transport/sse"] # Client feature
@@ -58,6 +59,18 @@ hyper-server = [
 ]
 ssl = ["axum-server/tls-rustls"]
 macros = ["rust-mcp-macros/sdk"]
+
+# enabled mcp protocol version 2025_03_26
+2025_03_26 = ["rust-mcp-schema/2025_03_26",
+"rust-mcp-macros/2025_03_26",
+"rust-mcp-transport/2025_03_26",
+"rust-mcp-schema/schema_utils"]
+
+# enabled mcp protocol version 2024_11_05
+2024_11_05 = ["rust-mcp-schema/2024_11_05",
+"rust-mcp-macros/2024_11_05",
+"rust-mcp-transport/2024_11_05",
+"rust-mcp-schema/schema_utils"]
 
 [lints]
 workspace = true

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -11,7 +11,8 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-rust-mcp-schema = { workspace = true }
+
+rust-mcp-schema = { workspace = true, default-features=false}
 
 async-trait = { workspace = true }
 futures = { workspace = true }
@@ -34,7 +35,12 @@ workspace = true
 
 ### FEATURES #################################################################
 [features]
-default = ["stdio", "sse"] # Default features
+default = ["stdio", "sse","2025_03_26"] # Default features
 
 stdio = []
 sse = ["reqwest"]
+# enabled mcp protocol version 2025_03_26
+2025_03_26 = ["rust-mcp-schema/2025_03_26","rust-mcp-schema/schema_utils"]
+
+# enabled mcp protocol version 2024_11_05
+2024_11_05 = ["rust-mcp-schema/2024_11_05","rust-mcp-schema/schema_utils"]

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "server",
     "macros",
+    "2025_03_26"
 ] }
 
 tokio = { workspace = true }

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -12,6 +12,7 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "macros",
     "hyper-server",
     "ssl",
+    "2025_03_26"
 ] }
 
 tokio = { workspace = true }

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -11,6 +11,7 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "server",
     "macros",
     "hyper-server",
+    "2025_03_26"
 ] }
 
 tokio = { workspace = true }

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -11,6 +11,7 @@ rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "server",
     "macros",
     "hyper-server",
+    "2025_03_26"
 ] }
 
 tokio = { workspace = true }

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT"
 rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
+    "2025_03_26"
+
 ] }
 
 tokio = { workspace = true }

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT"
 rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
+    "2025_03_26"
+
 ] }
 
 tokio = { workspace = true }

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT"
 rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
+    "2025_03_26"
+
 ] }
 
 tokio = { workspace = true }

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT"
 rust-mcp-sdk = { workspace = true, default-features = false, features = [
     "client",
     "macros",
+    "2025_03_26"
+
 ] }
 
 tokio = { workspace = true }


### PR DESCRIPTION
### 📌 Summary
This PR helps with switching to the older versions of mcp protoco, by introducing new flags. to switch to `2024_11_05` use 

```toml
rust-mcp-sdk = { version="*" ,  default-features = false, features = [ "client", "server" , "macros",  "2024_11_05" ] }
```


Note: multiple mcp protocol version support will be implemented in phase 2 when this PR is merged https://github.com/rust-mcp-stack/rust-mcp-schema/pull/73

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- Related issue #48 

