### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.4.3",
+    "crates/rust-mcp-sdk": "0.4.4",
     "crates/rust-mcp-macros": "0.4.2",
     "crates/rust-mcp-transport": "0.3.5",
-    "examples/hello-world-mcp-server": "0.1.19",
-    "examples/hello-world-mcp-server-core": "0.1.10",
-    "examples/simple-mcp-client": "0.1.19",
-    "examples/simple-mcp-client-core": "0.1.19",
-    "examples/hello-world-server-core-sse": "0.1.10",
-    "examples/hello-world-server-sse": "0.1.19",
-    "examples/simple-mcp-client-core-sse": "0.1.10",
-    "examples/simple-mcp-client-sse": "0.1.10"
+    "examples/hello-world-mcp-server": "0.1.20",
+    "examples/hello-world-mcp-server-core": "0.1.11",
+    "examples/simple-mcp-client": "0.1.20",
+    "examples/simple-mcp-client-core": "0.1.20",
+    "examples/hello-world-server-core-sse": "0.1.11",
+    "examples/hello-world-server-sse": "0.1.20",
+    "examples/simple-mcp-client-core-sse": "0.1.11",
+    "examples/simple-mcp-client-sse": "0.1.11"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "futures",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "colored",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "colored",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "colored",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.3...rust-mcp-sdk-v0.4.4) (2025-06-20)
+
+
+### 🚀 Features
+
+* Enable rustls support in reqwest ([d6c6293](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/d6c6293c4ac66fadafee7385b80e0f4cd002e7e4))
+
 ## [0.4.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.2...rust-mcp-sdk-v0.4.3) (2025-06-17)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.20</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.11</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.11</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.20</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.4.4</summary>

## [0.4.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.3...rust-mcp-sdk-v0.4.4) (2025-06-20)


### 🚀 Features

* Enable rustls support in reqwest ([d6c6293](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/d6c6293c4ac66fadafee7385b80e0f4cd002e7e4))
</details>

<details><summary>simple-mcp-client: 0.1.20</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.20</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.11</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.11</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).