### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.4.4",
+    "crates/rust-mcp-sdk": "0.4.5",
     "crates/rust-mcp-macros": "0.4.2",
-    "crates/rust-mcp-transport": "0.3.5",
-    "examples/hello-world-mcp-server": "0.1.20",
-    "examples/hello-world-mcp-server-core": "0.1.11",
-    "examples/simple-mcp-client": "0.1.20",
-    "examples/simple-mcp-client-core": "0.1.20",
-    "examples/hello-world-server-core-sse": "0.1.11",
-    "examples/hello-world-server-sse": "0.1.20",
-    "examples/simple-mcp-client-core-sse": "0.1.11",
-    "examples/simple-mcp-client-sse": "0.1.11"
+    "crates/rust-mcp-transport": "0.3.6",
+    "examples/hello-world-mcp-server": "0.1.21",
+    "examples/hello-world-mcp-server-core": "0.1.12",
+    "examples/simple-mcp-client": "0.1.21",
+    "examples/simple-mcp-client-core": "0.1.21",
+    "examples/hello-world-server-core-sse": "0.1.12",
+    "examples/hello-world-server-sse": "0.1.21",
+    "examples/simple-mcp-client-core-sse": "0.1.12",
+    "examples/simple-mcp-client-sse": "0.1.12"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "futures",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "colored",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "colored",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "colored",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.3.5", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-transport = { version = "0.3.6", path = "crates/rust-mcp-transport", default-features = false }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.4.2", path = "crates/rust-mcp-macros", default-features = false }
 

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.4.5](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.4...rust-mcp-sdk-v0.4.5) (2025-06-20)
+
 ## [0.4.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.3...rust-mcp-sdk-v0.4.4) (2025-06-20)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.6](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.3.5...rust-mcp-transport-v0.3.6) (2025-06-20)
+
+
+### 🐛 Bug Fixes
+
+* Sync reqwest dependencies in rust-mcp-transport ([f76468e](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f76468eec7efb37f530a7c32f1de561b7bf2e21f))
+
 ## [0.3.5](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.3.4...rust-mcp-transport-v0.3.5) (2025-06-17)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.21</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.12</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.12</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.21</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.4.5</summary>

## [0.4.5](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.4...rust-mcp-sdk-v0.4.5) (2025-06-20)
</details>

<details><summary>rust-mcp-transport: 0.3.6</summary>

## [0.3.6](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.3.5...rust-mcp-transport-v0.3.6) (2025-06-20)


### 🐛 Bug Fixes

* Sync reqwest dependencies in rust-mcp-transport ([f76468e](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f76468eec7efb37f530a7c32f1de561b7bf2e21f))
</details>

<details><summary>simple-mcp-client: 0.1.21</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.21</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.12</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.12</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).