### PR TITLE
chore: remove leftover prints for tracing statements - Fixes TUI apps using the SDK

### DIFF
--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
@@ -144,7 +144,8 @@ pub trait ClientHandler: Send + Sync + 'static {
         runtime: &dyn McpClient,
     ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
-            eprintln!("Process error: {}", error_message);
+            tracing::error!("Process error: {}", error_message);
+            //eprintln!("Process error: {}", error_message);
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
@@ -145,7 +145,6 @@ pub trait ClientHandler: Send + Sync + 'static {
     ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
             tracing::error!("Process error: {}", error_message);
-            //eprintln!("Process error: {}", error_message);
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
@@ -48,7 +48,8 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
         runtime: &dyn McpClient,
     ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
-            eprintln!("Process error: {}", error_message);
+            tracing::error!("Process error: {}", error_message);
+            //eprintln!("Process error: {}", error_message);
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
@@ -49,7 +49,6 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
     ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
             tracing::error!("Process error: {}", error_message);
-            //eprintln!("Process error: {}", error_message);
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -118,7 +118,8 @@ impl McpClient for ClientRuntime {
                                     break;
                                 }
                                 Err(e) => {
-                                    eprintln!("Error reading from std_err: {}", e);
+                                    tracing::error!("Error reading from std_err: {}", e);
+                                    //eprintln!("Error reading from std_err: {}", e);
                                     break;
                                 }
                             }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -119,7 +119,6 @@ impl McpClient for ClientRuntime {
                                 }
                                 Err(e) => {
                                     tracing::error!("Error reading from std_err: {}", e);
-                                    //eprintln!("Error reading from std_err: {}", e);
                                     break;
                                 }
                             }

--- a/crates/rust-mcp-transport/src/client_sse.rs
+++ b/crates/rust-mcp-transport/src/client_sse.rs
@@ -259,7 +259,6 @@ where
                         let body = String::from_utf8_lossy(&data).trim().to_string();
                           if let Err(e) = http_post(&client_clone, &post_url, body, &custom_headers).await {
                             tracing::error!("Failed to POST message: {:?}", e);
-                            //eprintln!("Failed to POST message: {:?}", e);
                       }
                     },
                     None => break, // Exit if channel is closed

--- a/crates/rust-mcp-transport/src/client_sse.rs
+++ b/crates/rust-mcp-transport/src/client_sse.rs
@@ -258,7 +258,8 @@ where
                         // trim the trailing \n before making a request
                         let body = String::from_utf8_lossy(&data).trim().to_string();
                           if let Err(e) = http_post(&client_clone, &post_url, body, &custom_headers).await {
-                            eprintln!("Failed to POST message: {:?}", e);
+                            tracing::error!("Failed to POST message: {:?}", e);
+                            //eprintln!("Failed to POST message: {:?}", e);
                       }
                     },
                     None => break, // Exit if channel is closed

--- a/crates/rust-mcp-transport/src/mcp_stream.rs
+++ b/crates/rust-mcp-transport/src/mcp_stream.rs
@@ -127,10 +127,6 @@ impl MCPStream {
                                                             "Received response or error without a matching request: {:?}",
                                                             &message.is_response()
                                                         );
-                                                        //eprintln!(
-                                                        //    "Error: Received response does not correspond to any request. {:?}",
-                                                        //    &message.is_response()
-                                                        //);
                                                     }
                                                 }
                                             } else {

--- a/crates/rust-mcp-transport/src/mcp_stream.rs
+++ b/crates/rust-mcp-transport/src/mcp_stream.rs
@@ -123,10 +123,14 @@ impl MCPStream {
                                                         //An error that is unrelated to a request.
                                                         tx.send(message).map_err(GenericSendError::new)?;
                                                     } else {
-                                                        eprintln!(
-                                                            "Error: Received response does not correspond to any request. {:?}",
+                                                        tracing::warn!(
+                                                            "Received response or error without a matching request: {:?}",
                                                             &message.is_response()
                                                         );
+                                                        //eprintln!(
+                                                        //    "Error: Received response does not correspond to any request. {:?}",
+                                                        //    &message.is_response()
+                                                        //);
                                                     }
                                                 }
                                             } else {

--- a/crates/rust-mcp-transport/src/utils/sse_stream.rs
+++ b/crates/rust-mcp-transport/src/utils/sse_stream.rs
@@ -68,7 +68,6 @@ impl SseStream {
                 Ok(resp) => resp,
                 Err(e) => {
                     tracing::error!("Failed to connect to SSE: {}", e);
-                    //eprintln!("Failed to connect to SSE: {}", e);
                     if retry_count >= self.max_retries {
                         tracing::error!("Max retries reached, giving up");
                         if let Some(tx) = endpoint_event_tx.take() {
@@ -163,7 +162,6 @@ impl SseStream {
                                     tracing::error!(
                                         "Readable stream closed, shutting down SSE task"
                                     );
-                                    //eprintln!("Readable stream closed, shutting down SSE task");
                                     if !endpoint_event_received {
                                         if let Some(tx) = endpoint_event_tx.take() {
                                             let _ = tx.send(None);

--- a/crates/rust-mcp-transport/src/utils/sse_stream.rs
+++ b/crates/rust-mcp-transport/src/utils/sse_stream.rs
@@ -67,7 +67,8 @@ impl SseStream {
             {
                 Ok(resp) => resp,
                 Err(e) => {
-                    eprintln!("Failed to connect to SSE: {}", e);
+                    tracing::error!("Failed to connect to SSE: {}", e);
+                    //eprintln!("Failed to connect to SSE: {}", e);
                     if retry_count >= self.max_retries {
                         tracing::error!("Max retries reached, giving up");
                         if let Some(tx) = endpoint_event_tx.take() {
@@ -159,7 +160,10 @@ impl SseStream {
                             if !content.is_empty() {
                                 let bytes = Bytes::copy_from_slice(content.as_bytes());
                                 if self.read_tx.send(bytes).await.is_err() {
-                                    eprintln!("Readable stream closed, shutting down SSE task");
+                                    tracing::error!(
+                                        "Readable stream closed, shutting down SSE task"
+                                    );
+                                    //eprintln!("Readable stream closed, shutting down SSE task");
                                     if !endpoint_event_received {
                                         if let Some(tx) = endpoint_event_tx.take() {
                                             let _ = tx.send(None);


### PR DESCRIPTION
### 📌 Summary
I'm currently using this SDK for a TUI app, but the TUI breaks when the MCP server I'm trying to connect to fails either SSE or stdio, I noticed the eprint statements in the source code and I noticed that tracing was being used as well. Changing to tracing allows me to create a log file to redirect these errors and do not pollute the app with unexpected output. 

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- Fixes #


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Changed eprint statements for tracing:error / tracing:warn

### 🛠️ Testing Steps
<!-- Explain how reviewers can test your changes, if applicable -->

Create a new client and set-up an unreachable SSE server or stdio server, no output to stdout should be written unless rust_log is being set.

### 💡 Additional Notes
<!-- Any other information or context about the PR -->
