### PR TITLE
fix: new clippy warnings

### DIFF
--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -460,8 +460,7 @@ mod tests {
             let ty: syn::Type = syn::parse_str(ty_str).unwrap();
             assert!(
                 !might_be_struct(&ty),
-                "Expected '{}' to be not a struct",
-                ty_str
+                "Expected '{ty_str}' to be not a struct"
             );
         }
     }

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/fallback_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/fallback_routes.rs
@@ -10,6 +10,6 @@ pub fn routes() -> Router {
 pub async fn not_found(uri: Uri) -> (StatusCode, String) {
     (
         StatusCode::INTERNAL_SERVER_ERROR,
-        format!("Server Error!\r\n uri: {}", uri),
+        format!("Server Error!\r\n uri: {uri}"),
     )
 }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler.rs
@@ -144,7 +144,7 @@ pub trait ClientHandler: Send + Sync + 'static {
         runtime: &dyn McpClient,
     ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
-            tracing::error!("Process error: {}", error_message);
+            tracing::error!("Process error: {error_message}");
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_client_handler_core.rs
@@ -48,7 +48,7 @@ pub trait ClientHandlerCore: Send + Sync + 'static {
         runtime: &dyn McpClient,
     ) -> std::result::Result<(), RpcError> {
         if !runtime.is_shut_down().await {
-            tracing::error!("Process error: {}", error_message);
+            tracing::error!("Process error: {error_message}");
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -33,7 +33,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<InitializeResult, RpcError> {
         runtime
             .set_client_details(initialize_request.params.clone())
-            .map_err(|err| RpcError::internal_error().with_message(format!("{}", err)))?;
+            .map_err(|err| RpcError::internal_error().with_message(format!("{err}")))?;
 
         let mut server_info = runtime.server_info().to_owned();
         // Provide compatibility for clients using older MCP protocol versions.

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -118,7 +118,7 @@ impl McpClient for ClientRuntime {
                                     break;
                                 }
                                 Err(e) => {
-                                    tracing::error!("Error reading from std_err: {}", e);
+                                    tracing::error!("Error reading from std_err: {e}");
                                     break;
                                 }
                             }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
@@ -70,7 +70,7 @@ impl McpServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
             // keep a copy of the InitializeRequestParams which includes client_info and capabilities
             runtime
                 .set_client_details(initialize_request.params.clone())
-                .map_err(|err| RpcError::internal_error().with_message(format!("{}", err)))?;
+                .map_err(|err| RpcError::internal_error().with_message(format!("{err}")))?;
         }
 
         // handle request and get the result

--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -21,10 +21,7 @@ use crate::error::{McpSdkError, SdkResult};
 /// assert_eq!(msg, "Server does not support resources (required for resources/list)");
 /// ```
 pub fn format_assertion_message(entity: &str, capability: &str, method_name: &str) -> String {
-    format!(
-        "{} does not support {} (required for {})",
-        entity, capability, method_name
-    )
+    format!("{entity} does not support {capability} (required for {method_name})")
 }
 
 /// Checks if the client and server protocol versions are compatible by ensuring they are equal.

--- a/crates/rust-mcp-sdk/tests/test_server_sse.rs
+++ b/crates/rust-mcp-sdk/tests/test_server_sse.rs
@@ -42,7 +42,7 @@ mod tets_server_sse {
         sleep(Duration::from_millis(750)).await;
 
         let client = Client::new();
-        println!("connecting to : {}", server_endpoint);
+        println!("connecting to : {server_endpoint}");
         // Act: Connect to the SSE endpoint and read the event stream
         let response = client
             .get(server_endpoint)
@@ -105,7 +105,7 @@ mod tets_server_sse {
         sleep(Duration::from_millis(750)).await;
 
         let client = Client::new();
-        println!("connecting to : {}", server_endpoint);
+        println!("connecting to : {server_endpoint}");
         // Act: Connect to the SSE endpoint and read the event stream
         let response = client
             .get(server_endpoint)
@@ -171,7 +171,7 @@ mod tets_server_sse {
         sleep(Duration::from_millis(750)).await;
 
         let client = Client::new();
-        println!("connecting to : {}", server_endpoint);
+        println!("connecting to : {server_endpoint}");
         // Act: Connect to the SSE endpoint and read the event stream
         let response = client
             .get(server_endpoint)

--- a/crates/rust-mcp-transport/src/client_sse.rs
+++ b/crates/rust-mcp-transport/src/client_sse.rs
@@ -125,11 +125,11 @@ impl ClientSseTransport {
         let mut header_map = HeaderMap::new();
 
         for (key, value) in headers {
-            let header_name = key.parse::<HeaderName>().map_err(|e| {
-                TransportError::InvalidOptions(format!("Invalid header name: {}", e))
-            })?;
+            let header_name = key
+                .parse::<HeaderName>()
+                .map_err(|e| TransportError::InvalidOptions(format!("Invalid header name: {e}")))?;
             let header_value = HeaderValue::from_str(value).map_err(|e| {
-                TransportError::InvalidOptions(format!("Invalid header value: {}", e))
+                TransportError::InvalidOptions(format!("Invalid header value: {e}"))
             })?;
             header_map.insert(header_name, header_value);
         }
@@ -258,7 +258,7 @@ where
                         // trim the trailing \n before making a request
                         let body = String::from_utf8_lossy(&data).trim().to_string();
                           if let Err(e) = http_post(&client_clone, &post_url, body, &custom_headers).await {
-                            tracing::error!("Failed to POST message: {:?}", e);
+                            tracing::error!("Failed to POST message: {e:?}");
                       }
                     },
                     None => break, // Exit if channel is closed

--- a/crates/rust-mcp-transport/src/mcp_stream.rs
+++ b/crates/rust-mcp-transport/src/mcp_stream.rs
@@ -140,8 +140,7 @@ impl MCPStream {
                                         Err(e) => {
                                             // Handle error in reading from readable_std
                                             return Err(TransportError::ProcessError(format!(
-                                                "Error reading from readable_std: {}",
-                                                e
+                                                "Error reading from readable_std: {e}"
                                             )));
                                         }
                         }

--- a/crates/rust-mcp-transport/src/utils.rs
+++ b/crates/rust-mcp-transport/src/utils.rs
@@ -67,14 +67,14 @@ pub(crate) fn endpoint_with_session_id(endpoint: &str, session_id: &SessionId) -
 
     // Build the query string
     let new_query = match query {
-        Some(q) if !q.is_empty() => format!("{}&sessionId={}", q, session_id),
-        _ => format!("sessionId={}", session_id),
+        Some(q) if !q.is_empty() => format!("{q}&sessionId={session_id}"),
+        _ => format!("sessionId={session_id}"),
     };
 
     // Construct final URL
     match fragment {
-        Some(f) => format!("{}?{}#{}", path, new_query, f),
-        None => format!("{}?{}", path, new_query),
+        Some(f) => format!("{path}?{new_query}#{f}"),
+        None => format!("{path}?{new_query}"),
     }
 }
 

--- a/crates/rust-mcp-transport/src/utils/http_utils.rs
+++ b/crates/rust-mcp-transport/src/utils/http_utils.rs
@@ -46,7 +46,7 @@ pub fn extract_origin(url: &str) -> Option<String> {
     let host_port = &rest[..end];
 
     // Reconstruct origin
-    Some(format!("{}://{}", scheme, host_port))
+    Some(format!("{scheme}://{host_port}"))
 }
 
 #[cfg(test)]

--- a/crates/rust-mcp-transport/src/utils/sse_stream.rs
+++ b/crates/rust-mcp-transport/src/utils/sse_stream.rs
@@ -67,7 +67,7 @@ impl SseStream {
             {
                 Ok(resp) => resp,
                 Err(e) => {
-                    tracing::error!("Failed to connect to SSE: {}", e);
+                    tracing::error!("Failed to connect to SSE: {e}");
                     if retry_count >= self.max_retries {
                         tracing::error!("Max retries reached, giving up");
                         if let Some(tx) = endpoint_event_tx.take() {

--- a/examples/hello-world-mcp-server-core/src/handler.rs
+++ b/examples/hello-world-mcp-server-core/src/handler.rs
@@ -78,7 +78,7 @@ impl ServerHandlerCore for MyServerHandler {
 
                 // Return Method not found for any other requests
                 _ => Err(RpcError::method_not_found()
-                    .with_message(format!("No handler is implemented for '{}'.", method_name,))),
+                    .with_message(format!("No handler is implemented for '{method_name}'.",))),
             },
             // Handle custom requests
             RequestFromClient::CustomRequest(_) => Err(RpcError::method_not_found()

--- a/examples/hello-world-server-core-sse/src/handler.rs
+++ b/examples/hello-world-server-core-sse/src/handler.rs
@@ -77,7 +77,7 @@ impl ServerHandlerCore for MyServerHandler {
 
                 // Return Method not found for any other requests
                 _ => Err(RpcError::method_not_found()
-                    .with_message(format!("No handler is implemented for '{}'.", method_name,))),
+                    .with_message(format!("No handler is implemented for '{method_name}'.",))),
             },
             // Handle custom requests
             RequestFromClient::CustomRequest(_) => Err(RpcError::method_not_found()

--- a/examples/simple-mcp-client-core-sse/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-core-sse/src/inquiry_utils.rs
@@ -202,7 +202,7 @@ impl InquiryUtils {
         let max_pings = n;
         println!();
         for ping_index in 1..=max_pings {
-            print!("Ping the server ({} out of {})...", ping_index, max_pings);
+            print!("Ping the server ({ping_index} out of {max_pings})...");
             std::io::stdout().flush().unwrap();
             let ping_result = self.client.ping(None).await;
             print!(

--- a/examples/simple-mcp-client-core/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-core/src/inquiry_utils.rs
@@ -202,7 +202,7 @@ impl InquiryUtils {
         let max_pings = n;
         println!();
         for ping_index in 1..=max_pings {
-            print!("Ping the server ({} out of {})...", ping_index, max_pings);
+            print!("Ping the server ({ping_index} out of {max_pings})...");
             std::io::stdout().flush().unwrap();
             let ping_result = self.client.ping(None).await;
             print!(

--- a/examples/simple-mcp-client-sse/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client-sse/src/inquiry_utils.rs
@@ -202,7 +202,7 @@ impl InquiryUtils {
         let max_pings = n;
         println!();
         for ping_index in 1..=max_pings {
-            print!("Ping the server ({} out of {})...", ping_index, max_pings);
+            print!("Ping the server ({ping_index} out of {max_pings})...");
             std::io::stdout().flush().unwrap();
             let ping_result = self.client.ping(None).await;
             print!(

--- a/examples/simple-mcp-client/src/inquiry_utils.rs
+++ b/examples/simple-mcp-client/src/inquiry_utils.rs
@@ -202,7 +202,7 @@ impl InquiryUtils {
         let max_pings = n;
         println!();
         for ping_index in 1..=max_pings {
-            print!("Ping the server ({} out of {})...", ping_index, max_pings);
+            print!("Ping the server ({ping_index} out of {max_pings})...");
             std::io::stdout().flush().unwrap();
             let ping_result = self.client.ping(None).await;
             print!(


### PR DESCRIPTION
### 📌 Summary

This PR fixes new clippy warnings. I also had to enable at least one schema by default, but I think it's a good change, and makes it easier to use the crate.

Sorry for mixed PR, these other issues were causing troubles when I tried to fix clippy warnings.

### 🔍 Related Issues

In PR #63 , ci is failing because of these new errors

- Fixes #


### ✨ Changes Made

~~- added rust-mcp-sdk as dev-dependency to rust-mcp-macros~~
~~- strategically placed `#[cfg(any(feature = "2025_03_26", not(feature = "2024_11_05")))]` in a few places to fix compilation errors~~
~~- rust-mcp-transport is not optional anymore~~
- fixed clippy warnings

### 🛠️ Testing Steps
<!-- Explain how reviewers can test your changes, if applicable -->

### 💡 Additional Notes
<!-- Any other information or context about the PR -->
