### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-    "crates/rust-mcp-sdk": "0.4.6",
+    "crates/rust-mcp-sdk": "0.4.7",
     "crates/rust-mcp-macros": "0.4.2",
     "crates/rust-mcp-transport": "0.3.6",
-    "examples/hello-world-mcp-server": "0.1.22",
-    "examples/hello-world-mcp-server-core": "0.1.13",
-    "examples/simple-mcp-client": "0.1.22",
-    "examples/simple-mcp-client-core": "0.1.22",
-    "examples/hello-world-server-core-sse": "0.1.13",
-    "examples/hello-world-server-sse": "0.1.22",
-    "examples/simple-mcp-client-core-sse": "0.1.13",
-    "examples/simple-mcp-client-sse": "0.1.13"
+    "examples/hello-world-mcp-server": "0.1.23",
+    "examples/hello-world-mcp-server-core": "0.1.14",
+    "examples/simple-mcp-client": "0.1.23",
+    "examples/simple-mcp-client-core": "0.1.23",
+    "examples/hello-world-server-core-sse": "0.1.14",
+    "examples/hello-world-server-sse": "0.1.23",
+    "examples/simple-mcp-client-core-sse": "0.1.14",
+    "examples/simple-mcp-client-sse": "0.1.14"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-sse"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-sse"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "async-trait",
  "futures",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "async-trait",
  "colored",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "async-trait",
  "colored",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "colored",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.7](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.6...rust-mcp-sdk-v0.4.7) (2025-06-29)
+
+
+### 🚀 Features
+
+* Make hyper optional ([#63](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/63)) ([8dd95a2](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd95a2a112d6c661ddc3deede2dd606b4ff743b))
+
 ## [0.4.6](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.5...rust-mcp-sdk-v0.4.6) (2025-06-23)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-sse/Cargo.toml
+++ b/examples/hello-world-server-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-sse"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-sse/Cargo.toml
+++ b/examples/hello-world-server-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-sse"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.23</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.14</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-sse: 0.1.14</summary>

### Dependencies


</details>

<details><summary>hello-world-server-sse: 0.1.23</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.4.7</summary>

## [0.4.7](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.4.6...rust-mcp-sdk-v0.4.7) (2025-06-29)


### 🚀 Features

* Make hyper optional ([#63](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/63)) ([8dd95a2](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd95a2a112d6c661ddc3deede2dd606b4ff743b))
</details>

<details><summary>simple-mcp-client: 0.1.23</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.23</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.14</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.14</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).