### PR TITLE
fix: address issue with improper server start failure handling

### DIFF
--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -22,8 +22,18 @@ pub enum McpSdkError {
     #[cfg(feature = "hyper-server")]
     #[error("{0}")]
     TransportServerError(#[from] TransportServerError),
-    #[error("Incompatible mcp protocol version!\n client:{0}\nserver:{1}")]
+    #[error("Incompatible mcp protocol version: client:{0} server:{1}")]
     IncompatibleProtocolVersion(String, String),
+}
+
+impl McpSdkError {
+    /// Returns the RPC error message if the error is of type `McpSdkError::RpcError`.
+    pub fn rpc_error_message(&self) -> Option<&String> {
+        if let McpSdkError::RpcError(rpc_error) = self {
+            return Some(&rpc_error.message);
+        }
+        None
+    }
 }
 
 #[deprecated(since = "0.2.0", note = "Use `McpSdkError` instead.")]

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -106,7 +106,14 @@ impl McpServer for ServerRuntime {
                     // create a response to send back to the client
                     let response: MessageFromServer = match result {
                         Ok(success_value) => success_value.into(),
-                        Err(error_value) => MessageFromServer::Error(error_value),
+                        Err(error_value) => {
+                            // Error occurred during initialization.
+                            // A likely cause could be an unsupported protocol version.
+                            if !self.is_initialized() {
+                                return Err(error_value.into());
+                            }
+                            MessageFromServer::Error(error_value)
+                        }
                     };
 
                     // send the response back with corresponding request id

--- a/examples/hello-world-mcp-server-core/src/main.rs
+++ b/examples/hello-world-mcp-server-core/src/main.rs
@@ -40,5 +40,13 @@ async fn main() -> SdkResult<()> {
     let server = server_runtime_core::create_server(server_details, transport, handler);
 
     // STEP 5: Start the server
-    server.start().await
+    if let Err(start_error) = server.start().await {
+        eprintln!(
+            "{}",
+            start_error
+                .rpc_error_message()
+                .unwrap_or(&start_error.to_string())
+        );
+    };
+    Ok(())
 }

--- a/examples/hello-world-mcp-server/src/main.rs
+++ b/examples/hello-world-mcp-server/src/main.rs
@@ -42,5 +42,13 @@ async fn main() -> SdkResult<()> {
     let server: ServerRuntime = server_runtime::create_server(server_details, transport, handler);
 
     // STEP 5: Start the server
-    server.start().await
+    if let Err(start_error) = server.start().await {
+        eprintln!(
+            "{}",
+            start_error
+                .rpc_error_message()
+                .unwrap_or(&start_error.to_string())
+        );
+    };
+    Ok(())
 }

--- a/examples/hello-world-server-core-sse/src/handler.rs
+++ b/examples/hello-world-server-core-sse/src/handler.rs
@@ -36,9 +36,15 @@ impl ServerHandlerCore for MyServerHandler {
                         &initialize_request.params.protocol_version,
                         &server_info.protocol_version,
                     )
-                    .map_err(|err| RpcError::internal_error().with_message(err.to_string()))?
-                    {
-                        server_info.protocol_version = initialize_request.params.protocol_version;
+                    .map_err(|err| {
+                        tracing::error!(
+                            "Incompatible protocol version :\nclient: {}\nserver: {}",
+                            &initialize_request.params.protocol_version,
+                            &server_info.protocol_version
+                        );
+                        RpcError::internal_error().with_message(err.to_string())
+                    })? {
+                        server_info.protocol_version = updated_protocol_version;
                     }
 
                     return Ok(server_info.into());

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
### 📌 Summary
This PR address issue with improper server start failure handling, for instance when server does not support the mcp protocol version that client is requesting.


### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- Partially addresses #69 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Updated ServerHandler to call set_client_details only after ensuring protocol version compatibility, preventing incorrect initialization to true.
- Updated ServerRuntime to exit early upon detecting an incompatible version, enabling process termination and graceful shutdown.
- Implemented a rpc_error_message() method for McpSdkError, to help extracting the message from RpcError error types
- Updated mcp server examples to output proper message when server initialization fails :
<img width="711" alt="image" src="https://github.com/user-attachments/assets/31b4dbd2-46cc-4b78-8ae9-b3df894b594b" />