### PR TITLE
chore: refactor transport trait and runtime architecture

### DIFF
--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
@@ -19,6 +19,7 @@ use axum::{
     Extension, Router,
 };
 use futures::stream::{self};
+use rust_mcp_schema::schema_utils::ClientMessage;
 use rust_mcp_transport::{error::TransportError, SessionId, SseTransport};
 use std::{convert::Infallible, sync::Arc, time::Duration};
 use tokio::{
@@ -78,7 +79,7 @@ pub async fn handle_sse(
     State(state): State<Arc<AppState>>,
 ) -> TransportServerResult<impl IntoResponse> {
     let messages_endpoint =
-        SseTransport::message_endpoint(&state.sse_message_endpoint, &session_id);
+        SseTransport::<ClientMessage>::message_endpoint(&state.sse_message_endpoint, &session_id);
 
     // readable stream of string to be used in transport
     let (read_tx, read_rx) = duplex(DUPLEX_BUFFER_SIZE);

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -76,13 +76,13 @@ impl McpClient for ClientRuntime {
     where
         MessageDispatcher<ServerMessage>: McpDispatch<ServerMessage, MessageFromClient>,
     {
-        (self.transport.sender().await) as _
+        (self.transport.message_sender().await) as _
     }
 
     async fn start(self: Arc<Self>) -> SdkResult<()> {
         let mut stream = self.transport.start().await?;
 
-        let mut error_io_stream = self.transport.error_io().await.write().await;
+        let mut error_io_stream = self.transport.error_stream().await.write().await;
         let error_io_stream = error_io_stream.take();
 
         let self_clone = Arc::clone(&self);

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -28,16 +28,10 @@ pub struct ClientRuntime {
     client_details: InitializeRequestParams,
     // Details about the connected server
     server_details: Arc<RwLock<Option<InitializeResult>>>,
-    message_sender: tokio::sync::RwLock<Option<MessageDispatcher<ServerMessage>>>,
     handlers: Mutex<Vec<tokio::task::JoinHandle<Result<(), McpSdkError>>>>,
 }
 
 impl ClientRuntime {
-    pub(crate) async fn set_message_sender(&self, sender: MessageDispatcher<ServerMessage>) {
-        let mut lock = self.message_sender.write().await;
-        *lock = Some(sender);
-    }
-
     pub(crate) fn new(
         client_details: InitializeRequestParams,
         transport: impl Transport<ServerMessage, MessageFromClient>,
@@ -48,7 +42,6 @@ impl ClientRuntime {
             handler,
             client_details,
             server_details: Arc::new(RwLock::new(None)),
-            message_sender: tokio::sync::RwLock::new(None),
             handlers: Mutex::new(vec![]),
         }
     }
@@ -83,12 +76,14 @@ impl McpClient for ClientRuntime {
     where
         MessageDispatcher<ServerMessage>: McpDispatch<ServerMessage, MessageFromClient>,
     {
-        (&self.message_sender) as _
+        (self.transport.sender().await) as _
     }
 
     async fn start(self: Arc<Self>) -> SdkResult<()> {
-        let (mut stream, sender, error_io) = self.transport.start().await?;
-        self.set_message_sender(sender).await;
+        let mut stream = self.transport.start().await?;
+
+        let mut error_io_stream = self.transport.error_io().await.write().await;
+        let error_io_stream = error_io_stream.take();
 
         let self_clone = Arc::clone(&self);
         let self_clone_err = Arc::clone(&self);
@@ -96,30 +91,32 @@ impl McpClient for ClientRuntime {
         let err_task = tokio::spawn(async move {
             let self_ref = &*self_clone_err;
 
-            if let IoStream::Readable(error_input) = error_io {
-                let mut reader = BufReader::new(error_input).lines();
-                loop {
-                    tokio::select! {
-                        should_break = self_ref.transport.is_shut_down() =>{
-                            if should_break {
-                                break;
+            if let Some(error_io) = error_io_stream {
+                if let IoStream::Readable(error_input) = error_io {
+                    let mut reader = BufReader::new(error_input).lines();
+                    loop {
+                        tokio::select! {
+                            should_break = self_ref.transport.is_shut_down() =>{
+                                if should_break {
+                                    break;
+                                }
                             }
-                        }
-                        line = reader.next_line() =>{
-                            match line {
-                                Ok(Some(error_message)) => {
-                                    self_ref
-                                        .handler
-                                        .handle_process_error(error_message, self_ref)
-                                        .await?;
-                                }
-                                Ok(None) => {
-                                    // end of input
-                                    break;
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error reading from std_err: {e}");
-                                    break;
+                            line = reader.next_line() =>{
+                                match line {
+                                    Ok(Some(error_message)) => {
+                                        self_ref
+                                            .handler
+                                            .handle_process_error(error_message, self_ref)
+                                            .await?;
+                                    }
+                                    Ok(None) => {
+                                        // end of input
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("Error reading from std_err: {e}");
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -125,12 +125,10 @@ impl McpServer for ServerRuntime {
 
     async fn stderr_message(&self, message: String) -> SdkResult<()> {
         let mut lock = self.transport.error_io().await.write().await;
-        if let Some(io_stream) = lock.as_mut() {
-            if let IoStream::Writable(stderr) = io_stream {
-                stderr.write_all(message.as_bytes()).await?;
-                stderr.write_all(b"\n").await?;
-                stderr.flush().await?;
-            }
+        if let Some(IoStream::Writable(stderr)) = lock.as_mut() {
+            stderr.write_all(message.as_bytes()).await?;
+            stderr.write_all(b"\n").await?;
+            stderr.flush().await?;
         }
         Ok(())
     }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use rust_mcp_transport::{IoStream, McpDispatch, MessageDispatcher, Transport};
 use schema_utils::ClientMessage;
-use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 use tokio::io::AsyncWriteExt;
 
@@ -27,9 +26,6 @@ pub struct ServerRuntime {
     server_details: Arc<InitializeResult>,
     // Details about the connected client
     client_details: Arc<RwLock<Option<InitializeRequestParams>>>,
-
-    message_sender: tokio::sync::RwLock<Option<MessageDispatcher<ClientMessage>>>,
-    error_stream: tokio::sync::RwLock<Option<Pin<Box<dyn tokio::io::AsyncWrite + Send + Sync>>>>,
     #[cfg(feature = "hyper-server")]
     session_id: Option<SessionId>,
 }
@@ -70,24 +66,14 @@ impl McpServer for ServerRuntime {
     where
         MessageDispatcher<ClientMessage>: McpDispatch<ClientMessage, MessageFromServer>,
     {
-        (&self.message_sender) as _
+        (self.transport.sender().await) as _
     }
 
     /// Main runtime loop, processes incoming messages and handles requests
     async fn start(&self) -> SdkResult<()> {
-        // Start the transport layer to begin handling messages
-        // self.transport.start().await?;
-        // Open the transport stream
-        // let mut stream = self.transport.open();
-        let (mut stream, sender, error_io) = self.transport.start().await?;
+        let mut stream = self.transport.start().await?;
 
-        self.set_message_sender(sender).await;
-
-        if let IoStream::Writable(error_stream) = error_io {
-            self.set_error_stream(error_stream).await;
-        }
-
-        let sender = self.sender().await.read().await;
+        let sender = self.transport.sender().await.read().await;
         let sender = sender
             .as_ref()
             .ok_or(schema_utils::SdkError::connection_closed())?;
@@ -138,33 +124,22 @@ impl McpServer for ServerRuntime {
     }
 
     async fn stderr_message(&self, message: String) -> SdkResult<()> {
-        let mut lock = self.error_stream.write().await;
-        if let Some(stderr) = lock.as_mut() {
-            stderr.write_all(message.as_bytes()).await?;
-            stderr.write_all(b"\n").await?;
-            stderr.flush().await?;
+        let mut lock = self.transport.error_io().await.write().await;
+        if let Some(io_stream) = lock.as_mut() {
+            if let IoStream::Writable(stderr) = io_stream {
+                stderr.write_all(message.as_bytes()).await?;
+                stderr.write_all(b"\n").await?;
+                stderr.flush().await?;
+            }
         }
         Ok(())
     }
 }
 
 impl ServerRuntime {
-    pub(crate) async fn set_message_sender(&self, sender: MessageDispatcher<ClientMessage>) {
-        let mut lock = self.message_sender.write().await;
-        *lock = Some(sender);
-    }
-
     #[cfg(feature = "hyper-server")]
     pub(crate) async fn session_id(&self) -> Option<SessionId> {
         self.session_id.to_owned()
-    }
-
-    pub(crate) async fn set_error_stream(
-        &self,
-        error_stream: Pin<Box<dyn tokio::io::AsyncWrite + Send + Sync>>,
-    ) {
-        let mut lock = self.error_stream.write().await;
-        *lock = Some(error_stream);
     }
 
     #[cfg(feature = "hyper-server")]
@@ -179,8 +154,6 @@ impl ServerRuntime {
             client_details: Arc::new(RwLock::new(None)),
             transport: Box::new(transport),
             handler,
-            message_sender: tokio::sync::RwLock::new(None),
-            error_stream: tokio::sync::RwLock::new(None),
             session_id: Some(session_id),
         }
     }
@@ -195,8 +168,6 @@ impl ServerRuntime {
             client_details: Arc::new(RwLock::new(None)),
             transport: Box::new(transport),
             handler,
-            message_sender: tokio::sync::RwLock::new(None),
-            error_stream: tokio::sync::RwLock::new(None),
             #[cfg(feature = "hyper-server")]
             session_id: None,
         }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -66,14 +66,14 @@ impl McpServer for ServerRuntime {
     where
         MessageDispatcher<ClientMessage>: McpDispatch<ClientMessage, MessageFromServer>,
     {
-        (self.transport.sender().await) as _
+        (self.transport.message_sender().await) as _
     }
 
     /// Main runtime loop, processes incoming messages and handles requests
     async fn start(&self) -> SdkResult<()> {
         let mut stream = self.transport.start().await?;
 
-        let sender = self.transport.sender().await.read().await;
+        let sender = self.transport.message_sender().await.read().await;
         let sender = sender
             .as_ref()
             .ok_or(schema_utils::SdkError::connection_closed())?;
@@ -124,7 +124,7 @@ impl McpServer for ServerRuntime {
     }
 
     async fn stderr_message(&self, message: String) -> SdkResult<()> {
-        let mut lock = self.transport.error_io().await.write().await;
+        let mut lock = self.transport.error_stream().await.write().await;
         if let Some(IoStream::Writable(stderr)) = lock.as_mut() {
             stderr.write_all(message.as_bytes()).await?;
             stderr.write_all(b"\n").await?;

--- a/crates/rust-mcp-transport/src/client_sse.rs
+++ b/crates/rust-mcp-transport/src/client_sse.rs
@@ -316,11 +316,11 @@ where
         Ok(stream)
     }
 
-    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
+    async fn message_sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
         &self.message_sender as _
     }
 
-    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+    async fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
         &self.error_stream as _
     }
 

--- a/crates/rust-mcp-transport/src/sse.rs
+++ b/crates/rust-mcp-transport/src/sse.rs
@@ -2,6 +2,7 @@ use crate::schema::schema_utils::{McpMessage, RpcMessage};
 use crate::schema::RequestId;
 use async_trait::async_trait;
 use futures::Stream;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -15,15 +16,23 @@ use crate::transport::Transport;
 use crate::utils::{endpoint_with_session_id, CancellationTokenSource};
 use crate::{IoStream, McpDispatch, SessionId, TransportOptions};
 
-pub struct SseTransport {
+pub struct SseTransport<R>
+where
+    R: RpcMessage + Clone + Send + Sync + DeserializeOwned + 'static,
+{
     shutdown_source: tokio::sync::RwLock<Option<CancellationTokenSource>>,
     is_shut_down: Mutex<bool>,
     read_write_streams: Mutex<Option<(DuplexStream, DuplexStream)>>,
     options: Arc<TransportOptions>,
+    message_sender: tokio::sync::RwLock<Option<MessageDispatcher<R>>>,
+    error_stream: tokio::sync::RwLock<Option<IoStream>>,
 }
 
 /// Server-Sent Events (SSE) transport implementation
-impl SseTransport {
+impl<R> SseTransport<R>
+where
+    R: RpcMessage + Clone + Send + Sync + DeserializeOwned + 'static,
+{
     /// Creates a new SseTransport instance
     ///
     /// Initializes the transport with provided read and write duplex streams and options.
@@ -45,16 +54,31 @@ impl SseTransport {
             options,
             shutdown_source: tokio::sync::RwLock::new(None),
             is_shut_down: Mutex::new(false),
+            message_sender: tokio::sync::RwLock::new(None),
+            error_stream: tokio::sync::RwLock::new(None),
         })
     }
 
     pub fn message_endpoint(endpoint: &str, session_id: &SessionId) -> String {
         endpoint_with_session_id(endpoint, session_id)
     }
+
+    pub(crate) async fn set_message_sender(&self, sender: MessageDispatcher<R>) {
+        let mut lock = self.message_sender.write().await;
+        *lock = Some(sender);
+    }
+
+    pub(crate) async fn set_error_stream(
+        &self,
+        error_stream: Pin<Box<dyn tokio::io::AsyncWrite + Send + Sync>>,
+    ) {
+        let mut lock = self.error_stream.write().await;
+        *lock = Some(IoStream::Writable(error_stream));
+    }
 }
 
 #[async_trait]
-impl<R, S> Transport<R, S> for SseTransport
+impl<R, S> Transport<R, S> for SseTransport<R>
 where
     R: RpcMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
     S: McpMessage + Clone + Send + Sync + serde::Serialize + 'static,
@@ -69,13 +93,7 @@ where
     ///
     /// # Errors
     /// * Returns `TransportError` if streams are already taken or not initialized
-    async fn start(
-        &self,
-    ) -> TransportResult<(
-        Pin<Box<dyn Stream<Item = R> + Send>>,
-        MessageDispatcher<R>,
-        IoStream,
-    )>
+    async fn start(&self) -> TransportResult<Pin<Box<dyn Stream<Item = R> + Send>>>
     where
         MessageDispatcher<R>: McpDispatch<R, S>,
     {
@@ -103,7 +121,13 @@ where
             cancellation_token,
         );
 
-        Ok((stream, sender, error_stream))
+        self.set_message_sender(sender).await;
+
+        if let IoStream::Writable(error_stream) = error_stream {
+            self.set_error_stream(error_stream).await;
+        }
+
+        Ok(stream)
     }
 
     /// Checks if the transport has been shut down
@@ -113,6 +137,14 @@ where
     async fn is_shut_down(&self) -> bool {
         let result = self.is_shut_down.lock().await;
         *result
+    }
+
+    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
+        &self.message_sender as _
+    }
+
+    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+        &self.error_stream as _
     }
 
     /// Shuts down the transport, terminating tasks and signaling closure

--- a/crates/rust-mcp-transport/src/sse.rs
+++ b/crates/rust-mcp-transport/src/sse.rs
@@ -139,11 +139,11 @@ where
         *result
     }
 
-    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
+    async fn message_sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
         &self.message_sender as _
     }
 
-    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+    async fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
         &self.error_stream as _
     }
 

--- a/crates/rust-mcp-transport/src/stdio.rs
+++ b/crates/rust-mcp-transport/src/stdio.rs
@@ -2,6 +2,7 @@ use crate::schema::schema_utils::{McpMessage, RpcMessage};
 use crate::schema::RequestId;
 use async_trait::async_trait;
 use futures::Stream;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -22,16 +23,24 @@ use crate::{IoStream, McpDispatch, TransportOptions};
 /// and server-side communication by optionally launching a subprocess or using the current
 /// process's stdio streams. The transport handles message streaming, dispatching, and shutdown
 /// operations, integrating with the MCP runtime ecosystem.
-pub struct StdioTransport {
+pub struct StdioTransport<R>
+where
+    R: RpcMessage + Clone + Send + Sync + DeserializeOwned + 'static,
+{
     command: Option<String>,
     args: Option<Vec<String>>,
     env: Option<HashMap<String, String>>,
     options: TransportOptions,
     shutdown_source: tokio::sync::RwLock<Option<CancellationTokenSource>>,
     is_shut_down: Mutex<bool>,
+    message_sender: tokio::sync::RwLock<Option<MessageDispatcher<R>>>,
+    error_stream: tokio::sync::RwLock<Option<IoStream>>,
 }
 
-impl StdioTransport {
+impl<R> StdioTransport<R>
+where
+    R: RpcMessage + Clone + Send + Sync + DeserializeOwned + 'static,
+{
     /// Creates a new `StdioTransport` instance for MCP Server.
     ///
     /// This constructor configures the transport to use the current process's stdio streams,
@@ -53,6 +62,8 @@ impl StdioTransport {
             options,
             shutdown_source: tokio::sync::RwLock::new(None),
             is_shut_down: Mutex::new(false),
+            message_sender: tokio::sync::RwLock::new(None),
+            error_stream: tokio::sync::RwLock::new(None),
         })
     }
 
@@ -84,6 +95,8 @@ impl StdioTransport {
             options,
             shutdown_source: tokio::sync::RwLock::new(None),
             is_shut_down: Mutex::new(false),
+            message_sender: tokio::sync::RwLock::new(None),
+            error_stream: tokio::sync::RwLock::new(None),
         })
     }
 
@@ -109,10 +122,23 @@ impl StdioTransport {
             (command, command_args)
         }
     }
+
+    pub(crate) async fn set_message_sender(&self, sender: MessageDispatcher<R>) {
+        let mut lock = self.message_sender.write().await;
+        *lock = Some(sender);
+    }
+
+    pub(crate) async fn set_error_stream(
+        &self,
+        error_stream: Pin<Box<dyn tokio::io::AsyncWrite + Send + Sync>>,
+    ) {
+        let mut lock = self.error_stream.write().await;
+        *lock = Some(IoStream::Writable(error_stream));
+    }
 }
 
 #[async_trait]
-impl<R, S> Transport<R, S> for StdioTransport
+impl<R, S> Transport<R, S> for StdioTransport<R>
 where
     R: RpcMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
     S: McpMessage + Clone + Send + Sync + serde::Serialize + 'static,
@@ -130,13 +156,7 @@ where
     ///
     /// # Errors
     /// Returns a `TransportError` if the subprocess fails to spawn or stdio streams cannot be accessed.
-    async fn start(
-        &self,
-    ) -> TransportResult<(
-        Pin<Box<dyn Stream<Item = R> + Send>>,
-        MessageDispatcher<R>,
-        IoStream,
-    )>
+    async fn start(&self) -> TransportResult<Pin<Box<dyn Stream<Item = R> + Send>>>
     where
         MessageDispatcher<R>: McpDispatch<R, S>,
     {
@@ -200,7 +220,13 @@ where
                 cancellation_token,
             );
 
-            Ok((stream, sender, error_stream))
+            self.set_message_sender(sender).await;
+
+            if let IoStream::Writable(error_stream) = error_stream {
+                self.set_error_stream(error_stream).await;
+            }
+
+            Ok(stream)
         } else {
             let pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<R>>>> =
                 Arc::new(Mutex::new(HashMap::new()));
@@ -213,7 +239,12 @@ where
                 cancellation_token,
             );
 
-            Ok((stream, sender, error_stream))
+            self.set_message_sender(sender).await;
+
+            if let IoStream::Writable(error_stream) = error_stream {
+                self.set_error_stream(error_stream).await;
+            }
+            Ok(stream)
         }
     }
 
@@ -221,6 +252,14 @@ where
     async fn is_shut_down(&self) -> bool {
         let result = self.is_shut_down.lock().await;
         *result
+    }
+
+    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
+        &self.message_sender as _
+    }
+
+    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+        &self.error_stream as _
     }
 
     // Shuts down the transport, terminating any subprocess and signaling closure.

--- a/crates/rust-mcp-transport/src/stdio.rs
+++ b/crates/rust-mcp-transport/src/stdio.rs
@@ -254,11 +254,11 @@ where
         *result
     }
 
-    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
+    async fn message_sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
         &self.message_sender as _
     }
 
-    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+    async fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
         &self.error_stream as _
     }
 

--- a/crates/rust-mcp-transport/src/transport.rs
+++ b/crates/rust-mcp-transport/src/transport.rs
@@ -113,8 +113,8 @@ where
     async fn start(&self) -> TransportResult<Pin<Box<dyn Stream<Item = R> + Send>>>
     where
         MessageDispatcher<R>: McpDispatch<R, S>;
-    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>>;
-    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>>;
+    async fn message_sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>>;
+    async fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>>;
     async fn shut_down(&self) -> TransportResult<()>;
     async fn is_shut_down(&self) -> bool;
 }

--- a/crates/rust-mcp-transport/src/transport.rs
+++ b/crates/rust-mcp-transport/src/transport.rs
@@ -110,15 +110,11 @@ where
     R: McpMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
     S: Clone + Send + Sync + serde::Serialize + 'static,
 {
-    async fn start(
-        &self,
-    ) -> TransportResult<(
-        Pin<Box<dyn Stream<Item = R> + Send>>,
-        MessageDispatcher<R>,
-        IoStream,
-    )>
+    async fn start(&self) -> TransportResult<Pin<Box<dyn Stream<Item = R> + Send>>>
     where
         MessageDispatcher<R>: McpDispatch<R, S>;
+    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>>;
+    async fn error_io(&self) -> &tokio::sync::RwLock<Option<IoStream>>;
     async fn shut_down(&self) -> TransportResult<()>;
     async fn is_shut_down(&self) -> bool;
 }


### PR DESCRIPTION
### 📌 Summary
Refactored the transport trait and runtime architecture by encapsulating message_sender and the error stream within the transport itself. This improves architectural clarity and separation of concerns, paving the way for upcoming features such as multi-transport support and streamable http