### PR TITLE
feat: add Streamable HTTP Support to MCP Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arc-swap"
@@ -257,9 +257,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -638,9 +638,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hello-world-mcp-server"
@@ -877,7 +877,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1138,9 +1138,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1149,7 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -1432,7 +1432,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "web-time",
@@ -1453,7 +1453,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -1613,9 +1613,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1712,7 +1712,7 @@ dependencies = [
  "rust-mcp-transport",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1731,7 +1731,7 @@ dependencies = [
  "rust-mcp-schema",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1771,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1915,9 +1915,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -1932,7 +1932,7 @@ dependencies = [
  "rust-mcp-sdk",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
@@ -1946,7 +1946,7 @@ dependencies = [
  "rust-mcp-sdk",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
 ]
 
@@ -1960,7 +1960,7 @@ dependencies = [
  "rust-mcp-sdk",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1976,7 +1976,7 @@ dependencies = [
  "rust-mcp-sdk",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1984,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2068,11 +2068,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -2088,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2164,9 +2164,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2216,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2379,9 +2379,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -2584,6 +2584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,7 +2613,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2628,10 +2634,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2859,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -257,9 +257,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -644,9 +644,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -854,14 +854,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -924,7 +924,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1063,6 +1063,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,9 +1166,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -1374,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1420,7 +1431,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1436,7 +1447,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -1457,7 +1468,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1492,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -1549,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
 dependencies = [
  "bitflags",
 ]
@@ -1678,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec1ff3507a619b9945f60a94dac448541aef8c9803aa6192c30f4a932cb1499"
+checksum = "a0e71aee61257cd3d4a78fdc10c92c29e7a55c4f767119ffdafd837bb5e5cb9a"
 dependencies = [
  "serde",
  "serde_json",
@@ -1729,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1760,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1794,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1844,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1991,6 +2002,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2143,20 +2164,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2519,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ This project supports following transports:
 - [x] Streamable HTTP Support for MCP Servers
 - [x] DNS Rebinding Protection
 - [x] Batch Messages
-- [x] Streaming & non-streaming JSON response
+- [x] Streaming & non-streaming JSON responses
 - [ ] Streamable HTTP Support for MCP Clients
 - [ ] Resumability
-- [ ] Authentication / Oauth
+- [ ] Authentication / OAuth
 
 **⚠️** Project is currently under development and should be used at your own risk.
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,26 @@ By default, it uses the **2025-06-18** version, but earlier versions can be enab
 
 
 
-This project currently supports following transports:
-- **stdio** (Standard Input/Output)
-- **sse** (Server-Sent Events).
-
+This project supports following transports:
+- **Stdio** (Standard Input/Output)
+- **SSE** (Server-Sent Events).
+- **Streamable HTTP**.
 
 
 🚀 The **rust-mcp-sdk** includes a lightweight [Axum](https://github.com/tokio-rs/axum) based server that handles all core functionality seamlessly. Switching between `stdio` and `sse` is straightforward, requiring minimal code changes. The server is designed to efficiently handle multiple concurrent client connections and offers built-in support for SSL.
 
-**⚠️** **Streamable HTTP** transport and authentication still in progress and not yet available. Project is currently under development and should be used at your own risk.
+
+**Streamable HTTP support checklist**
+
+- [x] Streamable HTTP Support for MCP Servers
+- [x] DNS Rebinding Protection
+- [x] Batch Messages
+- [x] Streaming & non-streaming JSON response
+- [ ] Streamable HTTP Support for MCP Clients
+- [ ] Resumability
+- [ ] Authentication / Oauth
+
+**⚠️** Project is currently under development and should be used at your own risk.
 
 ## Table of Contents
 - [Usage Examples](#usage-examples)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This project supports following transports:
 🚀 The **rust-mcp-sdk** includes a lightweight [Axum](https://github.com/tokio-rs/axum) based server that handles all core functionality seamlessly. Switching between `stdio` and `sse` is straightforward, requiring minimal code changes. The server is designed to efficiently handle multiple concurrent client connections and offers built-in support for SSL.
 
 
-**Streamable HTTP support checklist**
 
+**MCP Streamable HTTP Support**
 - [x] Streamable HTTP Support for MCP Servers
 - [x] DNS Rebinding Protection
 - [x] Batch Messages

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -21,6 +21,7 @@ syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 
+
 [dev-dependencies]
 rust-mcp-schema = { workspace = true, default-features = false }
 

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -37,10 +37,10 @@ This project supports following transports:
 - [x] Streamable HTTP Support for MCP Servers
 - [x] DNS Rebinding Protection
 - [x] Batch Messages
-- [x] Streaming & non-streaming JSON response
+- [x] Streaming & non-streaming JSON responses
 - [ ] Streamable HTTP Support for MCP Clients
 - [ ] Resumability
-- [ ] Authentication / Oauth
+- [ ] Authentication / OAuth
 
 **⚠️** Project is currently under development and should be used at your own risk.
 

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -23,15 +23,26 @@ By default, it uses the **2025-06-18** version, but earlier versions can be enab
 
 
 
-This project currently supports following transports:
-- **stdio** (Standard Input/Output)
-- **sse** (Server-Sent Events).
-
+This project supports following transports:
+- **Stdio** (Standard Input/Output)
+- **SSE** (Server-Sent Events).
+- **Streamable HTTP**.
 
 
 🚀 The **rust-mcp-sdk** includes a lightweight [Axum](https://github.com/tokio-rs/axum) based server that handles all core functionality seamlessly. Switching between `stdio` and `sse` is straightforward, requiring minimal code changes. The server is designed to efficiently handle multiple concurrent client connections and offers built-in support for SSL.
 
-**⚠️** **Streamable HTTP** transport and authentication still in progress and not yet available. Project is currently under development and should be used at your own risk.
+
+**Streamable HTTP support checklist**
+
+- [x] Streamable HTTP Support for MCP Servers
+- [x] DNS Rebinding Protection
+- [x] Batch Messages
+- [x] Streaming & non-streaming JSON response
+- [ ] Streamable HTTP Support for MCP Clients
+- [ ] Resumability
+- [ ] Authentication / Oauth
+
+**⚠️** Project is currently under development and should be used at your own risk.
 
 ## Table of Contents
 - [Usage Examples](#usage-examples)

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -32,8 +32,8 @@ This project supports following transports:
 🚀 The **rust-mcp-sdk** includes a lightweight [Axum](https://github.com/tokio-rs/axum) based server that handles all core functionality seamlessly. Switching between `stdio` and `sse` is straightforward, requiring minimal code changes. The server is designed to efficiently handle multiple concurrent client connections and offers built-in support for SSL.
 
 
-**Streamable HTTP support checklist**
 
+**MCP Streamable HTTP Support**
 - [x] Streamable HTTP Support for MCP Servers
 - [x] DNS Rebinding Protection
 - [x] Batch Messages

--- a/crates/rust-mcp-sdk/src/error.rs
+++ b/crates/rust-mcp-sdk/src/error.rs
@@ -1,6 +1,8 @@
-use crate::schema::RpcError;
+use crate::schema::{ParseProtocolVersionError, RpcError};
+
 use rust_mcp_transport::error::TransportError;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 #[cfg(feature = "hyper-server")]
 use crate::hyper_servers::error::TransportServerError;
@@ -16,14 +18,18 @@ pub enum McpSdkError {
     #[error("{0}")]
     TransportError(#[from] TransportError),
     #[error("{0}")]
+    JoinError(#[from] JoinError),
+    #[error("{0}")]
     AnyError(Box<(dyn std::error::Error + Send + Sync)>),
     #[error("{0}")]
     SdkError(#[from] crate::schema::schema_utils::SdkError),
     #[cfg(feature = "hyper-server")]
     #[error("{0}")]
     TransportServerError(#[from] TransportServerError),
-    #[error("Incompatible mcp protocol version: client:{0} server:{1}")]
+    #[error("Incompatible mcp protocol version: requested:{0} current:{1}")]
     IncompatibleProtocolVersion(String, String),
+    #[error("{0}")]
+    ParseProtocolVersionError(#[from] ParseProtocolVersionError),
 }
 
 impl McpSdkError {

--- a/crates/rust-mcp-sdk/src/hyper_servers.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers.rs
@@ -1,5 +1,6 @@
 mod app_state;
 pub mod error;
+pub mod hyper_runtime;
 pub mod hyper_server;
 pub mod hyper_server_core;
 mod middlewares;

--- a/crates/rust-mcp-sdk/src/hyper_servers/app_state.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/app_state.rs
@@ -19,5 +19,23 @@ pub struct AppState {
     pub handler: Arc<dyn McpServerHandler>,
     pub ping_interval: Duration,
     pub sse_message_endpoint: String,
+    pub http_streamable_endpoint: String,
     pub transport_options: Arc<TransportOptions>,
+    pub enable_json_response: bool,
+    /// List of allowed host header values for DNS rebinding protection.
+    /// If not specified, host validation is disabled.
+    pub allowed_hosts: Option<Vec<String>>,
+    /// List of allowed origin header values for DNS rebinding protection.
+    /// If not specified, origin validation is disabled.
+    pub allowed_origins: Option<Vec<String>>,
+    /// Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
+    /// Default is false for backwards compatibility.
+    pub dns_rebinding_protection: bool,
+}
+
+impl AppState {
+    pub fn needs_dns_protection(&self) -> bool {
+        self.dns_rebinding_protection
+            && (self.allowed_hosts.is_some() || self.allowed_origins.is_some())
+    }
 }

--- a/crates/rust-mcp-sdk/src/hyper_servers/error.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/error.rs
@@ -21,6 +21,8 @@ pub enum TransportServerError {
     InvalidServerOptions(String),
     #[error("{0}")]
     SslCertError(String),
+    #[error("{0}")]
+    TransportError(String),
 }
 
 impl IntoResponse for TransportServerError {

--- a/crates/rust-mcp-sdk/src/hyper_servers/hyper_runtime.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/hyper_runtime.rs
@@ -1,0 +1,198 @@
+use std::{sync::Arc, time::Duration};
+
+use crate::{
+    mcp_server::HyperServer,
+    schema::{
+        schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient},
+        CreateMessageRequestParams, CreateMessageResult, LoggingMessageNotificationParams,
+        PromptListChangedNotificationParams, ResourceListChangedNotificationParams,
+        ResourceUpdatedNotificationParams, ToolListChangedNotificationParams,
+    },
+    McpServer,
+};
+
+use axum_server::Handle;
+use rust_mcp_transport::SessionId;
+use tokio::{sync::Mutex, task::JoinHandle};
+
+use crate::{
+    error::SdkResult,
+    hyper_servers::app_state::AppState,
+    mcp_server::{
+        error::{TransportServerError, TransportServerResult},
+        ServerRuntime,
+    },
+};
+
+pub struct HyperRuntime {
+    pub(crate) state: Arc<AppState>,
+    pub(crate) server_task: JoinHandle<Result<(), TransportServerError>>,
+    pub(crate) server_handle: Handle,
+}
+
+impl HyperRuntime {
+    pub async fn create(server: HyperServer) -> SdkResult<Self> {
+        let addr = server.options.resolve_server_address().await?;
+        let state = server.state();
+
+        let server_handle = server.server_handle();
+
+        let server_task = tokio::spawn(async move {
+            #[cfg(feature = "ssl")]
+            if server.options.enable_ssl {
+                server.start_ssl(addr).await
+            } else {
+                server.start_http(addr).await
+            }
+
+            #[cfg(not(feature = "ssl"))]
+            if server.options.enable_ssl {
+                panic!("SSL requested but the 'ssl' feature is not enabled");
+            } else {
+                server.start_http(addr).await
+            }
+        });
+
+        Ok(Self {
+            state,
+            server_task,
+            server_handle,
+        })
+    }
+
+    pub fn graceful_shutdown(&self, timeout: Option<Duration>) {
+        self.server_handle.graceful_shutdown(timeout);
+    }
+
+    pub async fn await_server(self) -> SdkResult<()> {
+        let result = self.server_task.await?;
+        result.map_err(|err| err.into())
+    }
+
+    pub async fn runtime_by_session(
+        &self,
+        session_id: &SessionId,
+    ) -> TransportServerResult<Arc<Mutex<Arc<ServerRuntime>>>> {
+        self.state.session_store.get(session_id).await.ok_or(
+            TransportServerError::SessionIdInvalid(session_id.to_string()),
+        )
+    }
+
+    pub async fn send_request(
+        &self,
+        session_id: &SessionId,
+        request: RequestFromServer,
+        timeout: Option<Duration>,
+    ) -> SdkResult<ResultFromClient> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.request(request, timeout).await
+    }
+
+    pub async fn send_notification(
+        &self,
+        session_id: &SessionId,
+        notification: NotificationFromServer,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.send_notification(notification).await
+    }
+
+    pub async fn send_logging_message(
+        &self,
+        session_id: &SessionId,
+        params: LoggingMessageNotificationParams,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.send_logging_message(params).await
+    }
+
+    /// An optional notification from the server to the client, informing it that
+    /// the list of prompts it offers has changed.
+    /// This may be issued by servers without any previous subscription from the client.
+    pub async fn send_prompt_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<PromptListChangedNotificationParams>,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.send_prompt_list_changed(params).await
+    }
+
+    /// An optional notification from the server to the client,
+    /// informing it that the list of resources it can read from has changed.
+    /// This may be issued by servers without any previous subscription from the client.
+    pub async fn send_resource_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<ResourceListChangedNotificationParams>,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.send_resource_list_changed(params).await
+    }
+
+    /// A notification from the server to the client, informing it that
+    /// a resource has changed and may need to be read again.
+    ///  This should only be sent if the client previously sent a resources/subscribe request.
+    pub async fn send_resource_updated(
+        &self,
+        session_id: &SessionId,
+        params: ResourceUpdatedNotificationParams,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.send_resource_updated(params).await
+    }
+
+    /// An optional notification from the server to the client, informing it that
+    /// the list of tools it offers has changed.
+    /// This may be issued by servers without any previous subscription from the client.
+    pub async fn send_tool_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<ToolListChangedNotificationParams>,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.send_tool_list_changed(params).await
+    }
+
+    /// A ping request to check that the other party is still alive.
+    /// The receiver must promptly respond, or else may be disconnected.
+    ///
+    /// This function creates a `PingRequest` with no specific parameters, sends the request and awaits the response
+    /// Once the response is received, it attempts to convert it into the expected
+    /// result type.
+    ///
+    /// # Returns
+    /// A `SdkResult` containing the `rust_mcp_schema::Result` if the request is successful.
+    /// If the request or conversion fails, an error is returned.
+    pub async fn ping(
+        &self,
+        session_id: &SessionId,
+        timeout: Option<Duration>,
+    ) -> SdkResult<crate::schema::Result> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.ping(timeout).await
+    }
+
+    /// A request from the server to sample an LLM via the client.
+    /// The client has full discretion over which model to select.
+    /// The client should also inform the user before beginning sampling,
+    /// to allow them to inspect the request (human in the loop)
+    /// and decide whether to approve it.
+    pub async fn create_message(
+        &self,
+        session_id: &SessionId,
+        params: CreateMessageRequestParams,
+    ) -> SdkResult<CreateMessageResult> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        let runtime = runtime.lock().await.to_owned();
+        runtime.create_message(params).await
+    }
+}

--- a/crates/rust-mcp-sdk/src/hyper_servers/middlewares.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/middlewares.rs
@@ -1,1 +1,2 @@
+pub(crate) mod protect_dns_rebinding;
 pub(crate) mod session_id_gen;

--- a/crates/rust-mcp-sdk/src/hyper_servers/middlewares/protect_dns_rebinding.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/middlewares/protect_dns_rebinding.rs
@@ -1,0 +1,66 @@
+use crate::hyper_servers::app_state::AppState;
+use crate::schema::schema_utils::SdkError;
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::IntoResponse,
+    Json,
+};
+use hyper::{
+    header::{HOST, ORIGIN},
+    HeaderMap, StatusCode,
+};
+use std::sync::Arc;
+
+// Middleware to protect against DNS rebinding attacks by validating Host and Origin headers.
+pub async fn protect_dns_rebinding(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    if !state.needs_dns_protection() {
+        // If protection is not needed, pass the request to the next handler
+        return next.run(request).await.into_response();
+    }
+
+    if let Some(allowed_hosts) = state.allowed_hosts.as_ref() {
+        if !allowed_hosts.is_empty() {
+            let Some(host) = headers.get(HOST).and_then(|h| h.to_str().ok()) else {
+                let error = SdkError::bad_request().with_message("Invalid Host header: [unknown] ");
+                return (StatusCode::FORBIDDEN, Json(error)).into_response();
+            };
+
+            if !allowed_hosts
+                .iter()
+                .any(|allowed| allowed.eq_ignore_ascii_case(host))
+            {
+                let error = SdkError::bad_request()
+                    .with_message(format!("Invalid Host header: \"{host}\" ").as_str());
+                return (StatusCode::FORBIDDEN, Json(error)).into_response();
+            }
+        }
+    }
+
+    if let Some(allowed_origins) = state.allowed_origins.as_ref() {
+        if !allowed_origins.is_empty() {
+            let Some(origin) = headers.get(ORIGIN).and_then(|h| h.to_str().ok()) else {
+                let error =
+                    SdkError::bad_request().with_message("Invalid Origin header: [unknown] ");
+                return (StatusCode::FORBIDDEN, Json(error)).into_response();
+            };
+
+            if !allowed_origins
+                .iter()
+                .any(|allowed| allowed.eq_ignore_ascii_case(origin))
+            {
+                let error = SdkError::bad_request()
+                    .with_message(format!("Invalid Origin header: \"{origin}\" ").as_str());
+                return (StatusCode::FORBIDDEN, Json(error)).into_response();
+            }
+        }
+    }
+
+    // If all checks pass, proceed to the next handler in the chain
+    next.run(request).await
+}

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes.rs
@@ -27,7 +27,7 @@ pub fn app_routes(state: Arc<AppState>, server_options: &HyperServerOptions) -> 
         ))
         .merge({
             let mut r = Router::new();
-            if matches!(server_options.supprt_sse, Some(supprt_sse) if supprt_sse) {
+            if matches!(server_options.support_sse, Some(support_sse) if support_sse) {
                 r = r
                     .merge(sse_routes::routes(
                         state.clone(),

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes.rs
@@ -27,7 +27,7 @@ pub fn app_routes(state: Arc<AppState>, server_options: &HyperServerOptions) -> 
         ))
         .merge({
             let mut r = Router::new();
-            if matches!(server_options.support_sse, Some(support_sse) if support_sse) {
+            if server_options.sse_support {
                 r = r
                     .merge(sse_routes::routes(
                         state.clone(),

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/fallback_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/fallback_routes.rs
@@ -9,7 +9,7 @@ pub fn routes() -> Router {
 
 pub async fn not_found(uri: Uri) -> (StatusCode, String) {
     (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        format!("Server Error!\r\n uri: {uri}"),
+        StatusCode::NOT_FOUND,
+        format!("The requested uri does not exist:\r\nuri: {uri}"),
     )
 }

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
@@ -339,6 +339,7 @@ pub async fn delete_session(
             let runtime = runtime.lock().await.to_owned();
             runtime.shutdown().await;
             state.session_store.delete(&session_id).await;
+            tracing::info!("client disconnected : {}", &session_id);
             Ok((StatusCode::OK, Json("ok")).into_response())
         }
         None => {

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
@@ -1,0 +1,368 @@
+use crate::{
+    error::SdkResult,
+    hyper_servers::{
+        app_state::AppState,
+        error::{TransportServerError, TransportServerResult},
+    },
+    mcp_runtimes::server_runtime::DEFAULT_STREAM_ID,
+    mcp_server::{server_runtime, ServerRuntime},
+    mcp_traits::mcp_handler::McpServerHandler,
+    utils::validate_mcp_protocol_version,
+};
+
+use crate::schema::schema_utils::{ClientMessage, SdkError};
+
+use axum::{http::HeaderValue, response::IntoResponse};
+use axum::{
+    response::{
+        sse::{Event, KeepAlive},
+        Sse,
+    },
+    Json,
+};
+use futures::stream;
+use hyper::{header, HeaderMap, StatusCode};
+use rust_mcp_transport::{SessionId, SseTransport};
+use std::{sync::Arc, time::Duration};
+use tokio::io::{duplex, AsyncBufReadExt, BufReader};
+
+pub const MCP_SESSION_ID_HEADER: &str = "Mcp-Session-Id";
+pub const MCP_PROTOCOL_VERSION_HEADER: &str = "Mcp-Protocol-Version";
+
+const DUPLEX_BUFFER_SIZE: usize = 8192;
+
+async fn create_sse_stream(
+    runtime: Arc<ServerRuntime>,
+    session_id: SessionId,
+    state: Arc<AppState>,
+    payload: Option<&str>,
+    standalone: bool,
+) -> TransportServerResult<hyper::Response<axum::body::Body>> {
+    // readable stream of string to be used in transport
+    let (read_tx, read_rx) = duplex(DUPLEX_BUFFER_SIZE);
+    // writable stream to deliver message to the client
+    let (write_tx, write_rx) = duplex(DUPLEX_BUFFER_SIZE);
+
+    let transport = SseTransport::<ClientMessage>::new(
+        read_rx,
+        write_tx,
+        read_tx,
+        Arc::clone(&state.transport_options),
+    )
+    .map_err(|err| TransportServerError::TransportError(err.to_string()))?;
+
+    let stream_id = if standalone {
+        DEFAULT_STREAM_ID.to_string()
+    } else {
+        state.id_generator.generate()
+    };
+    let ping_interval = state.ping_interval;
+    let runtime_clone = Arc::clone(&runtime);
+
+    let payload_string = payload.map(|p| p.to_string());
+
+    //Start the server runtime
+    tokio::spawn(async move {
+        match runtime_clone
+            .start_stream(transport, &stream_id, ping_interval, payload_string)
+            .await
+        {
+            Ok(_) => tracing::info!("stream {} exited gracefully.", &stream_id),
+            Err(err) => tracing::info!("stream {} exited with error : {}", &stream_id, err),
+        }
+        let _ = runtime.remove_transport(&stream_id).await;
+    });
+
+    // Construct SSE stream
+    let reader = BufReader::new(write_rx);
+
+    let message_stream = stream::unfold(reader, |mut reader| async move {
+        let mut line = String::new();
+
+        match reader.read_line(&mut line).await {
+            Ok(0) => None, // EOF
+            Ok(_) => {
+                let trimmed_line = line.trim_end_matches('\n').to_owned();
+                Some((Ok(Event::default().data(trimmed_line)), reader))
+            }
+            Err(e) => Some((Err(e), reader)),
+        }
+    });
+
+    let sse_stream =
+        Sse::new(message_stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(10)));
+
+    // Return SSE response with keep-alive
+    // Create a Response and set headers
+    let mut response = sse_stream.into_response();
+    response.headers_mut().insert(
+        MCP_SESSION_ID_HEADER,
+        HeaderValue::from_str(&session_id).unwrap(),
+    );
+    //TODO: move deserialization out of mcp_stream.rs
+    // *response.status_mut() = StatusCode::ACCEPTED;
+    Ok(response)
+}
+
+pub async fn create_standalone_stream(
+    session_id: SessionId,
+    state: Arc<AppState>,
+) -> TransportServerResult<hyper::Response<axum::body::Body>> {
+    let runtime = state.session_store.get(&session_id).await.ok_or(
+        TransportServerError::SessionIdInvalid(session_id.to_string()),
+    )?;
+    let runtime = runtime.lock().await.to_owned();
+
+    if runtime.stream_id_exists(DEFAULT_STREAM_ID).await {
+        let error =
+            SdkError::bad_request().with_message("Only one SSE stream is allowed per session");
+        return Ok((StatusCode::CONFLICT, Json(error)).into_response());
+    }
+
+    create_sse_stream(
+        runtime.clone(),
+        session_id.clone(),
+        state.clone(),
+        None,
+        true,
+    )
+    .await
+}
+
+pub async fn start_new_session(
+    state: Arc<AppState>,
+    payload: &str,
+) -> TransportServerResult<hyper::Response<axum::body::Body>> {
+    let session_id: SessionId = state.id_generator.generate();
+
+    let h: Arc<dyn McpServerHandler> = state.handler.clone();
+    // create a new server instance with unique session_id and
+    let runtime: Arc<ServerRuntime> = Arc::new(server_runtime::create_server_instance(
+        Arc::clone(&state.server_details),
+        h,
+        session_id.to_owned(),
+    ));
+
+    tracing::info!(
+        "a new client joined : {}",
+        runtime.session_id().await.unwrap_or_default().to_owned()
+    );
+
+    let response = create_sse_stream(
+        runtime.clone(),
+        session_id.clone(),
+        state.clone(),
+        Some(payload),
+        false,
+    )
+    .await;
+
+    if response.is_ok() {
+        state
+            .session_store
+            .set(session_id.to_owned(), runtime.clone())
+            .await;
+    }
+    response
+}
+
+async fn single_shot_stream(
+    runtime: Arc<ServerRuntime>,
+    session_id: SessionId,
+    state: Arc<AppState>,
+    payload: Option<&str>,
+    standalone: bool,
+) -> TransportServerResult<hyper::Response<axum::body::Body>> {
+    // readable stream of string to be used in transport
+    let (read_tx, read_rx) = duplex(DUPLEX_BUFFER_SIZE);
+    // writable stream to deliver message to the client
+    let (write_tx, write_rx) = duplex(DUPLEX_BUFFER_SIZE);
+
+    let transport = SseTransport::<ClientMessage>::new(
+        read_rx,
+        write_tx,
+        read_tx,
+        Arc::clone(&state.transport_options),
+    )
+    .map_err(|err| TransportServerError::TransportError(err.to_string()))?;
+
+    let stream_id = if standalone {
+        DEFAULT_STREAM_ID.to_string()
+    } else {
+        state.id_generator.generate()
+    };
+    let ping_interval = state.ping_interval;
+    let runtime_clone = Arc::clone(&runtime);
+
+    let payload_string = payload.map(|p| p.to_string());
+
+    tokio::spawn(async move {
+        match runtime_clone
+            .start_stream(transport, &stream_id, ping_interval, payload_string)
+            .await
+        {
+            Ok(_) => tracing::info!("stream {} exited gracefully.", &stream_id),
+            Err(err) => tracing::info!("stream {} exited with error : {}", &stream_id, err),
+        }
+        let _ = runtime.remove_transport(&stream_id).await;
+    });
+
+    // Construct SSE stream
+    let mut reader = BufReader::new(write_rx);
+    let mut line = String::new();
+    let response = match reader.read_line(&mut line).await {
+        Ok(0) => None, // EOF
+        Ok(_) => {
+            let trimmed_line = line.trim_end_matches('\n').to_owned();
+            Some(Ok(trimmed_line))
+        }
+        Err(e) => Some(Err(e)),
+    };
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        MCP_SESSION_ID_HEADER,
+        HeaderValue::from_str(&session_id).unwrap(),
+    );
+
+    match response {
+        Some(response_result) => match response_result {
+            Ok(response_str) => {
+                Ok((StatusCode::OK, headers, response_str.to_string()).into_response())
+            }
+            Err(err) => Ok((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                headers,
+                Json(err.to_string()),
+            )
+                .into_response()),
+        },
+        None => Ok((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            headers,
+            Json("End of the transport stream reached."),
+        )
+            .into_response()),
+    }
+}
+
+pub async fn process_incoming_message_return(
+    session_id: SessionId,
+    state: Arc<AppState>,
+    payload: &str,
+) -> TransportServerResult<impl IntoResponse> {
+    match state.session_store.get(&session_id).await {
+        Some(runtime) => {
+            let runtime = runtime.lock().await.to_owned();
+
+            single_shot_stream(
+                runtime.clone(),
+                session_id.clone(),
+                state.clone(),
+                Some(payload),
+                false,
+            )
+            .await
+            // Ok(StatusCode::OK.into_response())
+        }
+        None => {
+            let error = SdkError::session_not_found();
+            Ok((StatusCode::NOT_FOUND, Json(error)).into_response())
+        }
+    }
+}
+
+pub async fn process_incoming_message(
+    session_id: SessionId,
+    state: Arc<AppState>,
+    payload: &str,
+) -> TransportServerResult<impl IntoResponse> {
+    match state.session_store.get(&session_id).await {
+        Some(runtime) => {
+            let runtime = runtime.lock().await.to_owned();
+
+            create_sse_stream(
+                runtime.clone(),
+                session_id.clone(),
+                state.clone(),
+                Some(payload),
+                false,
+            )
+            .await
+        }
+        None => {
+            let error = SdkError::session_not_found();
+            Ok((StatusCode::NOT_FOUND, Json(error)).into_response())
+        }
+    }
+}
+
+pub async fn delete_session(
+    session_id: SessionId,
+    state: Arc<AppState>,
+) -> TransportServerResult<impl IntoResponse> {
+    match state.session_store.get(&session_id).await {
+        Some(runtime) => {
+            let runtime = runtime.lock().await.to_owned();
+            runtime.shutdown().await;
+            state.session_store.delete(&session_id).await;
+            Ok((StatusCode::OK, Json("ok")).into_response())
+        }
+        None => {
+            let error = SdkError::session_not_found();
+            Ok((StatusCode::NOT_FOUND, Json(error)).into_response())
+        }
+    }
+}
+
+pub fn acceptable_content_type(headers: &HeaderMap) -> bool {
+    let accept_header = headers
+        .get("content-type")
+        .and_then(|val| val.to_str().ok())
+        .unwrap_or("");
+    accept_header
+        .split(',')
+        .any(|val| val.trim().starts_with("application/json"))
+}
+
+pub fn validate_mcp_protocol_version_header(headers: &HeaderMap) -> SdkResult<()> {
+    let protocol_version_header = headers
+        .get(MCP_PROTOCOL_VERSION_HEADER)
+        .and_then(|val| val.to_str().ok())
+        .unwrap_or("");
+
+    // requests without protocol version header are acceptable
+    if protocol_version_header.is_empty() {
+        return Ok(());
+    }
+
+    validate_mcp_protocol_version(protocol_version_header)
+}
+
+pub fn accepts_event_stream(headers: &HeaderMap) -> bool {
+    let accept_header = headers
+        .get("accept")
+        .and_then(|val| val.to_str().ok())
+        .unwrap_or("");
+
+    accept_header
+        .split(',')
+        .any(|val| val.trim().starts_with("text/event-stream"))
+}
+
+pub fn valid_streaming_http_accept_header(headers: &HeaderMap) -> bool {
+    let accept_header = headers
+        .get("accept")
+        .and_then(|val| val.to_str().ok())
+        .unwrap_or("");
+
+    let types: Vec<_> = accept_header.split(',').map(|v| v.trim()).collect();
+
+    let has_event_stream = types.iter().any(|v| v.starts_with("text/event-stream"));
+    let has_json = types.iter().any(|v| v.starts_with("application/json"));
+    has_event_stream && has_json
+}

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
@@ -76,7 +76,7 @@ async fn create_sse_stream(
             .start_stream(transport, &stream_id, ping_interval, payload_string)
             .await
         {
-            Ok(_) => tracing::info!("stream {} exited gracefully.", &stream_id),
+            Ok(_) => tracing::trace!("stream {} exited gracefully.", &stream_id),
             Err(err) => tracing::info!("stream {} exited with error : {}", &stream_id, err),
         }
         let _ = runtime.remove_transport(&stream_id).await;

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/streamable_http_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/streamable_http_routes.rs
@@ -1,0 +1,158 @@
+use super::hyper_utils::{start_new_session, MCP_SESSION_ID_HEADER};
+use crate::schema::schema_utils::SdkError;
+use crate::{
+    error::McpSdkError,
+    hyper_servers::{
+        app_state::AppState,
+        error::TransportServerResult,
+        middlewares::protect_dns_rebinding::protect_dns_rebinding,
+        routes::hyper_utils::{
+            acceptable_content_type, accepts_event_stream, create_standalone_stream,
+            delete_session, process_incoming_message, process_incoming_message_return,
+            valid_streaming_http_accept_header, validate_mcp_protocol_version_header,
+        },
+    },
+    utils::valid_initialize_method,
+};
+use axum::{
+    extract::{Query, State},
+    middleware,
+    response::IntoResponse,
+    routing::{delete, post},
+    Json, Router,
+};
+use hyper::{HeaderMap, StatusCode};
+use rust_mcp_transport::SessionId;
+use std::{collections::HashMap, sync::Arc};
+
+use axum::routing::get;
+
+pub fn routes(state: Arc<AppState>, streamable_http_endpoint: &str) -> Router<Arc<AppState>> {
+    Router::new()
+        .route(streamable_http_endpoint, get(handle_streamable_http_get))
+        .route(streamable_http_endpoint, post(handle_streamable_http_post))
+        .route(
+            streamable_http_endpoint,
+            delete(handle_streamable_http_delete),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            protect_dns_rebinding,
+        ))
+}
+
+pub async fn handle_streamable_http_get(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+) -> TransportServerResult<impl IntoResponse> {
+    if !accepts_event_stream(&headers) {
+        let error = SdkError::bad_request().with_message(r#"Client must accept text/event-stream"#);
+        return Ok((StatusCode::NOT_ACCEPTABLE, Json(error)).into_response());
+    }
+
+    if let Err(parse_error) = validate_mcp_protocol_version_header(&headers) {
+        let error =
+            SdkError::bad_request().with_message(format!(r#"Bad Request: {parse_error}"#).as_str());
+        return Ok((StatusCode::BAD_REQUEST, Json(error)).into_response());
+    }
+
+    let session_id: Option<SessionId> = headers
+        .get(MCP_SESSION_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|s| s.to_string());
+
+    match session_id {
+        Some(session_id) => {
+            let res = create_standalone_stream(session_id, state).await?;
+            Ok(res.into_response())
+        }
+        None => {
+            let error = SdkError::bad_request().with_message("Bad request: session not found");
+            Ok((StatusCode::BAD_REQUEST, Json(error)).into_response())
+        }
+    }
+}
+
+pub async fn handle_streamable_http_post(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Query(_params): Query<HashMap<String, String>>,
+    payload: String,
+) -> TransportServerResult<impl IntoResponse> {
+    if !valid_streaming_http_accept_header(&headers) {
+        let error = SdkError::bad_request()
+            .with_message(r#"Client must accept both application/json and text/event-stream"#);
+        return Ok((StatusCode::NOT_ACCEPTABLE, Json(error)).into_response());
+    }
+
+    if !acceptable_content_type(&headers) {
+        let error = SdkError::bad_request()
+            .with_message(r#"Unsupported Media Type: Content-Type must be application/json"#);
+        return Ok((StatusCode::UNSUPPORTED_MEDIA_TYPE, Json(error)).into_response());
+    }
+
+    if let Err(parse_error) = validate_mcp_protocol_version_header(&headers) {
+        let error =
+            SdkError::bad_request().with_message(format!(r#"Bad Request: {parse_error}"#).as_str());
+        return Ok((StatusCode::BAD_REQUEST, Json(error)).into_response());
+    }
+
+    let session_id: Option<SessionId> = headers
+        .get(MCP_SESSION_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|s| s.to_string());
+
+    //TODO: validate reconnect after disconnect
+
+    match session_id {
+        // has session-id => write to the existing stream
+        Some(id) => {
+            if state.enable_json_response {
+                let res = process_incoming_message_return(id, state, &payload).await?;
+                Ok(res.into_response())
+            } else {
+                let res = process_incoming_message(id, state, &payload).await?;
+                Ok(res.into_response())
+            }
+        }
+        None => match valid_initialize_method(&payload) {
+            Ok(_) => {
+                return start_new_session(state, &payload).await;
+            }
+            Err(McpSdkError::SdkError(error)) => {
+                Ok((StatusCode::BAD_REQUEST, Json(error)).into_response())
+            }
+            Err(error) => {
+                let error = SdkError::bad_request().with_message(&error.to_string());
+                Ok((StatusCode::BAD_REQUEST, Json(error)).into_response())
+            }
+        },
+    }
+}
+
+pub async fn handle_streamable_http_delete(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+) -> TransportServerResult<impl IntoResponse> {
+    if let Err(parse_error) = validate_mcp_protocol_version_header(&headers) {
+        let error =
+            SdkError::bad_request().with_message(format!(r#"Bad Request: {parse_error}"#).as_str());
+        return Ok((StatusCode::BAD_REQUEST, Json(error)).into_response());
+    }
+
+    let session_id: Option<SessionId> = headers
+        .get(MCP_SESSION_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|s| s.to_string());
+
+    match session_id {
+        Some(id) => {
+            let res = delete_session(id, state).await;
+            Ok(res.into_response())
+        }
+        None => {
+            let error = SdkError::bad_request().with_message("Bad Request: Session not found");
+            Ok((StatusCode::BAD_REQUEST, Json(error)).into_response())
+        }
+    }
+}

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -70,7 +70,7 @@ pub struct HyperServerOptions {
     /// Optional thread-safe session id generator to generate unique session IDs.
     pub session_id_generator: Option<Arc<dyn IdGenerator>>,
     /// If set to true, the SSE transport will also be supported for backward compatibility (default: true)
-    pub support_sse: Option<bool>,
+    pub sse_support: bool,
     /// List of allowed host header values for DNS rebinding protection.
     /// If not specified, host validation is disabled.
     pub allowed_hosts: Option<Vec<String>>,
@@ -206,7 +206,7 @@ impl Default for HyperServerOptions {
             ssl_key_path: None,
             session_id_generator: None,
             enable_json_response: None,
-            support_sse: Some(true),
+            sse_support: true,
             allowed_hosts: None,
             allowed_origins: None,
             dns_rebinding_protection: false,
@@ -316,7 +316,7 @@ impl HyperServer {
             self.options.streamable_http_endpoint()
         );
 
-        if self.options.support_sse.unwrap_or_default() {
+        if self.options.sse_support {
             let sse_url = format!(
                 "\n• SSE {} is available at {}://{}{}",
                 server_type,

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -363,8 +363,9 @@ impl HyperServer {
 
         // Spawn a task to trigger shutdown on signal
         let handle_clone = self.handle.clone();
+        let state_clone = self.state().clone();
         tokio::spawn(async move {
-            shutdown_signal(handle_clone).await;
+            shutdown_signal(handle_clone, state_clone).await;
         });
 
         let handle_clone = self.handle.clone();
@@ -453,7 +454,7 @@ async fn shutdown_signal(handle: Handle, state: Arc<AppState>) {
     }
 
     tracing::info!("Signal received, starting graceful shutdown");
-    state.session_store.clear();
+    state.session_store.clear().await;
     // Trigger graceful shutdown with a timeout
     handle.graceful_shutdown(Some(Duration::from_secs(GRACEFUL_SHUTDOWN_TMEOUT_SECS)));
 }

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -70,7 +70,7 @@ pub struct HyperServerOptions {
     /// Optional thread-safe session id generator to generate unique session IDs.
     pub session_id_generator: Option<Arc<dyn IdGenerator>>,
     /// If set to true, the SSE transport will also be supported for backward compatibility (default: true)
-    pub supprt_sse: Option<bool>,
+    pub support_sse: Option<bool>,
     /// List of allowed host header values for DNS rebinding protection.
     /// If not specified, host validation is disabled.
     pub allowed_hosts: Option<Vec<String>>,
@@ -206,7 +206,7 @@ impl Default for HyperServerOptions {
             ssl_key_path: None,
             session_id_generator: None,
             enable_json_response: None,
-            supprt_sse: Some(true),
+            support_sse: Some(true),
             allowed_hosts: None,
             allowed_origins: None,
             dns_rebinding_protection: false,
@@ -316,7 +316,7 @@ impl HyperServer {
             self.options.streamable_http_endpoint()
         );
 
-        if self.options.supprt_sse.unwrap_or_default() {
+        if self.options.support_sse.unwrap_or_default() {
             let sse_url = format!(
                 "\n• SSE {} is available at {}://{}{}",
                 server_type,

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -1,4 +1,7 @@
-use crate::mcp_traits::mcp_handler::McpServerHandler;
+use crate::{
+    error::SdkResult, mcp_server::hyper_runtime::HyperRuntime,
+    mcp_traits::mcp_handler::McpServerHandler,
+};
 #[cfg(feature = "ssl")]
 use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
@@ -27,6 +30,8 @@ const GRACEFUL_SHUTDOWN_TMEOUT_SECS: u64 = 30;
 const DEFAULT_SSE_ENDPOINT: &str = "/sse";
 // Default MCP Messages endpoint path
 const DEFAULT_MESSAGES_ENDPOINT: &str = "/messages";
+// Default Streamable HTTP endpoint path
+const DEFAULT_STREAMABLE_HTTP_ENDPOINT: &str = "/mcp";
 
 /// Configuration struct for the Hyper server
 /// Used to configure the HyperServer instance.
@@ -35,10 +40,21 @@ pub struct HyperServerOptions {
     pub host: String,
     /// Hostname or IP address the server will bind to (default: "8080")
     pub port: u16,
+
     /// Optional custom path for the Server-Sent Events (SSE) endpoint (default: `/sse`)
     pub custom_sse_endpoint: Option<String>,
-    /// Optional custom path for the MCP messages endpoint (default: `/messages`)
+    /// Optional custom path for the MCP messages endpoint for sse (default: `/messages`)
     pub custom_messages_endpoint: Option<String>,
+
+    /// Optional custom path for the Streamable HTTP endpoint (default: `/mcp`)
+    pub custom_streamable_http_endpoint: Option<String>,
+
+    /// This setting only applies to streamable HTTP.
+    /// If true, the server will return JSON responses instead of starting an SSE stream.
+    /// This can be useful for simple request/response scenarios without streaming.
+    /// Default is false (SSE streams are preferred).
+    pub enable_json_response: Option<bool>,
+
     /// Interval between automatic ping messages sent to clients to detect disconnects
     pub ping_interval: Duration,
     /// Enables SSL/TLS if set to `true`
@@ -53,6 +69,17 @@ pub struct HyperServerOptions {
     pub transport_options: Arc<TransportOptions>,
     /// Optional thread-safe session id generator to generate unique session IDs.
     pub session_id_generator: Option<Arc<dyn IdGenerator>>,
+    /// If set to true, the SSE transport will also be supported for backward compatibility (default: true)
+    pub supprt_sse: Option<bool>,
+    /// List of allowed host header values for DNS rebinding protection.
+    /// If not specified, host validation is disabled.
+    pub allowed_hosts: Option<Vec<String>>,
+    /// List of allowed origin header values for DNS rebinding protection.
+    /// If not specified, origin validation is disabled.
+    pub allowed_origins: Option<Vec<String>>,
+    /// Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
+    /// Default is false for backwards compatibility.
+    pub dns_rebinding_protection: bool,
 }
 
 impl HyperServerOptions {
@@ -94,7 +121,7 @@ impl HyperServerOptions {
     ///
     /// # Returns
     /// * `TransportServerResult<SocketAddr>` - The resolved server address or an error
-    async fn resolve_server_address(&self) -> TransportServerResult<SocketAddr> {
+    pub(crate) async fn resolve_server_address(&self) -> TransportServerResult<SocketAddr> {
         self.validate()?;
 
         let mut host = self.host.to_string();
@@ -123,6 +150,24 @@ impl HyperServerOptions {
         Ok(addr)
     }
 
+    pub fn base_url(&self) -> String {
+        format!(
+            "{}://{}:{}",
+            if self.enable_ssl { "https" } else { "http" },
+            self.host,
+            self.port
+        )
+    }
+    pub fn streamable_http_url(&self) -> String {
+        format!("{}{}", self.base_url(), self.streamable_http_endpoint())
+    }
+    pub fn sse_url(&self) -> String {
+        format!("{}{}", self.base_url(), self.sse_endpoint())
+    }
+    pub fn sse_message_url(&self) -> String {
+        format!("{}{}", self.base_url(), self.sse_messages_endpoint())
+    }
+
     pub fn sse_endpoint(&self) -> &str {
         self.custom_sse_endpoint
             .as_deref()
@@ -133,6 +178,12 @@ impl HyperServerOptions {
         self.custom_messages_endpoint
             .as_deref()
             .unwrap_or(DEFAULT_MESSAGES_ENDPOINT)
+    }
+
+    pub fn streamable_http_endpoint(&self) -> &str {
+        self.custom_messages_endpoint
+            .as_deref()
+            .unwrap_or(DEFAULT_STREAMABLE_HTTP_ENDPOINT)
     }
 }
 
@@ -146,6 +197,7 @@ impl Default for HyperServerOptions {
             host: "127.0.0.1".to_string(),
             port: 8080,
             custom_sse_endpoint: None,
+            custom_streamable_http_endpoint: None,
             custom_messages_endpoint: None,
             ping_interval: DEFAULT_CLIENT_PING_INTERVAL,
             transport_options: Default::default(),
@@ -153,6 +205,11 @@ impl Default for HyperServerOptions {
             ssl_cert_path: None,
             ssl_key_path: None,
             session_id_generator: None,
+            enable_json_response: None,
+            supprt_sse: Some(true),
+            allowed_hosts: None,
+            allowed_origins: None,
+            dns_rebinding_protection: false,
         }
     }
 }
@@ -161,7 +218,7 @@ impl Default for HyperServerOptions {
 pub struct HyperServer {
     app: Router,
     state: Arc<AppState>,
-    options: HyperServerOptions,
+    pub(crate) options: HyperServerOptions,
     handle: Handle,
 }
 
@@ -192,7 +249,12 @@ impl HyperServer {
             handler,
             ping_interval: server_options.ping_interval,
             sse_message_endpoint: server_options.sse_messages_endpoint().to_owned(),
+            http_streamable_endpoint: server_options.streamable_http_endpoint().to_owned(),
             transport_options: Arc::clone(&server_options.transport_options),
+            enable_json_response: server_options.enable_json_response.unwrap_or(false),
+            allowed_hosts: server_options.allowed_hosts.take(),
+            allowed_origins: server_options.allowed_origins.take(),
+            dns_rebinding_protection: server_options.dns_rebinding_protection,
         });
         let app = app_routes(Arc::clone(&state), &server_options);
         Self {
@@ -246,15 +308,30 @@ impl HyperServer {
             "http"
         };
 
-        let server_url = format!(
-            "{} is available at {}://{}{}",
+        let mut server_url = format!(
+            "\n• Streamable HTTP {} is available at {}://{}{}",
             server_type,
             protocol,
             addr,
-            self.options.sse_endpoint()
+            self.options.streamable_http_endpoint()
         );
 
+        if self.options.supprt_sse.unwrap_or_default() {
+            let sse_url = format!(
+                "\n• SSE {} is available at {}://{}{}",
+                server_type,
+                protocol,
+                addr,
+                self.options.sse_endpoint()
+            );
+            server_url.push_str(&sse_url);
+        };
+
         Ok(server_url)
+    }
+
+    pub fn options(&self) -> &HyperServerOptions {
+        &self.options
     }
 
     // pub fn with_layer<L>(mut self, layer: L) -> Self
@@ -274,7 +351,7 @@ impl HyperServer {
     /// # Returns
     /// * `TransportServerResult<()>` - Ok if the server starts successfully, Err otherwise
     #[cfg(feature = "ssl")]
-    async fn start_ssl(self, addr: SocketAddr) -> TransportServerResult<()> {
+    pub(crate) async fn start_ssl(self, addr: SocketAddr) -> TransportServerResult<()> {
         let config = RustlsConfig::from_pem_file(
             self.options.ssl_cert_path.as_deref().unwrap_or_default(),
             self.options.ssl_key_path.as_deref().unwrap_or_default(),
@@ -310,7 +387,7 @@ impl HyperServer {
     ///
     /// # Returns
     /// * `TransportServerResult<()>` - Ok if the server starts successfully, Err otherwise
-    async fn start_http(self, addr: SocketAddr) -> TransportServerResult<()> {
+    pub(crate) async fn start_http(self, addr: SocketAddr) -> TransportServerResult<()> {
         tracing::info!("{}", self.server_info(Some(addr)).await?);
 
         // Spawn a task to trigger shutdown on signal
@@ -333,23 +410,20 @@ impl HyperServer {
     /// Panics if SSL is requested but the "ssl" feature is not enabled.
     ///
     /// # Returns
-    /// * `TransportServerResult<()>` - Ok if the server starts successfully, Err otherwise
-    pub async fn start(self) -> TransportServerResult<()> {
-        let addr = self.options.resolve_server_address().await?;
+    /// * `SdkResult<()>` - Ok if the server starts successfully, Err otherwise
+    pub async fn start(self) -> SdkResult<()> {
+        let runtime = HyperRuntime::create(self).await?;
+        runtime.await_server().await
+    }
 
-        #[cfg(feature = "ssl")]
-        if self.options.enable_ssl {
-            self.start_ssl(addr).await
-        } else {
-            self.start_http(addr).await
-        }
-
-        #[cfg(not(feature = "ssl"))]
-        if self.options.enable_ssl {
-            panic!("SSL requested but the 'ssl' feature is not enabled");
-        } else {
-            self.start_http(addr).await
-        }
+    /// Similar to start() , but returns a HyperRuntime after server started
+    ///
+    /// HyperRuntime could be used to access sessions and send server initiated messages if needed
+    ///
+    /// # Returns
+    /// * `SdkResult<HyperRuntime>` - Ok if the server starts successfully, Err otherwise
+    pub async fn start_runtime(self) -> SdkResult<HyperRuntime> {
+        HyperRuntime::create(self).await
     }
 }
 

--- a/crates/rust-mcp-sdk/src/hyper_servers/session_store.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/session_store.rs
@@ -4,11 +4,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 pub use in_memory::*;
 use rust_mcp_transport::SessionId;
-use tokio::{io::DuplexStream, sync::Mutex};
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
+use crate::mcp_server::ServerRuntime;
+
 // Type alias for the server-side duplex stream used in sessions
-pub type TxServer = DuplexStream;
+pub type TxServer = Arc<ServerRuntime>;
 
 /// Trait defining the interface for session storage operations
 ///
@@ -40,7 +42,9 @@ pub trait SessionStore: Send + Sync {
 
     async fn keys(&self) -> Vec<SessionId>;
 
-    async fn values(&self) -> Vec<Arc<Mutex<DuplexStream>>>;
+    async fn values(&self) -> Vec<Arc<Mutex<TxServer>>>;
+
+    async fn has(&self, session: &SessionId) -> bool;
 }
 
 /// Trait for generating session identifiers

--- a/crates/rust-mcp-sdk/src/hyper_servers/session_store/in_memory.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/session_store/in_memory.rs
@@ -3,7 +3,6 @@ use super::{SessionStore, TxServer};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::io::DuplexStream;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
@@ -59,8 +58,12 @@ impl SessionStore for InMemorySessionStore {
         let store = self.store.read().await;
         store.keys().cloned().collect::<Vec<_>>()
     }
-    async fn values(&self) -> Vec<Arc<Mutex<DuplexStream>>> {
+    async fn values(&self) -> Vec<Arc<Mutex<TxServer>>> {
         let store = self.store.read().await;
         store.values().cloned().collect::<Vec<_>>()
+    }
+    async fn has(&self, session: &SessionId) -> bool {
+        let store = self.store.read().await;
+        store.contains_key(session)
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime.rs
@@ -1,14 +1,18 @@
 pub mod mcp_client_runtime;
 pub mod mcp_client_runtime_core;
 
-use crate::schema::schema_utils::{self, MessageFromClient, ServerMessage};
 use crate::schema::{
+    schema_utils::{
+        self, ClientMessage, ClientMessages, FromMessage, MessageFromClient, ServerMessage,
+        ServerMessages,
+    },
     InitializeRequest, InitializeRequestParams, InitializeResult, InitializedNotification,
     RpcError, ServerResult,
 };
 use async_trait::async_trait;
-use futures::future::join_all;
+use futures::future::{join_all, try_join_all};
 use futures::StreamExt;
+
 use rust_mcp_transport::{IoStream, McpDispatch, MessageDispatcher, Transport};
 use std::sync::{Arc, RwLock};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -21,7 +25,15 @@ use crate::utils::ensure_server_protocole_compatibility;
 
 pub struct ClientRuntime {
     // The transport interface for handling messages between client and server
-    transport: Box<dyn Transport<ServerMessage, MessageFromClient>>,
+    transport: Arc<
+        dyn Transport<
+            ServerMessages,
+            MessageFromClient,
+            ServerMessage,
+            ClientMessages,
+            ClientMessage,
+        >,
+    >,
     // The handler for processing MCP messages
     handler: Box<dyn McpClientHandler>,
     // // Information about the server
@@ -34,11 +46,17 @@ pub struct ClientRuntime {
 impl ClientRuntime {
     pub(crate) fn new(
         client_details: InitializeRequestParams,
-        transport: impl Transport<ServerMessage, MessageFromClient>,
+        transport: impl Transport<
+            ServerMessages,
+            MessageFromClient,
+            ServerMessage,
+            ClientMessages,
+            ClientMessage,
+        >,
         handler: Box<dyn McpClientHandler>,
     ) -> Self {
         Self {
-            transport: Box::new(transport),
+            transport: Arc::new(transport),
             handler,
             client_details,
             server_details: Arc::new(RwLock::new(None)),
@@ -68,21 +86,79 @@ impl ClientRuntime {
         }
         Ok(())
     }
+
+    pub(crate) async fn handle_message(
+        &self,
+        message: ServerMessage,
+        transport: &Arc<
+            dyn Transport<
+                ServerMessages,
+                MessageFromClient,
+                ServerMessage,
+                ClientMessages,
+                ClientMessage,
+            >,
+        >,
+    ) -> SdkResult<Option<ClientMessage>> {
+        let response = match message {
+            ServerMessage::Request(jsonrpc_request) => {
+                let result = self
+                    .handler
+                    .handle_request(jsonrpc_request.request, self)
+                    .await;
+
+                // create a response to send back to the server
+                let response: MessageFromClient = match result {
+                    Ok(success_value) => success_value.into(),
+                    Err(error_value) => MessageFromClient::Error(error_value),
+                };
+
+                let mcp_message = ClientMessage::from_message(response, Some(jsonrpc_request.id))?;
+                Some(mcp_message)
+            }
+            ServerMessage::Notification(jsonrpc_notification) => {
+                self.handler
+                    .handle_notification(jsonrpc_notification.notification, self)
+                    .await?;
+                None
+            }
+            ServerMessage::Error(jsonrpc_error) => {
+                self.handler.handle_error(jsonrpc_error.error, self).await?;
+                None
+            }
+            ServerMessage::Response(response) => {
+                if let Some(tx_response) = transport.pending_request_tx(&response.id).await {
+                    tx_response
+                        .send(ServerMessage::Response(response))
+                        .map_err(|e| RpcError::internal_error().with_message(e.to_string()))?;
+                } else {
+                    tracing::warn!(
+                        "Received response or error without a matching request: {:?}",
+                        &response.id
+                    );
+                }
+                None
+            }
+        };
+        Ok(response)
+    }
 }
 
 #[async_trait]
 impl McpClient for ClientRuntime {
-    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<ServerMessage>>>
+    fn sender(&self) -> Arc<tokio::sync::RwLock<Option<MessageDispatcher<ServerMessage>>>>
     where
-        MessageDispatcher<ServerMessage>: McpDispatch<ServerMessage, MessageFromClient>,
+        MessageDispatcher<ServerMessage>:
+            McpDispatch<ServerMessages, ClientMessages, ServerMessage, ClientMessage>,
     {
-        (self.transport.message_sender().await) as _
+        (self.transport.message_sender().clone()) as _
     }
 
     async fn start(self: Arc<Self>) -> SdkResult<()> {
+        //TODO: improve the flow
         let mut stream = self.transport.start().await?;
-
-        let mut error_io_stream = self.transport.error_stream().await.write().await;
+        let transport = self.transport.clone();
+        let mut error_io_stream = transport.error_stream().write().await;
         let error_io_stream = error_io_stream.take();
 
         let self_clone = Arc::clone(&self);
@@ -125,52 +201,57 @@ impl McpClient for ClientRuntime {
             Ok::<(), McpSdkError>(())
         });
 
-        // send initialize request to the MCP server
-        self_clone.initialize_request().await?;
+        let transport = self.transport.clone();
 
         let main_task = tokio::spawn(async move {
-            let sender = self_clone.sender().await.read().await;
+            let sender = self_clone.sender();
+            let sender = sender.read().await;
             let sender = sender
                 .as_ref()
                 .ok_or(schema_utils::SdkError::connection_closed())?;
-            while let Some(mcp_message) = stream.next().await {
+            while let Some(mcp_messages) = stream.next().await {
                 let self_ref = &*self_clone;
 
-                match mcp_message {
-                    ServerMessage::Request(jsonrpc_request) => {
-                        let result = self_ref
-                            .handler
-                            .handle_request(jsonrpc_request.request, self_ref)
-                            .await;
+                match mcp_messages {
+                    ServerMessages::Single(server_message) => {
+                        let result = self_ref.handle_message(server_message, &transport).await;
 
-                        // create a response to send back to the server
-                        let response: MessageFromClient = match result {
-                            Ok(success_value) => success_value.into(),
-                            Err(error_value) => MessageFromClient::Error(error_value),
-                        };
-                        // send the response back with corresponding request id
-                        sender
-                            .send(response, Some(jsonrpc_request.id), None)
-                            .await?;
+                        match result {
+                            Ok(result) => {
+                                if let Some(result) = result {
+                                    sender
+                                        .send_message(ClientMessages::Single(result), None)
+                                        .await?;
+                                }
+                            }
+                            Err(error) => {
+                                tracing::error!("Error handling message : {}", error)
+                            }
+                        }
                     }
-                    ServerMessage::Notification(jsonrpc_notification) => {
-                        self_ref
-                            .handler
-                            .handle_notification(jsonrpc_notification.notification, self_ref)
-                            .await?;
+                    ServerMessages::Batch(server_messages) => {
+                        let handling_tasks: Vec<_> = server_messages
+                            .into_iter()
+                            .map(|server_message| {
+                                self_ref.handle_message(server_message, &transport)
+                            })
+                            .collect();
+                        let results: Vec<_> = try_join_all(handling_tasks).await?;
+                        let results: Vec<_> = results.into_iter().flatten().collect();
+
+                        if !results.is_empty() {
+                            sender
+                                .send_message(ClientMessages::Batch(results), None)
+                                .await?;
+                        }
                     }
-                    ServerMessage::Error(jsonrpc_error) => {
-                        self_ref
-                            .handler
-                            .handle_error(jsonrpc_error.error, self_ref)
-                            .await?;
-                    }
-                    // The response is the result of a request, it is processed at the transport level.
-                    ServerMessage::Response(_) => {}
                 }
             }
             Ok::<(), McpSdkError>(())
         });
+
+        // send initialize request to the MCP server
+        self.initialize_request().await?;
 
         let mut lock = self.handlers.lock().await;
         lock.push(main_task);

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use crate::schema::{
     schema_utils::{
-        MessageFromClient, NotificationFromServer, RequestFromServer, ResultFromClient,
-        ServerMessage,
+        ClientMessage, ClientMessages, MessageFromClient, NotificationFromServer,
+        RequestFromServer, ResultFromClient, ServerMessage, ServerMessages,
     },
     InitializeRequestParams, RpcError, ServerNotification, ServerRequest,
 };
@@ -40,7 +40,13 @@ use super::ClientRuntime;
 /// [Repository Example](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/simple-mcp-client)
 pub fn create_client(
     client_details: InitializeRequestParams,
-    transport: impl Transport<ServerMessage, MessageFromClient>,
+    transport: impl Transport<
+        ServerMessages,
+        MessageFromClient,
+        ServerMessage,
+        ClientMessages,
+        ClientMessage,
+    >,
     handler: impl ClientHandler,
 ) -> Arc<ClientRuntime> {
     Arc::new(ClientRuntime::new(

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/client_runtime/mcp_client_runtime_core.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use crate::schema::{
     schema_utils::{
-        MessageFromClient, NotificationFromServer, RequestFromServer, ResultFromClient,
-        ServerMessage,
+        ClientMessage, ClientMessages, MessageFromClient, NotificationFromServer,
+        RequestFromServer, ResultFromClient, ServerMessage, ServerMessages,
     },
     InitializeRequestParams, RpcError,
 };
 use async_trait::async_trait;
+
 use rust_mcp_transport::Transport;
 
 use crate::{
@@ -41,7 +42,13 @@ use super::ClientRuntime;
 /// [Repository Example](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/simple-mcp-client-core)
 pub fn create_client(
     client_details: InitializeRequestParams,
-    transport: impl Transport<ServerMessage, MessageFromClient>,
+    transport: impl Transport<
+        ServerMessages,
+        MessageFromClient,
+        ServerMessage,
+        ClientMessages,
+        ClientMessage,
+    >,
     handler: impl ClientHandlerCore,
 ) -> Arc<ClientRuntime> {
     Arc::new(ClientRuntime::new(

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -390,7 +390,10 @@ impl ServerRuntime {
                             }
                         }
                     }
-
+                    // close the stream after all messages are sent, unless it is a standalone stream
+                    if !stream_id.eq(DEFAULT_STREAM_ID){
+                        return  Ok(());
+                    }
                 }
                 _ = &mut disconnect_rx => {
                                 self.remove_transport(stream_id).await?;

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -1,25 +1,45 @@
 pub mod mcp_server_runtime;
 pub mod mcp_server_runtime_core;
+use crate::schema::{
+    schema_utils::{
+        ClientMessage, ClientMessages, FromMessage, MessageFromServer, SdkError, ServerMessage,
+        ServerMessages,
+    },
+    InitializeRequestParams, InitializeResult, RequestId, RpcError,
+};
 
-use crate::schema::schema_utils::{self, MessageFromServer};
-use crate::schema::{InitializeRequestParams, InitializeResult, RpcError};
 use async_trait::async_trait;
-use futures::StreamExt;
-use rust_mcp_transport::{IoStream, McpDispatch, MessageDispatcher, Transport};
-use schema_utils::ClientMessage;
+use futures::future::try_join_all;
+use futures::{StreamExt, TryFutureExt};
+
+use rust_mcp_transport::{IoStream, TransportDispatcher};
+
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::oneshot;
 
 use crate::error::SdkResult;
 use crate::mcp_traits::mcp_handler::McpServerHandler;
 use crate::mcp_traits::mcp_server::McpServer;
 #[cfg(feature = "hyper-server")]
 use rust_mcp_transport::SessionId;
+pub const DEFAULT_STREAM_ID: &str = "STANDALONE-STREAM";
+
+// Define a type alias for the TransportDispatcher trait object
+type TransportType = Arc<
+    dyn TransportDispatcher<
+        ClientMessages,
+        MessageFromServer,
+        ClientMessage,
+        ServerMessages,
+        ServerMessage,
+    >,
+>;
 
 /// Struct representing the runtime core of the MCP server, handling transport and client details
 pub struct ServerRuntime {
-    // The transport interface for handling messages between client and server
-    transport: Box<dyn Transport<ClientMessage, MessageFromServer>>,
     // The handler for processing MCP messages
     handler: Arc<dyn McpServerHandler>,
     // Information about the server
@@ -28,6 +48,7 @@ pub struct ServerRuntime {
     client_details: Arc<RwLock<Option<InitializeRequestParams>>>,
     #[cfg(feature = "hyper-server")]
     session_id: Option<SessionId>,
+    transport_map: tokio::sync::RwLock<HashMap<String, TransportType>>,
 }
 
 #[async_trait]
@@ -46,6 +67,42 @@ impl McpServer for ServerRuntime {
         }
     }
 
+    async fn send(
+        &self,
+        message: MessageFromServer,
+        request_id: Option<RequestId>,
+        request_timeout: Option<Duration>,
+    ) -> SdkResult<Option<ClientMessages>> {
+        let transport_map = self.transport_map.read().await;
+        let transport = transport_map.get(DEFAULT_STREAM_ID).ok_or(
+            RpcError::internal_error()
+                .with_message("transport stream does not exists or is closed!".to_string()),
+        )?;
+
+        let mcp_message = ServerMessage::from_message(message, request_id)?;
+        transport
+            .send_message(ServerMessages::Single(mcp_message), request_timeout)
+            .map_err(|err| err.into())
+            .await
+    }
+
+    async fn send_batch(
+        &self,
+        messages: Vec<ServerMessage>,
+        request_timeout: Option<Duration>,
+    ) -> SdkResult<Option<Vec<ClientMessage>>> {
+        let transport_map = self.transport_map.read().await;
+        let transport = transport_map.get(DEFAULT_STREAM_ID).ok_or(
+            RpcError::internal_error()
+                .with_message("transport stream does not exists or is closed!".to_string()),
+        )?;
+
+        transport
+            .send_batch(messages, request_timeout)
+            .map_err(|err| err.into())
+            .await
+    }
+
     /// Returns the server's details, including server capability,
     /// instructions, protocol_version , server_info and optional meta data
     fn server_info(&self) -> &InitializeResult {
@@ -62,69 +119,67 @@ impl McpServer for ServerRuntime {
         }
     }
 
-    async fn sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<ClientMessage>>>
-    where
-        MessageDispatcher<ClientMessage>: McpDispatch<ClientMessage, MessageFromServer>,
-    {
-        (self.transport.message_sender().await) as _
-    }
-
     /// Main runtime loop, processes incoming messages and handles requests
     async fn start(&self) -> SdkResult<()> {
-        let mut stream = self.transport.start().await?;
+        let transport_map = self.transport_map.read().await;
 
-        let sender = self.transport.message_sender().await.read().await;
-        let sender = sender
-            .as_ref()
-            .ok_or(schema_utils::SdkError::connection_closed())?;
+        let transport = transport_map.get(DEFAULT_STREAM_ID).ok_or(
+            RpcError::internal_error()
+                .with_message("transport stream does not exists or is closed!".to_string()),
+        )?;
+
+        let mut stream = transport.start().await?;
 
         self.handler.on_server_started(self).await;
 
         // Process incoming messages from the client
-        while let Some(mcp_message) = stream.next().await {
-            match mcp_message {
-                // Handle a client request
-                ClientMessage::Request(client_jsonrpc_request) => {
-                    let result = self
-                        .handler
-                        .handle_request(client_jsonrpc_request.request, self)
-                        .await;
-                    // create a response to send back to the client
-                    let response: MessageFromServer = match result {
-                        Ok(success_value) => success_value.into(),
-                        Err(error_value) => {
-                            // Error occurred during initialization.
-                            // A likely cause could be an unsupported protocol version.
-                            if !self.is_initialized() {
-                                return Err(error_value.into());
-                            }
-                            MessageFromServer::Error(error_value)
-                        }
-                    };
+        while let Some(mcp_messages) = stream.next().await {
+            match mcp_messages {
+                ClientMessages::Single(client_message) => {
+                    let result = self.handle_message(client_message, transport).await;
 
-                    // send the response back with corresponding request id
-                    sender
-                        .send(response, Some(client_jsonrpc_request.id), None)
-                        .await?;
+                    match result {
+                        Ok(result) => {
+                            if let Some(result) = result {
+                                transport
+                                    .send_message(ServerMessages::Single(result), None)
+                                    .await?;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::error!("Error handling message : {}", error)
+                        }
+                    }
                 }
-                ClientMessage::Notification(client_jsonrpc_notification) => {
-                    self.handler
-                        .handle_notification(client_jsonrpc_notification.notification, self)
-                        .await?;
+                ClientMessages::Batch(client_messages) => {
+                    let handling_tasks: Vec<_> = client_messages
+                        .into_iter()
+                        .map(|client_message| self.handle_message(client_message, transport))
+                        .collect();
+
+                    let results: Vec<_> = try_join_all(handling_tasks).await?;
+
+                    let results: Vec<_> = results.into_iter().flatten().collect();
+
+                    if !results.is_empty() {
+                        transport
+                            .send_message(ServerMessages::Batch(results), None)
+                            .await?;
+                    }
                 }
-                ClientMessage::Error(jsonrpc_error) => {
-                    self.handler.handle_error(jsonrpc_error.error, self).await?;
-                }
-                // The response is the result of a request, it is processed at the transport level.
-                ClientMessage::Response(_) => {}
             }
         }
-
         return Ok(());
     }
 
     async fn stderr_message(&self, message: String) -> SdkResult<()> {
-        let mut lock = self.transport.error_stream().await.write().await;
+        let transport_map = self.transport_map.read().await;
+        let transport = transport_map.get(DEFAULT_STREAM_ID).ok_or(
+            RpcError::internal_error()
+                .with_message("transport stream does not exists or is closed!".to_string()),
+        )?;
+        let mut lock = transport.error_stream().write().await;
+
         if let Some(IoStream::Writable(stderr)) = lock.as_mut() {
             stderr.write_all(message.as_bytes()).await?;
             stderr.write_all(b"\n").await?;
@@ -135,6 +190,218 @@ impl McpServer for ServerRuntime {
 }
 
 impl ServerRuntime {
+    pub(crate) async fn consume_payload_string(
+        &self,
+        stream_id: &str,
+        payload: &str,
+    ) -> SdkResult<()> {
+        let transport_map = self.transport_map.read().await;
+
+        let transport = transport_map.get(stream_id).ok_or(
+            RpcError::internal_error()
+                .with_message("stream id does not exists or is closed!".to_string()),
+        )?;
+
+        transport.consume_string_payload(payload).await?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn handle_message(
+        &self,
+        message: ClientMessage,
+        transport: &Arc<
+            dyn TransportDispatcher<
+                ClientMessages,
+                MessageFromServer,
+                ClientMessage,
+                ServerMessages,
+                ServerMessage,
+            >,
+        >,
+    ) -> SdkResult<Option<ServerMessage>> {
+        let response = match message {
+            // Handle a client request
+            ClientMessage::Request(client_jsonrpc_request) => {
+                let result = self
+                    .handler
+                    .handle_request(client_jsonrpc_request.request, self)
+                    .await;
+                // create a response to send back to the client
+                let response: MessageFromServer = match result {
+                    Ok(success_value) => success_value.into(),
+                    Err(error_value) => {
+                        // Error occurred during initialization.
+                        // A likely cause could be an unsupported protocol version.
+                        if !self.is_initialized() {
+                            return Err(error_value.into());
+                        }
+                        MessageFromServer::Error(error_value)
+                    }
+                };
+
+                let mpc_message: ServerMessage =
+                    ServerMessage::from_message(response, Some(client_jsonrpc_request.id))?;
+
+                Some(mpc_message)
+            }
+            ClientMessage::Notification(client_jsonrpc_notification) => {
+                self.handler
+                    .handle_notification(client_jsonrpc_notification.notification, self)
+                    .await?;
+                None
+            }
+            ClientMessage::Error(jsonrpc_error) => {
+                self.handler.handle_error(jsonrpc_error.error, self).await?;
+                None
+            }
+            // The response is the result of a request, it is processed at the transport level.
+            ClientMessage::Response(response) => {
+                if let Some(tx_response) = transport.pending_request_tx(&response.id).await {
+                    tx_response
+                        .send(ClientMessage::Response(response))
+                        .map_err(|e| RpcError::internal_error().with_message(e.to_string()))?;
+                } else {
+                    tracing::warn!(
+                        "Received response or error without a matching request: {:?}",
+                        &response.id
+                    );
+                }
+                None
+            }
+        };
+        Ok(response)
+    }
+
+    pub(crate) async fn store_transport(
+        &self,
+        stream_id: &str,
+        transport: Arc<
+            dyn TransportDispatcher<
+                ClientMessages,
+                MessageFromServer,
+                ClientMessage,
+                ServerMessages,
+                ServerMessage,
+            >,
+        >,
+    ) -> SdkResult<()> {
+        let mut transport_map = self.transport_map.write().await;
+        tracing::trace!("save transport for stream id : {}", stream_id);
+        transport_map.insert(stream_id.to_string(), transport);
+        Ok(())
+    }
+
+    pub(crate) async fn remove_transport(&self, stream_id: &str) -> SdkResult<()> {
+        let mut transport_map = self.transport_map.write().await;
+        tracing::trace!("removing transport for stream id : {}", stream_id);
+        transport_map.remove(stream_id);
+        Ok(())
+    }
+
+    pub(crate) async fn transport_by_stream(
+        &self,
+        stream_id: &str,
+    ) -> SdkResult<
+        Arc<
+            dyn TransportDispatcher<
+                ClientMessages,
+                MessageFromServer,
+                ClientMessage,
+                ServerMessages,
+                ServerMessage,
+            >,
+        >,
+    > {
+        let transport_map = self.transport_map.read().await;
+        transport_map.get(stream_id).cloned().ok_or_else(|| {
+            RpcError::internal_error()
+                .with_message(format!("Transport for key {stream_id} not found"))
+                .into()
+        })
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let mut transport_map = self.transport_map.write().await;
+        let items: Vec<_> = transport_map.drain().map(|(_, v)| v).collect();
+        drop(transport_map);
+        for item in items {
+            let _ = item.shut_down().await;
+        }
+    }
+
+    pub(crate) async fn stream_id_exists(&self, stream_id: &str) -> bool {
+        let transport_map = self.transport_map.read().await;
+        transport_map.contains_key(stream_id)
+    }
+
+    pub(crate) async fn start_stream(
+        self: Arc<Self>,
+        transport: impl TransportDispatcher<
+            ClientMessages,
+            MessageFromServer,
+            ClientMessage,
+            ServerMessages,
+            ServerMessage,
+        >,
+        stream_id: &str,
+        ping_interval: Duration,
+        payload: Option<String>,
+    ) -> SdkResult<()> {
+        let mut stream = transport.start().await?;
+
+        self.store_transport(stream_id, Arc::new(transport)).await?;
+
+        let transport = self.transport_by_stream(stream_id).await?;
+
+        let (disconnect_tx, mut disconnect_rx) = oneshot::channel::<()>();
+        let _ = transport.keep_alive(ping_interval, disconnect_tx).await;
+
+        // in case there is a payload, we consume it by transport to get processed
+        if let Some(payload) = payload {
+            transport.consume_string_payload(&payload).await?;
+        }
+
+        loop {
+            tokio::select! {
+                Some(mcp_messages) = stream.next() =>{
+
+                    match mcp_messages {
+                        ClientMessages::Single(client_message) => {
+                            let result = self.handle_message(client_message, &transport).await?;
+                            if let Some(result) = result {
+                                transport.send_message(ServerMessages::Single(result), None).await?;
+                            }
+                        }
+                        ClientMessages::Batch(client_messages) => {
+
+                            let handling_tasks: Vec<_> = client_messages
+                                .into_iter()
+                                .map(|client_message| self.handle_message(client_message, &transport))
+                                .collect();
+
+                            let results: Vec<_> = try_join_all(handling_tasks).await?;
+
+                            let results: Vec<_> = results.into_iter().flatten().collect();
+
+
+                            if !results.is_empty() {
+                                transport.send_message(ServerMessages::Batch(results), None).await?;
+                            }
+                        }
+                    }
+
+                }
+                _ = &mut disconnect_rx => {
+                                self.remove_transport(stream_id).await?;
+                                // Disconnection detected by keep-alive task
+                                return Err(SdkError::connection_closed().into());
+
+                }
+            }
+        }
+    }
+
     #[cfg(feature = "hyper-server")]
     pub(crate) async fn session_id(&self) -> Option<SessionId> {
         self.session_id.to_owned()
@@ -143,31 +410,38 @@ impl ServerRuntime {
     #[cfg(feature = "hyper-server")]
     pub(crate) fn new_instance(
         server_details: Arc<InitializeResult>,
-        transport: impl Transport<ClientMessage, MessageFromServer>,
         handler: Arc<dyn McpServerHandler>,
         session_id: SessionId,
     ) -> Self {
         Self {
             server_details,
             client_details: Arc::new(RwLock::new(None)),
-            transport: Box::new(transport),
             handler,
             session_id: Some(session_id),
+            transport_map: tokio::sync::RwLock::new(HashMap::new()),
         }
     }
 
     pub(crate) fn new(
         server_details: InitializeResult,
-        transport: impl Transport<ClientMessage, MessageFromServer>,
+        transport: impl TransportDispatcher<
+            ClientMessages,
+            MessageFromServer,
+            ClientMessage,
+            ServerMessages,
+            ServerMessage,
+        >,
         handler: Arc<dyn McpServerHandler>,
     ) -> Self {
+        let mut map: HashMap<String, TransportType> = HashMap::new();
+        map.insert(DEFAULT_STREAM_ID.to_string(), Arc::new(transport));
         Self {
             server_details: Arc::new(server_details),
             client_details: Arc::new(RwLock::new(None)),
-            transport: Box::new(transport),
             handler,
             #[cfg(feature = "hyper-server")]
             session_id: None,
+            transport_map: tokio::sync::RwLock::new(map),
         }
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 
 use crate::schema::{
     schema_utils::{
-        self, CallToolError, ClientMessage, MessageFromServer, NotificationFromClient,
-        RequestFromClient, ResultFromServer,
+        self, CallToolError, ClientMessage, ClientMessages, MessageFromServer,
+        NotificationFromClient, RequestFromClient, ResultFromServer, ServerMessage, ServerMessages,
     },
     CallToolResult, ClientNotification, ClientRequest, InitializeResult, RpcError,
 };
 use async_trait::async_trait;
-use rust_mcp_transport::Transport;
+
+use rust_mcp_transport::TransportDispatcher;
 
 use super::ServerRuntime;
 #[cfg(feature = "hyper-server")]
@@ -40,7 +41,13 @@ use crate::{
 /// [Repository Example](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/hello-world-mcp-server)
 pub fn create_server(
     server_details: InitializeResult,
-    transport: impl Transport<ClientMessage, MessageFromServer>,
+    transport: impl TransportDispatcher<
+        ClientMessages,
+        MessageFromServer,
+        ClientMessage,
+        ServerMessages,
+        ServerMessage,
+    >,
     handler: impl ServerHandler,
 ) -> ServerRuntime {
     ServerRuntime::new(
@@ -53,11 +60,10 @@ pub fn create_server(
 #[cfg(feature = "hyper-server")]
 pub(crate) fn create_server_instance(
     server_details: Arc<InitializeResult>,
-    transport: impl Transport<ClientMessage, MessageFromServer>,
     handler: Arc<dyn McpServerHandler>,
     session_id: SessionId,
 ) -> ServerRuntime {
-    ServerRuntime::new_instance(server_details, transport, handler, session_id)
+    ServerRuntime::new_instance(server_details, handler, session_id)
 }
 
 pub(crate) struct ServerRuntimeInternalHandler<H> {

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
@@ -1,19 +1,19 @@
-use std::sync::Arc;
-
-use crate::schema::schema_utils::{
-    self, ClientMessage, MessageFromServer, NotificationFromClient, RequestFromClient,
-    ResultFromServer,
-};
-use crate::schema::{ClientRequest, InitializeResult, RpcError};
-use async_trait::async_trait;
-use rust_mcp_transport::Transport;
-
+use super::ServerRuntime;
 use crate::error::SdkResult;
 use crate::mcp_handlers::mcp_server_handler_core::ServerHandlerCore;
 use crate::mcp_traits::mcp_handler::McpServerHandler;
 use crate::mcp_traits::mcp_server::McpServer;
-
-use super::ServerRuntime;
+use crate::schema::schema_utils::{
+    self, ClientMessage, MessageFromServer, NotificationFromClient, RequestFromClient,
+    ResultFromServer, ServerMessage,
+};
+use crate::schema::{
+    schema_utils::{ClientMessages, ServerMessages},
+    ClientRequest, InitializeResult, RpcError,
+};
+use async_trait::async_trait;
+use rust_mcp_transport::TransportDispatcher;
+use std::sync::Arc;
 
 /// Creates a new MCP server runtime with the specified configuration.
 ///
@@ -35,7 +35,13 @@ use super::ServerRuntime;
 /// [Repository Example](https://github.com/rust-mcp-stack/rust-mcp-sdk/tree/main/examples/hello-world-mcp-server-core)
 pub fn create_server(
     server_details: InitializeResult,
-    transport: impl Transport<ClientMessage, MessageFromServer>,
+    transport: impl TransportDispatcher<
+        ClientMessages,
+        MessageFromServer,
+        ClientMessage,
+        ServerMessages,
+        ServerMessage,
+    >,
     handler: impl ServerHandlerCore,
 ) -> ServerRuntime {
     ServerRuntime::new(

--- a/crates/rust-mcp-sdk/tests/check_imports.rs
+++ b/crates/rust-mcp-sdk/tests/check_imports.rs
@@ -1,0 +1,85 @@
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::{self, Read};
+    use std::path::Path;
+
+    // List of files to exclude from the check
+    const EXCLUDED_FILES: &[&str] = &["src/schema.rs"];
+
+    // Check all .rs files for incorrect `use rust_mcp_schema` imports
+    #[test]
+    fn check_no_rust_mcp_schema_imports() {
+        let mut errors = Vec::new();
+
+        // Walk through the src directory
+        for entry in walk_src_dir("src").expect("Failed to read src directory") {
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            // only check files with .rs extension
+            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                let abs_path = path.to_string_lossy();
+                let relative_path = path.strip_prefix("src").unwrap_or(&path);
+                let path_str = relative_path.to_string_lossy();
+
+                // Skip excluded files
+                if EXCLUDED_FILES.iter().any(|&excluded| abs_path == excluded) {
+                    continue;
+                }
+
+                // Read the file content
+                match read_file(&path) {
+                    Ok(content) => {
+                        // Check for `use rust_mcp_schema`
+                        if content.contains("use rust_mcp_schema") {
+                            errors.push(format!(
+                                "File {} contains `use rust_mcp_schema`. Use `use crate::schema` instead.",
+                                abs_path
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        errors.push(format!("Failed to read file `{}`: {}", path_str, e));
+                    }
+                }
+            }
+        }
+
+        // If there are any errors, fail the test with all error messages
+        if !errors.is_empty() {
+            panic!(
+                "Found {} incorrect imports:\n{}\n\n",
+                errors.len(),
+                errors.join("\n")
+            );
+        }
+    }
+
+    // Helper function to walk the src directory
+    fn walk_src_dir<P: AsRef<Path>>(
+        path: P,
+    ) -> io::Result<impl Iterator<Item = io::Result<std::fs::DirEntry>>> {
+        Ok(std::fs::read_dir(path)?.flat_map(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                // Recursively walk subdirectories
+                walk_src_dir(&path)
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            } else {
+                vec![Ok(entry)]
+            }
+        }))
+    }
+
+    // Helper function to read file content
+    fn read_file(path: &Path) -> io::Result<String> {
+        let mut file = File::open(path)?;
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        Ok(content)
+    }
+}

--- a/crates/rust-mcp-sdk/tests/check_imports.rs
+++ b/crates/rust-mcp-sdk/tests/check_imports.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::fs::File;
     use std::io::{self, Read};
-    use std::path::Path;
+    use std::path::{Path, MAIN_SEPARATOR_STR};
 
     // List of files to exclude from the check
     const EXCLUDED_FILES: &[&str] = &["src/schema.rs"];
@@ -24,7 +24,10 @@ mod tests {
                 let path_str = relative_path.to_string_lossy();
 
                 // Skip excluded files
-                if EXCLUDED_FILES.iter().any(|&excluded| abs_path == excluded) {
+                if EXCLUDED_FILES
+                    .iter()
+                    .any(|&excluded| abs_path.replace(MAIN_SEPARATOR_STR, "/") == excluded)
+                {
                     continue;
                 }
 

--- a/crates/rust-mcp-sdk/tests/common/common.rs
+++ b/crates/rust-mcp-sdk/tests/common/common.rs
@@ -1,8 +1,15 @@
 mod test_server;
 use async_trait::async_trait;
+use reqwest::{Client, Response, Url};
+use rust_mcp_macros::{mcp_tool, JsonSchema};
 use rust_mcp_schema::ProtocolVersion;
 use rust_mcp_sdk::mcp_client::ClientHandler;
+
 use rust_mcp_sdk::schema::{ClientCapabilities, Implementation, InitializeRequestParams};
+use std::collections::HashMap;
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio_stream::StreamExt;
 
 pub use test_server::*;
 
@@ -10,6 +17,164 @@ pub const NPX_SERVER_EVERYTHING: &str = "@modelcontextprotocol/server-everything
 
 #[cfg(unix)]
 pub const UVX_SERVER_GIT: &str = "mcp-server-git";
+
+#[mcp_tool(
+    name = "say_hello",
+    description = "Accepts a person's name and says a personalized \"Hello\" to that person",
+    title = "A tool that says hello!",
+    idempotent_hint = false,
+    destructive_hint = false,
+    open_world_hint = false,
+    read_only_hint = false,
+    meta = r#"{"version": "1.0"}"#
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct SayHelloTool {
+    /// The name of the person to greet with a "Hello".
+    name: String,
+}
+
+pub async fn send_post_request(
+    base_url: &str,
+    message: &str,
+    session_id: Option<&str>,
+    post_headers: Option<HashMap<&str, &str>>,
+) -> Result<Response, reqwest::Error> {
+    let client = Client::new();
+    let url = Url::parse(base_url).expect("Invalid URL");
+
+    let mut headers = reqwest::header::HeaderMap::new();
+
+    let protocol_version = ProtocolVersion::V2025_06_18.to_string();
+    let post_headers = post_headers.unwrap_or({
+        let mut map: HashMap<&str, &str> = HashMap::new();
+        map.insert("Content-Type", "application/json");
+        map.insert("Accept", "application/json, text/event-stream");
+        map.insert("mcp-protocol-version", protocol_version.as_str());
+        map
+    });
+
+    if let Some(sid) = session_id {
+        headers.insert("mcp-session-id", sid.parse().unwrap());
+    }
+
+    for (key, value) in post_headers {
+        headers.insert(
+            reqwest::header::HeaderName::from_bytes(key.as_bytes()).unwrap(),
+            value.parse().unwrap(),
+        );
+    }
+
+    let body = message.to_string();
+
+    client.post(url).headers(headers).body(body).send().await
+}
+
+pub async fn send_delete_request(
+    base_url: &str,
+    session_id: Option<&str>,
+    post_headers: Option<HashMap<&str, &str>>,
+) -> Result<Response, reqwest::Error> {
+    let client = Client::new();
+    let url = Url::parse(base_url).expect("Invalid URL");
+
+    let mut headers = reqwest::header::HeaderMap::new();
+
+    let protocol_version = ProtocolVersion::V2025_06_18.to_string();
+    let post_headers = post_headers.unwrap_or({
+        let mut map: HashMap<&str, &str> = HashMap::new();
+        map.insert("Content-Type", "application/json");
+        map.insert("Accept", "application/json, text/event-stream");
+        map.insert("mcp-protocol-version", protocol_version.as_str());
+        map
+    });
+
+    if let Some(sid) = session_id {
+        headers.insert("mcp-session-id", sid.parse().unwrap());
+    }
+
+    for (key, value) in post_headers {
+        headers.insert(
+            reqwest::header::HeaderName::from_bytes(key.as_bytes()).unwrap(),
+            value.parse().unwrap(),
+        );
+    }
+
+    client.delete(url).headers(headers).send().await
+}
+
+pub async fn send_get_request(
+    base_url: &str,
+    extra_headers: Option<HashMap<&str, &str>>,
+) -> Result<Response, reqwest::Error> {
+    let client = Client::new();
+    let url = Url::parse(base_url).expect("Invalid URL");
+
+    let mut headers = reqwest::header::HeaderMap::new();
+
+    if let Some(extra) = extra_headers {
+        for (key, value) in extra {
+            headers.insert(
+                reqwest::header::HeaderName::from_bytes(key.as_bytes()).unwrap(),
+                value.parse().unwrap(),
+            );
+        }
+    }
+    client.get(url).headers(headers).send().await
+}
+
+use futures::stream::Stream;
+
+// stream: &mut impl Stream<Item = Result<hyper::body::Bytes, hyper::Error>>,
+pub async fn read_sse_event_from_stream(
+    stream: &mut (impl Stream<Item = Result<hyper::body::Bytes, reqwest::Error>> + Unpin),
+) -> Option<String> {
+    let mut buffer = String::new();
+
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(chunk) => {
+                let chunk_str = std::str::from_utf8(&chunk).unwrap();
+                buffer.push_str(chunk_str);
+
+                while let Some(pos) = buffer.find("\n\n") {
+                    let data = {
+                        // Scope to limit borrows
+                        let (event_str, rest) = buffer.split_at(pos);
+                        let mut data = None;
+
+                        // Process the event string
+                        for line in event_str.lines() {
+                            if line.starts_with("data:") {
+                                data = Some(line.trim_start_matches("data:").trim().to_string());
+                                break; // Exit loop after finding data
+                            }
+                        }
+
+                        // Update buffer after processing
+                        buffer = rest[2..].to_string(); // Skip "\n\n"
+                        data
+                    };
+
+                    // Return if data was found
+                    if let Some(data) = data {
+                        return Some(data);
+                    }
+                }
+            }
+            Err(_e) => {
+                // return Err(TransportServerError::HyperError(e));
+                return None;
+            }
+        }
+    }
+    None
+}
+
+pub async fn read_sse_event(response: Response) -> Option<String> {
+    let mut stream = response.bytes_stream();
+    read_sse_event_from_stream(&mut stream).await
+}
 
 pub fn test_client_info() -> InitializeRequestParams {
     InitializeRequestParams {
@@ -37,6 +202,72 @@ pub fn sse_data(sse_raw: &str) -> String {
     sse_raw.replace("data: ", "")
 }
 
+// Simple Xorshift PRNG struct
+struct Xorshift {
+    state: u64,
+}
+
+impl Xorshift {
+    // Initialize with a seed based on system time and process ID
+    fn new() -> Self {
+        // Get nanoseconds since UNIX epoch
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time error")
+            .as_nanos() as u64;
+        // Get process ID for additional entropy
+        let pid = process::id() as u64;
+        // Combine nanos and pid with a simple mix
+        let seed = nanos ^ (pid << 32) ^ (nanos.rotate_left(17));
+        Xorshift { state: seed | 1 } // Ensure non-zero seed
+    }
+
+    // Generate the next random u64 using Xorshift
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    // Generate a random u16 within a range [min, max]
+    fn next_u16_range(&mut self, min: u16, max: u16) -> u16 {
+        assert!(max >= min, "max must be greater than or equal to min");
+        let range = (max - min + 1) as u64;
+        min + (self.next_u64() % range) as u16
+    }
+}
+
+// Generate a random port number in the range [8081, 15000]
+pub fn random_port() -> u16 {
+    const MIN_PORT: u16 = 8081;
+    const MAX_PORT: u16 = 15000;
+
+    let mut rng = Xorshift::new();
+    rng.next_u16_range(MIN_PORT, MAX_PORT)
+}
+
+pub fn random_port_old() -> u16 {
+    let min: u16 = 8081;
+    let max: u16 = 15000;
+    let range = max - min + 1;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("systime error!");
+
+    // Combine seconds and nanoseconds for better entropy
+    let nanos = now.subsec_nanos() as u64;
+    let secs = now.as_secs();
+
+    // Simple hash-like mix
+    let mixed = (nanos ^ (secs << 16)) ^ (nanos.rotate_left(13));
+
+    min + ((mixed as u16) % range)
+}
+
 pub mod sample_tools {
     #[cfg(feature = "2025_06_18")]
     use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
@@ -56,7 +287,7 @@ pub mod sample_tools {
     #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
     pub struct SayHelloTool {
         /// The name of the person to greet with a "Hello".
-        name: String,
+        pub name: String,
     }
 
     impl SayHelloTool {

--- a/crates/rust-mcp-sdk/tests/test_client_runtime.rs
+++ b/crates/rust-mcp-sdk/tests/test_client_runtime.rs
@@ -43,9 +43,7 @@ async fn tets_client_launch_uvx_server() {
     .unwrap();
 
     let client = client_runtime::create_client(test_client_info(), transport, TestClientHandler {});
-
     client.clone().start().await.unwrap();
-
     let server_capabilities = client.server_capabilities().unwrap();
     let server_info = client.server_info().unwrap();
 

--- a/crates/rust-mcp-sdk/tests/test_streamable_http.rs
+++ b/crates/rust-mcp-sdk/tests/test_streamable_http.rs
@@ -1,0 +1,1254 @@
+use std::{collections::HashMap, error::Error, sync::Arc, time::Duration, vec};
+
+use hyper::StatusCode;
+use rust_mcp_schema::{
+    schema_utils::{
+        ClientJsonrpcRequest, ClientMessage, ClientMessages, FromMessage, NotificationFromServer,
+        ResultFromServer, RpcMessage, SdkError, SdkErrorCodes, ServerJsonrpcNotification,
+        ServerJsonrpcResponse, ServerMessages,
+    },
+    CallToolRequest, CallToolRequestParams, ListToolsRequest, LoggingLevel,
+    LoggingMessageNotificationParams, RequestId, RootsListChangedNotification, ServerNotification,
+    ServerResult,
+};
+use rust_mcp_sdk::mcp_server::HyperServerOptions;
+use serde_json::{json, Map, Value};
+use tokio_stream::StreamExt;
+
+use crate::common::{
+    random_port, read_sse_event, read_sse_event_from_stream, send_delete_request, send_get_request,
+    send_post_request,
+    test_server_common::{
+        create_start_server, initialize_request, LaunchedServer, TestIdGenerator,
+    },
+};
+
+#[path = "common/common.rs"]
+pub mod common;
+
+const ONE_MILLISECOND: Option<Duration> = Some(Duration::from_millis(1));
+
+async fn initialize_server(
+    enable_json_response: Option<bool>,
+) -> Result<(LaunchedServer, String), Box<dyn Error>> {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: random_port(),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        enable_json_response,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    let session_id = response
+        .headers()
+        .get("mcp-session-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    Ok((server, session_id))
+}
+
+// should initialize server and generate session ID
+#[tokio::test]
+async fn should_initialize_server_and_generate_session_id() {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: random_port(),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+    assert!(response.headers().get("mcp-session-id").is_some());
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject batch initialize request
+#[tokio::test]
+async fn should_reject_batch_initialize_request() {
+    let server_options = HyperServerOptions {
+        port: random_port(),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        enable_json_response: None,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let first_init_message = ClientJsonrpcRequest::new(
+        RequestId::String("first-init".to_string()),
+        initialize_request().into(),
+    );
+    let second_init_message = ClientJsonrpcRequest::new(
+        RequestId::String("second-init".to_string()),
+        initialize_request().into(),
+    );
+
+    let messages = vec![
+        ClientMessage::Request(first_init_message),
+        ClientMessage::Request(second_init_message),
+    ];
+    let batch_message = ClientMessages::Batch(messages);
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&batch_message).unwrap(),
+        None,
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    let error_data: SdkError = response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::INVALID_REQUEST as i64);
+    assert!(error_data
+        .message
+        .contains("Only one initialization request is allowed"));
+}
+
+// should handle post requests via sse response correctly
+#[tokio::test]
+async fn should_handle_post_requests_via_sse_response_correctly() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let event = read_sse_event(response).await.unwrap();
+    let message: ServerJsonrpcResponse = serde_json::from_str(&event).unwrap();
+
+    assert!(matches!(message.id, RequestId::Integer(1)));
+
+    let ResultFromServer::ServerResult(ServerResult::ListToolsResult(result)) = message.result
+    else {
+        panic!("invalid ListToolsResult")
+    };
+
+    assert_eq!(result.tools.len(), 1);
+
+    let tool = &result.tools[0];
+    assert_eq!(tool.name, "say_hello");
+    assert_eq!(
+        tool.description.as_ref().unwrap(),
+        r#"Accepts a person's name and says a personalized "Hello" to that person"#
+    );
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should call a tool and return the result
+#[tokio::test]
+async fn should_call_a_tool_and_return_the_result() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut map = Map::new();
+    map.insert("name".to_string(), Value::String("Ali".to_string()));
+
+    let json_rpc_message: ClientJsonrpcRequest = ClientJsonrpcRequest::new(
+        RequestId::Integer(1),
+        CallToolRequest::new(CallToolRequestParams {
+            arguments: Some(map),
+            name: "say_hello".to_string(),
+        })
+        .into(),
+    );
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let event = read_sse_event(response).await.unwrap();
+    let message: ServerJsonrpcResponse = serde_json::from_str(&event).unwrap();
+
+    assert!(matches!(message.id, RequestId::Integer(1)));
+
+    let ResultFromServer::ServerResult(ServerResult::CallToolResult(result)) = message.result
+    else {
+        panic!("invalid CallToolResult")
+    };
+
+    assert_eq!(result.content.len(), 1);
+    assert_eq!(
+        result.content[0].as_text_content().unwrap().text,
+        "Hello, Ali!"
+    );
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject requests without a valid session ID
+#[tokio::test]
+async fn should_reject_requests_without_a_valid_session_id() {
+    let (server, _session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None, // pass no session id
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error_data: SdkError = response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject invalid session ID
+#[tokio::test]
+async fn should_reject_invalid_session_id() {
+    let (server, _session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some("invalid-session-id"),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let error_data: SdkError = response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::SESSION_NOT_FOUND as i64); // Typescript sdk uses -32001 code
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+async fn get_standalone_stream(streamable_url: &str, session_id: &str) -> reqwest::Response {
+    let mut headers = HashMap::new();
+    headers.insert("Accept", "text/event-stream , application/json");
+    headers.insert("mcp-session-id", session_id);
+    headers.insert("mcp-protocol-version", "2025-03-26");
+
+    let response = send_get_request(streamable_url, Some(headers))
+        .await
+        .unwrap();
+    response
+}
+
+// should establish standalone SSE stream and receive server-initiated messages
+#[tokio::test]
+async fn should_establish_standalone_stream_and_receive_server_messages() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+    let response = get_standalone_stream(&server.streamable_url, &session_id).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert_eq!(
+        response
+            .headers()
+            .get("mcp-session-id")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        session_id
+    );
+
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "text/event-stream"
+    );
+
+    // Send a notification (server-initiated message) that should appear on SSE stream
+    server
+        .hyper_runtime
+        .send_logging_message(
+            &session_id,
+            LoggingMessageNotificationParams {
+                data: json!("Test notification"),
+                level: rust_mcp_schema::LoggingLevel::Info,
+                logger: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let event = read_sse_event(response).await.unwrap();
+    let message: ServerJsonrpcNotification = serde_json::from_str(&event).unwrap();
+
+    let NotificationFromServer::ServerNotification(ServerNotification::LoggingMessageNotification(
+        notification,
+    )) = message.notification
+    else {
+        panic!("invalid message received!");
+    };
+
+    assert_eq!(notification.params.level, LoggingLevel::Info);
+    assert_eq!(
+        notification.params.data.as_str().unwrap(),
+        "Test notification"
+    );
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should not close GET SSE stream after sending multiple server notifications
+#[tokio::test]
+async fn should_not_close_get_sse_stream() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+    let response = get_standalone_stream(&server.streamable_url, &session_id).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    server
+        .hyper_runtime
+        .send_logging_message(
+            &session_id,
+            LoggingMessageNotificationParams {
+                data: json!("First notification"),
+                level: rust_mcp_schema::LoggingLevel::Info,
+                logger: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut stream = response.bytes_stream();
+    let event = read_sse_event_from_stream(&mut stream).await.unwrap();
+    let message: ServerJsonrpcNotification = serde_json::from_str(&event).unwrap();
+
+    let NotificationFromServer::ServerNotification(ServerNotification::LoggingMessageNotification(
+        notification,
+    )) = message.notification
+    else {
+        panic!("invalid message received!");
+    };
+
+    assert_eq!(notification.params.level, LoggingLevel::Info);
+    assert_eq!(
+        notification.params.data.as_str().unwrap(),
+        "First notification"
+    );
+
+    server
+        .hyper_runtime
+        .send_logging_message(
+            &session_id,
+            LoggingMessageNotificationParams {
+                data: json!("Second notification"),
+                level: rust_mcp_schema::LoggingLevel::Info,
+                logger: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let event = read_sse_event_from_stream(&mut stream).await.unwrap();
+    let message: ServerJsonrpcNotification = serde_json::from_str(&event).unwrap();
+
+    let NotificationFromServer::ServerNotification(ServerNotification::LoggingMessageNotification(
+        notification_2,
+    )) = message.notification
+    else {
+        panic!("invalid message received!");
+    };
+
+    assert_eq!(notification_2.params.level, LoggingLevel::Info);
+    assert_eq!(
+        notification_2.params.data.as_str().unwrap(),
+        "Second notification"
+    );
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+//should reject second SSE stream for the same session
+#[tokio::test]
+async fn should_reject_second_sse_stream_for_the_same_session() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+    let response = get_standalone_stream(&server.streamable_url, &session_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let second_response = get_standalone_stream(&server.streamable_url, &session_id).await;
+    assert_eq!(second_response.status(), StatusCode::CONFLICT);
+
+    let error_data: SdkError = second_response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject GET requests without Accept: text/event-stream header
+#[tokio::test]
+async fn should_reject_get_requests() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Accept", "application/json");
+    headers.insert("mcp-session-id", &session_id);
+    headers.insert("mcp-protocol-version", "2025-03-26");
+
+    let response = send_get_request(&server.streamable_url, Some(headers))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE); //406
+    let error_data: SdkError = response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+    assert!(error_data.message.contains("must accept text/event-stream"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject POST requests without proper Accept header
+#[tokio::test]
+async fn reject_post_requests_without_accept_header() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let mut headers = HashMap::new();
+    headers.insert("Accept", "application/json");
+    headers.insert("mcp-session-id", &session_id);
+    headers.insert("mcp-protocol-version", "2025-03-26");
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE); //406
+
+    let error_data: SdkError = response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+    assert!(error_data
+        .message
+        .contains("must accept both application/json and text/event-stream"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+//should reject unsupported Content-Type
+#[tokio::test]
+async fn should_reject_unsupported_content_type() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "text/plain");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("mcp-session-id", &session_id);
+    headers.insert("mcp-protocol-version", "2025-03-26");
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE); //415
+
+    let error_data: SdkError = response.json().await.unwrap();
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+    assert!(error_data
+        .message
+        .contains("Content-Type must be application/json"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+//TODO: move deserialization logic out of mcp_stream.rs
+// should handle JSON-RPC batch notification messages with 202 response
+// #[tokio::test]
+// async fn should_handle_batch_notification_messages_with_202_response() {
+//     let (server, session_id) = initialize_server(None).await.unwrap();
+
+//     let batch_notification = ClientMessages::Batch(vec![
+//         RootsListChangedNotification::new(None).into(),
+//         RootsListChangedNotification::new(None).into(),
+//     ]);
+
+//     let response = send_post_request(
+//         &server.streamable_url,
+//         &serde_json::to_string(&batch_notification).unwrap(),
+//         Some(&session_id),
+//         None,
+//     )
+//     .await
+//     .expect("Request failed");
+//     assert_eq!(response.status(), StatusCode::ACCEPTED);
+// }
+
+// should send response messages to the connection that sent the request
+#[tokio::test]
+async fn should_send_response_messages_to_the_connection_that_sent_the_request() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message_1: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let mut map = Map::new();
+    map.insert("name".to_string(), Value::String("Ali".to_string()));
+
+    let json_rpc_message_2: ClientJsonrpcRequest = ClientJsonrpcRequest::new(
+        RequestId::Integer(1),
+        CallToolRequest::new(CallToolRequestParams {
+            arguments: Some(map),
+            name: "say_hello".to_string(),
+        })
+        .into(),
+    );
+
+    let response_1 = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message_1).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    let response_2 = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message_2).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response_1.status(), StatusCode::OK);
+    assert_eq!(response_2.status(), StatusCode::OK);
+
+    let event = read_sse_event(response_2).await.unwrap();
+    let message: ServerJsonrpcResponse = serde_json::from_str(&event).unwrap();
+
+    assert!(matches!(message.id, RequestId::Integer(1)));
+
+    let ResultFromServer::ServerResult(ServerResult::CallToolResult(result)) = message.result
+    else {
+        panic!("invalid CallToolResult")
+    };
+
+    assert_eq!(result.content.len(), 1);
+    assert_eq!(
+        result.content[0].as_text_content().unwrap().text,
+        "Hello, Ali!"
+    );
+
+    let event = read_sse_event(response_1).await.unwrap();
+    let message: ServerJsonrpcResponse = serde_json::from_str(&event).unwrap();
+
+    assert!(matches!(message.id, RequestId::Integer(1)));
+
+    let ResultFromServer::ServerResult(ServerResult::ListToolsResult(result)) = message.result
+    else {
+        panic!("invalid ListToolsResult")
+    };
+
+    assert_eq!(result.tools.len(), 1);
+
+    let tool = &result.tools[0];
+    assert_eq!(tool.name, "say_hello");
+    assert_eq!(
+        tool.description.as_ref().unwrap(),
+        r#"Accepts a person's name and says a personalized "Hello" to that person"#
+    );
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should properly handle DELETE requests and close session
+#[tokio::test]
+async fn should_properly_handle_delete_requests_and_close_session() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "text/plain");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("mcp-session-id", &session_id);
+    headers.insert("mcp-protocol-version", "2025-03-26");
+
+    let response = send_delete_request(&server.streamable_url, Some(&session_id), Some(headers))
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject DELETE requests with invalid session ID
+#[tokio::test]
+async fn should_reject_delete_requests_with_invalid_session_id() {
+    let (server, _session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "text/plain");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("mcp-session-id", "invalid-session-id");
+    headers.insert("mcp-protocol-version", "2025-03-26");
+
+    let response = send_delete_request(
+        &server.streamable_url,
+        Some("invalid-session-id"),
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let error_data: SdkError = response.json().await.unwrap();
+
+    assert_eq!(error_data.code, SdkErrorCodes::SESSION_NOT_FOUND as i64); // Typescript sdk uses -32001 code
+    assert!(error_data.message.contains("Session not found"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+/**
+ * protocol version header validation
+ */
+
+// should accept requests without protocol version header
+#[tokio::test]
+async fn should_accept_requests_without_protocol_version_header() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject requests with unsupported protocol version
+#[tokio::test]
+async fn should_reject_requests_with_unsupported_protocol_version() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("mcp-protocol-version", "1999-15-21");
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error_data: SdkError = response.json().await.unwrap();
+
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+    assert!(error_data.message.contains("Unsupported protocol version"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should handle protocol version validation for get requests
+#[tokio::test]
+async fn should_handle_protocol_version_validation_for_get_requests() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("mcp-protocol-version", "1999-15-21");
+    headers.insert("mcp-session-id", &session_id);
+
+    let response = send_get_request(&server.streamable_url, Some(headers))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error_data: SdkError = response.json().await.unwrap();
+
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+    assert!(error_data.message.contains("Unsupported protocol version"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should handle protocol version validation for DELETE requests
+#[tokio::test]
+async fn should_handle_protocol_version_validation_for_delete_requests() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("mcp-protocol-version", "1999-15-21");
+
+    let response = send_delete_request(&server.streamable_url, Some(&session_id), Some(headers))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error_data: SdkError = response.json().await.unwrap();
+
+    assert_eq!(error_data.code, SdkErrorCodes::BAD_REQUEST as i64); // Typescript sdk uses -32000 code
+    assert!(error_data.message.contains("Unsupported protocol version"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+/**
+ * Test JSON Response Mode
+ */
+
+// should return JSON response for a single request
+#[tokio::test]
+async fn should_return_json_response_for_a_single_request() {
+    let (server, session_id) = initialize_server(Some(true)).await.unwrap();
+
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(1), ListToolsRequest::new(None).into());
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+    assert!(response.headers().get("mcp-session-id").is_some());
+
+    let message = response.json::<ServerJsonrpcResponse>().await.unwrap();
+
+    let ResultFromServer::ServerResult(ServerResult::ListToolsResult(result)) = message.result
+    else {
+        panic!("invalid ListToolsResult")
+    };
+
+    assert_eq!(result.tools.len(), 1);
+
+    let tool = &result.tools[0];
+    assert_eq!(tool.name, "say_hello");
+    assert_eq!(
+        tool.description.as_ref().unwrap(),
+        r#"Accepts a person's name and says a personalized "Hello" to that person"#
+    );
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should return JSON response for batch requests
+#[tokio::test]
+async fn should_return_json_response_for_a_batch_request() {
+    let (server, session_id) = initialize_server(Some(true)).await.unwrap();
+
+    let json_rpc_message_1: ClientJsonrpcRequest = ClientJsonrpcRequest::new(
+        RequestId::String("req_1".to_string()),
+        ListToolsRequest::new(None).into(),
+    );
+
+    let mut map = Map::new();
+    map.insert("name".to_string(), Value::String("Ali".to_string()));
+    let json_rpc_message_3: ClientJsonrpcRequest = ClientJsonrpcRequest::new(
+        RequestId::String("req_2".to_string()),
+        CallToolRequest::new(CallToolRequestParams {
+            arguments: Some(map),
+            name: "say_hello".to_string(),
+        })
+        .into(),
+    );
+
+    let batch_message = ClientMessages::Batch(vec![
+        json_rpc_message_1.into(),
+        ClientMessage::from_message(RootsListChangedNotification::new(None), None).unwrap(),
+        json_rpc_message_3.into(),
+    ]);
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&batch_message).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+    assert!(response.headers().get("mcp-session-id").is_some());
+
+    let messages = response.json::<ServerMessages>().await.unwrap();
+
+    let ServerMessages::Batch(mut messages) = messages else {
+        panic!("Invalid message type");
+    };
+
+    assert_eq!(messages.len(), 2);
+
+    let mut results = messages.drain(0..);
+    let result_1 = results.next().unwrap();
+    assert_eq!(
+        result_1.request_id().unwrap(),
+        RequestId::String("req_1".to_string())
+    );
+    let ResultFromServer::ServerResult(ServerResult::ListToolsResult(_)) =
+        result_1.as_response().unwrap().result
+    else {
+        panic!("Expected a ListToolsResult");
+    };
+
+    let result_2 = results.next().unwrap();
+    assert_eq!(
+        result_2.request_id().unwrap(),
+        RequestId::String("req_2".to_string())
+    );
+    let ResultFromServer::ServerResult(ServerResult::CallToolResult(_)) =
+        result_2.as_response().unwrap().result
+    else {
+        panic!("Expected a CallToolResult");
+    };
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should handle batch request messages with SSE stream for responses
+#[tokio::test]
+async fn should_handle_batch_request_messages_with_sse_stream_for_responses() {
+    let (server, session_id) = initialize_server(None).await.unwrap();
+
+    let json_rpc_message_1: ClientJsonrpcRequest = ClientJsonrpcRequest::new(
+        RequestId::String("req_1".to_string()),
+        ListToolsRequest::new(None).into(),
+    );
+
+    let mut map = Map::new();
+    map.insert("name".to_string(), Value::String("Ali".to_string()));
+    let json_rpc_message_2: ClientJsonrpcRequest = ClientJsonrpcRequest::new(
+        RequestId::String("req_2".to_string()),
+        CallToolRequest::new(CallToolRequestParams {
+            arguments: Some(map),
+            name: "say_hello".to_string(),
+        })
+        .into(),
+    );
+
+    let batch_message =
+        ClientMessages::Batch(vec![json_rpc_message_1.into(), json_rpc_message_2.into()]);
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&batch_message).unwrap(),
+        Some(&session_id),
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+
+    let event = read_sse_event(response).await.unwrap();
+    let message: ServerMessages = serde_json::from_str(&event).unwrap();
+
+    let ServerMessages::Batch(mut messages) = message else {
+        panic!("Invalid message type");
+    };
+
+    assert_eq!(messages.len(), 2);
+
+    let mut results = messages.drain(0..);
+    let result_1 = results.next().unwrap();
+    assert_eq!(
+        result_1.request_id().unwrap(),
+        RequestId::String("req_1".to_string())
+    );
+    let ResultFromServer::ServerResult(ServerResult::ListToolsResult(_)) =
+        result_1.as_response().unwrap().result
+    else {
+        panic!("Expected a ListToolsResult");
+    };
+
+    let result_2 = results.next().unwrap();
+    assert_eq!(
+        result_2.request_id().unwrap(),
+        RequestId::String("req_2".to_string())
+    );
+    let ResultFromServer::ServerResult(ServerResult::CallToolResult(_)) =
+        result_2.as_response().unwrap().result
+    else {
+        panic!("Expected a CallToolResult");
+    };
+}
+
+// Test DNS rebinding protection
+
+// should accept requests with allowed host headers
+#[tokio::test]
+async fn should_accept_requests_with_allowed_host_headers() {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: 8090,
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        allowed_hosts: Some(vec!["127.0.0.1:8090".to_string()]),
+        dns_rebinding_protection: true,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+    assert!(response.headers().get("mcp-session-id").is_some());
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject requests with disallowed host headers
+#[tokio::test]
+async fn should_reject_requests_with_disallowed_host_headers() {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: random_port(),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        allowed_hosts: Some(vec!["example.com:3001".to_string()]),
+        dns_rebinding_protection: true,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        None,
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let error_data: SdkError = response.json().await.unwrap();
+    assert!(error_data.message.contains("Invalid Host header"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should reject GET requests with disallowed host headers
+#[tokio::test]
+async fn should_reject_get_requests_with_disallowed_host_headers() {
+    let server_options = HyperServerOptions {
+        port: random_port(),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        allowed_hosts: Some(vec!["example.com:3001".to_string()]),
+        dns_rebinding_protection: true,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+
+    let response = send_get_request(&server.streamable_url, Some(headers))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let error_data: SdkError = response.json().await.unwrap();
+    assert!(error_data.message.contains("Invalid Host header"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should accept requests with allowed origin headers
+#[tokio::test]
+async fn should_accept_requests_with_allowed_origin_headers() {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: 3000,
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        allowed_origins: Some(vec![
+            "http://localhost:3000".to_string(),
+            "https://example.com".to_string(),
+        ]),
+        dns_rebinding_protection: true,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    // Origin: "http://localhost:3000",
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("Origin", "http://localhost:3000");
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+    assert!(response.headers().get("mcp-session-id").is_some());
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+//should reject requests with disallowed origin headers
+#[tokio::test]
+async fn should_reject_requests_with_disallowed_origin_headers() {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: 3000,
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        allowed_origins: Some(vec!["http://localhost:3000".to_string()]),
+        dns_rebinding_protection: true,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("Origin", "http://evil.com");
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let error_data: SdkError = response.json().await.unwrap();
+
+    assert!(error_data.message.contains("Invalid Origin header"));
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}
+
+// should skip all validations when enableDnsRebindingProtection is false
+#[tokio::test]
+async fn should_skip_all_validations_when_false() {
+    let json_rpc_message: ClientJsonrpcRequest =
+        ClientJsonrpcRequest::new(RequestId::Integer(0), initialize_request().into());
+
+    let server_options = HyperServerOptions {
+        port: 3030,
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        allowed_hosts: Some(vec!["localhost".to_string()]),
+        allowed_origins: Some(vec!["http://localhost:3030".to_string()]),
+        dns_rebinding_protection: false,
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("Content-Type", "application/json");
+    headers.insert("Accept", "application/json, text/event-stream");
+    headers.insert("Origin", "http://evil.com");
+    headers.insert("Host", "evil.com");
+
+    let response = send_post_request(
+        &server.streamable_url,
+        &serde_json::to_string(&json_rpc_message).unwrap(),
+        None,
+        Some(headers),
+    )
+    .await
+    .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    server.hyper_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.hyper_runtime.await_server().await.unwrap()
+}

--- a/crates/rust-mcp-transport/README.md
+++ b/crates/rust-mcp-transport/README.md
@@ -2,8 +2,6 @@
 
 `rust-mcp-transport` is a part of the [rust-mcp-sdk](https://crates.io/crates/rust-mcp-sdk) ecosystem, offering transport implementations for the MCP (Model Context Protocol). It enables asynchronous data exchange and efficient MCP message handling between MCP Clients and Servers.
 
-**⚠️WARNING**: Currently, only Standard Input/Output (stdio) transport is supported. Server-Sent Events (SSE) transport is under development and will be available soon.
-
 ## Usage Example
 
 ### For MCP Server

--- a/crates/rust-mcp-transport/src/client_sse.rs
+++ b/crates/rust-mcp-transport/src/client_sse.rs
@@ -8,11 +8,12 @@ use crate::utils::{
 use crate::{IoStream, McpDispatch, TransportOptions};
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::Stream;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
+use tokio::sync::oneshot::Sender;
+use tokio::task::JoinHandle;
 
-use crate::schema::schema_utils::{McpMessage, RpcMessage};
+use crate::schema::schema_utils::McpMessage;
 use crate::schema::RequestId;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -54,7 +55,7 @@ impl Default for ClientSseTransportOptions {
 /// Manages SSE connections, HTTP POST requests, and message streaming for client-server communication.
 pub struct ClientSseTransport<R>
 where
-    R: RpcMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
+    R: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
 {
     /// Optional cancellation token source for shutting down the transport
     shutdown_source: tokio::sync::RwLock<Option<CancellationTokenSource>>,
@@ -76,13 +77,14 @@ where
     custom_headers: Option<HeaderMap>,
     sse_task: tokio::sync::RwLock<Option<tokio::task::JoinHandle<()>>>,
     post_task: tokio::sync::RwLock<Option<tokio::task::JoinHandle<()>>>,
-    message_sender: tokio::sync::RwLock<Option<MessageDispatcher<R>>>,
+    message_sender: Arc<tokio::sync::RwLock<Option<MessageDispatcher<R>>>>,
     error_stream: tokio::sync::RwLock<Option<IoStream>>,
+    pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<R>>>>,
 }
 
 impl<R> ClientSseTransport<R>
 where
-    R: RpcMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
+    R: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
 {
     /// Creates a new ClientSseTransport instance
     ///
@@ -97,8 +99,15 @@ where
     pub fn new(server_url: &str, options: ClientSseTransportOptions) -> TransportResult<Self> {
         let client = Client::new();
 
-        //TODO: error handling
-        let base_url = extract_origin(server_url).unwrap();
+        let base_url = match extract_origin(server_url) {
+            Some(url) => url,
+            None => {
+                let error_message =
+                    format!("Failed to extract origin from server URL: {server_url}");
+                tracing::error!(error_message);
+                return Err(TransportError::InvalidOptions(error_message));
+            }
+        };
 
         let headers = match &options.custom_headers {
             Some(h) => Some(Self::validate_headers(h)?),
@@ -119,8 +128,9 @@ where
             custom_headers: headers,
             sse_task: tokio::sync::RwLock::new(None),
             post_task: tokio::sync::RwLock::new(None),
-            message_sender: tokio::sync::RwLock::new(None),
+            message_sender: Arc::new(tokio::sync::RwLock::new(None)),
             error_stream: tokio::sync::RwLock::new(None),
+            pending_requests: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -187,10 +197,13 @@ where
 }
 
 #[async_trait]
-impl<R, S> Transport<R, S> for ClientSseTransport<R>
+impl<R, S, M, OR, OM> Transport<R, S, M, OR, OM> for ClientSseTransport<M>
 where
-    R: RpcMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
+    R: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
     S: McpMessage + Clone + Send + Sync + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
+    OR: Clone + Send + Sync + serde::Serialize + 'static,
+    OM: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
 {
     /// Starts the transport, initializing SSE and POST tasks
     ///
@@ -199,17 +212,14 @@ where
     /// # Returns
     /// * `TransportResult<(Pin<Box<dyn Stream<Item = R> + Send>>, MessageDispatcher<R>, IoStream)>`
     ///   - The message stream, dispatcher, and error stream
-    async fn start(&self) -> TransportResult<Pin<Box<dyn Stream<Item = R> + Send>>>
+    async fn start(&self) -> TransportResult<tokio_stream::wrappers::ReceiverStream<R>>
     where
-        MessageDispatcher<R>: McpDispatch<R, S>,
+        MessageDispatcher<M>: McpDispatch<R, OR, M, OM>,
     {
         // Create CancellationTokenSource and token
         let (cancellation_source, cancellation_token) = CancellationTokenSource::new();
         let mut lock = self.shutdown_source.write().await;
         *lock = Some(cancellation_source);
-
-        let pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<R>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
 
         let (write_tx, mut write_rx) = mpsc::channel::<Bytes>(DEFAULT_CHANNEL_CAPACITY);
         let (read_tx, read_rx) = mpsc::channel::<Bytes>(DEFAULT_CHANNEL_CAPACITY);
@@ -302,7 +312,7 @@ where
             readable,
             writable,
             IoStream::Writable(Box::pin(tokio::io::stderr())),
-            pending_requests,
+            self.pending_requests.clone(),
             self.request_timeout,
             cancellation_token,
         );
@@ -316,12 +326,29 @@ where
         Ok(stream)
     }
 
-    async fn message_sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
-        &self.message_sender as _
+    fn message_sender(&self) -> Arc<tokio::sync::RwLock<Option<MessageDispatcher<M>>>> {
+        self.message_sender.clone() as _
     }
 
-    async fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+    fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
         &self.error_stream as _
+    }
+
+    async fn consume_string_payload(&self, _payload: &str) -> TransportResult<()> {
+        Err(TransportError::FromString(
+            "Invalid invocation of consume_string_payload() function for ClientSseTransport"
+                .to_string(),
+        ))
+    }
+
+    async fn keep_alive(
+        &self,
+        _: Duration,
+        _: oneshot::Sender<()>,
+    ) -> TransportResult<JoinHandle<()>> {
+        Err(TransportError::FromString(
+            "Invalid invocation of keep_alive() function for ClientSseTransport".to_string(),
+        ))
     }
 
     /// Checks if the transport has been shut down
@@ -379,5 +406,10 @@ where
                 Err(TransportError::ShutdownTimeout)
             }
         }
+    }
+
+    async fn pending_request_tx(&self, request_id: &RequestId) -> Option<Sender<M>> {
+        let mut pending_requests = self.pending_requests.lock().await;
+        pending_requests.remove(request_id)
     }
 }

--- a/crates/rust-mcp-transport/src/error.rs
+++ b/crates/rust-mcp-transport/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use crate::utils::CancellationError;
 use core::fmt;
 use std::any::Any;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 
 /// A wrapper around a broadcast send error. This structure allows for generic error handling
 /// by boxing the underlying error into a type-erased form.
@@ -15,7 +15,7 @@ pub struct GenericSendError {
 
 #[allow(unused)]
 impl GenericSendError {
-    pub fn new<T: Send + 'static>(error: broadcast::error::SendError<T>) -> Self {
+    pub fn new<T: Send + 'static>(error: mpsc::error::SendError<T>) -> Self {
         Self {
             inner: Box::new(error),
         }

--- a/crates/rust-mcp-transport/src/message_dispatcher.rs
+++ b/crates/rust-mcp-transport/src/message_dispatcher.rs
@@ -181,7 +181,7 @@ impl McpDispatch<ServerMessages, ClientMessages, ServerMessage, ClientMessage>
                     .filter(|message| message.is_request())
                     .map(|message| {
                         (
-                            message.request_id().unwrap(), // guranteed to have request_id
+                            message.request_id().unwrap(), // guaranteed to have request_id
                             self.store_pending_request_for_message(message),
                         )
                     })
@@ -309,7 +309,7 @@ impl McpDispatch<ClientMessages, ServerMessages, ClientMessage, ServerMessage>
                     .filter(|message| message.is_request())
                     .map(|message| {
                         (
-                            message.request_id().unwrap(), // guranteed to have request_id
+                            message.request_id().unwrap(), // guaranteed to have request_id
                             self.store_pending_request_for_message(message),
                         )
                     })

--- a/crates/rust-mcp-transport/src/message_dispatcher.rs
+++ b/crates/rust-mcp-transport/src/message_dispatcher.rs
@@ -1,9 +1,12 @@
-use crate::schema::schema_utils::{
-    self, ClientMessage, FromMessage, McpMessage, MessageFromClient, MessageFromServer,
-    ServerMessage,
+use crate::schema::{
+    schema_utils::{
+        self, ClientMessage, ClientMessages, McpMessage, RpcMessage, ServerMessage, ServerMessages,
+    },
+    JsonrpcError,
 };
 use crate::schema::{RequestId, RpcError};
 use async_trait::async_trait;
+use futures::future::join_all;
 
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -11,7 +14,7 @@ use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::oneshot;
+use tokio::sync::oneshot::{self};
 use tokio::sync::Mutex;
 
 use crate::error::{TransportError, TransportResult};
@@ -68,7 +71,7 @@ impl<R> MessageDispatcher<R> {
     ///
     /// # Returns
     /// An `Option<RequestId>`: `Some` for requests or responses/errors, `None` for notifications.
-    fn request_id_for_message(
+    pub fn request_id_for_message(
         &self,
         message: &impl McpMessage,
         request_id: Option<RequestId>,
@@ -77,10 +80,7 @@ impl<R> MessageDispatcher<R> {
         if message.is_request() {
             // request_id should be None for requests
             assert!(request_id.is_none());
-            Some(RequestId::Integer(
-                self.message_id_counter
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-            ))
+            Some(self.next_request_id())
         } else if !message.is_notification() {
             // `request_id` must not be `None` for errors, notifications and responses
             assert!(request_id.is_some());
@@ -89,146 +89,300 @@ impl<R> MessageDispatcher<R> {
             None
         }
     }
-}
+    pub fn next_request_id(&self) -> RequestId {
+        RequestId::Integer(
+            self.message_id_counter
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        )
+    }
 
-#[async_trait]
-impl McpDispatch<ServerMessage, MessageFromClient> for MessageDispatcher<ServerMessage> {
-    /// Sends a message from the client to the server and awaits a response if applicable.
-    ///
-    /// Serializes the `MessageFromClient` to JSON, writes it to the transport, and waits for a
-    /// `ServerMessage` response if the message is a request. Notifications and responses return
-    /// `Ok(None)`.
-    ///
-    /// # Arguments
-    /// * `message` - The client message to send.
-    /// * `request_id` - An optional request ID (used for responses/errors, None for requests).
-    ///
-    /// # Returns
-    /// A `TransportResult` containing `Some(ServerMessage)` for requests with a response,
-    /// or `None` for notifications/responses, or an error if the operation fails.
-    ///
-    /// # Errors
-    /// Returns a `TransportError` if serialization, writing, or timeout occurs.
-    async fn send(
+    async fn store_pending_request(
         &self,
-        message: MessageFromClient,
-        request_id: Option<RequestId>,
-        request_timeout: Option<Duration>,
-    ) -> TransportResult<Option<ServerMessage>> {
-        let mut writable_std = self.writable_std.lock().await;
+        request_id: RequestId,
+    ) -> tokio::sync::oneshot::Receiver<R> {
+        let (tx_response, rx_response) = oneshot::channel::<R>();
+        let mut pending_requests = self.pending_requests.lock().await;
+        // store request id in the hashmap while waiting for a matching response
+        pending_requests.insert(request_id.clone(), tx_response);
+        rx_response
+    }
 
-        // returns the request_id to be used to construct the message
-        // a new requestId will be returned for Requests and Notification
-        let outgoing_request_id = self.request_id_for_message(&message, request_id);
-
-        let rx_response: Option<tokio::sync::oneshot::Receiver<ServerMessage>> = {
-            // Store the sender in the pending requests map
-            if message.is_request() {
-                if let Some(request_id) = &outgoing_request_id {
-                    let (tx_response, rx_response) = oneshot::channel::<ServerMessage>();
-                    let mut pending_requests = self.pending_requests.lock().await;
-                    // store request id in the hashmap while waiting for a matching response
-                    pending_requests.insert(request_id.clone(), tx_response);
-                    Some(rx_response)
-                } else {
-                    None
-                }
+    async fn store_pending_request_for_message<M: McpMessage + RpcMessage>(
+        &self,
+        message: &M,
+    ) -> Option<tokio::sync::oneshot::Receiver<R>> {
+        if message.is_request() {
+            if let Some(request_id) = message.request_id() {
+                Some(self.store_pending_request(request_id.clone()).await)
             } else {
                 None
             }
-        };
-
-        let mpc_message: ClientMessage = ClientMessage::from_message(message, outgoing_request_id)?;
-
-        //serialize the message and write it to the writable_std
-        let message_str = serde_json::to_string(&mpc_message)
-            .map_err(|_| crate::error::TransportError::JsonrpcError(RpcError::parse_error()))?;
-
-        writable_std.write_all(message_str.as_bytes()).await?;
-        writable_std.write_all(b"\n").await?; // new line
-        writable_std.flush().await?;
-
-        if let Some(rx) = rx_response {
-            // Wait for the response with timeout
-            match await_timeout(rx, request_timeout.unwrap_or(self.request_timeout)).await {
-                Ok(response) => Ok(Some(response)),
-                Err(error) => match error {
-                    TransportError::OneshotRecvError(_) => {
-                        Err(schema_utils::SdkError::connection_closed().into())
-                    }
-                    _ => Err(error),
-                },
-            }
         } else {
-            Ok(None)
+            None
         }
     }
 }
 
+// Client side dispatcher
 #[async_trait]
-impl McpDispatch<ClientMessage, MessageFromServer> for MessageDispatcher<ClientMessage> {
-    /// Sends a message from the server to the client and awaits a response if applicable.
+impl McpDispatch<ServerMessages, ClientMessages, ServerMessage, ClientMessage>
+    for MessageDispatcher<ServerMessage>
+{
+    /// Sends a message from the client to the server and awaits a response if applicable.
     ///
-    /// Serializes the `MessageFromServer` to JSON, writes it to the transport, and waits for a
-    /// `ClientMessage` response if the message is a request. Notifications and responses return
+    /// Serializes the `ClientMessages` to JSON, writes it to the transport, and waits for a
+    /// `ServerMessages` response if the message is a request. Notifications and responses return
     /// `Ok(None)`.
     ///
     /// # Arguments
-    /// * `message` - The server message to send.
-    /// * `request_id` - An optional request ID (used for responses/errors, None for requests).
+    /// * `messages` - The client message to send, coulld be a single message or batch.
     ///
     /// # Returns
-    /// A `TransportResult` containing `Some(ClientMessage)` for requests with a response,
+    /// A `TransportResult` containing `Some(ServerMessages)` for requests with a response,
     /// or `None` for notifications/responses, or an error if the operation fails.
     ///
     /// # Errors
     /// Returns a `TransportError` if serialization, writing, or timeout occurs.
+    async fn send_message(
+        &self,
+        messages: ClientMessages,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<ServerMessages>> {
+        match messages {
+            ClientMessages::Single(message) => {
+                let rx_response: Option<tokio::sync::oneshot::Receiver<ServerMessage>> =
+                    self.store_pending_request_for_message(&message).await;
+
+                //serialize the message and write it to the writable_std
+                let message_payload = serde_json::to_string(&message).map_err(|_| {
+                    crate::error::TransportError::JsonrpcError(RpcError::parse_error())
+                })?;
+
+                self.write_str(message_payload.as_str()).await?;
+
+                if let Some(rx) = rx_response {
+                    // Wait for the response with timeout
+                    match await_timeout(rx, request_timeout.unwrap_or(self.request_timeout)).await {
+                        Ok(response) => Ok(Some(ServerMessages::Single(response))),
+                        Err(error) => match error {
+                            TransportError::OneshotRecvError(_) => {
+                                Err(schema_utils::SdkError::connection_closed().into())
+                            }
+                            _ => Err(error),
+                        },
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+            ClientMessages::Batch(client_messages) => {
+                let (request_ids, pending_tasks): (Vec<_>, Vec<_>) = client_messages
+                    .iter()
+                    .filter(|message| message.is_request())
+                    .map(|message| {
+                        (
+                            message.request_id().unwrap(), // guranteed to have request_id
+                            self.store_pending_request_for_message(message),
+                        )
+                    })
+                    .unzip();
+
+                // send the batch messages to the server
+                let message_payload = serde_json::to_string(&client_messages).map_err(|_| {
+                    crate::error::TransportError::JsonrpcError(RpcError::parse_error())
+                })?;
+                self.write_str(message_payload.as_str()).await?;
+
+                // no request in the batch, no need to wait for the result
+                if pending_tasks.is_empty() {
+                    return Ok(None);
+                }
+
+                let tasks = join_all(pending_tasks).await;
+
+                let timeout_wrapped_futures = tasks.into_iter().filter_map(|rx| {
+                    rx.map(|rx| await_timeout(rx, request_timeout.unwrap_or(self.request_timeout)))
+                });
+
+                let results: Vec<_> = join_all(timeout_wrapped_futures)
+                    .await
+                    .into_iter()
+                    .zip(request_ids)
+                    .map(|(res, request_id)| match res {
+                        Ok(response) => response,
+                        Err(error) => ServerMessage::Error(JsonrpcError::new(
+                            RpcError::internal_error().with_message(error.to_string()),
+                            request_id.to_owned(),
+                        )),
+                    })
+                    .collect();
+
+                Ok(Some(ServerMessages::Batch(results)))
+            }
+        }
+    }
+
     async fn send(
         &self,
-        message: MessageFromServer,
-        request_id: Option<RequestId>,
+        message: ClientMessage,
         request_timeout: Option<Duration>,
-    ) -> TransportResult<Option<ClientMessage>> {
+    ) -> TransportResult<Option<ServerMessage>> {
+        let response = self.send_message(message.into(), request_timeout).await?;
+        match response {
+            Some(r) => Ok(Some(r.as_single()?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn send_batch(
+        &self,
+        message: Vec<ClientMessage>,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<Vec<ServerMessage>>> {
+        let response = self.send_message(message.into(), request_timeout).await?;
+        match response {
+            Some(r) => Ok(Some(r.as_batch()?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Writes a string payload to the underlying asynchronous writable stream,
+    /// appending a newline character and flushing the stream afterward.
+    ///
+    async fn write_str(&self, payload: &str) -> TransportResult<()> {
         let mut writable_std = self.writable_std.lock().await;
-
-        // returns the request_id to be used to construct the message
-        // a new requestId will be returned for Requests and Notification
-        let outgoing_request_id = self.request_id_for_message(&message, request_id);
-
-        let rx_response: Option<tokio::sync::oneshot::Receiver<ClientMessage>> = {
-            // Store the sender in the pending requests map
-            if message.is_request() {
-                if let Some(request_id) = &outgoing_request_id {
-                    let (tx_response, rx_response) = oneshot::channel::<ClientMessage>();
-                    let mut pending_requests = self.pending_requests.lock().await;
-                    // store request id in the hashmap while waiting for a matching response
-                    pending_requests.insert(request_id.clone(), tx_response);
-                    Some(rx_response)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        let mpc_message: ServerMessage = ServerMessage::from_message(message, outgoing_request_id)?;
-
-        //serialize the message and write it to the writable_std
-        let message_str = serde_json::to_string(&mpc_message)
-            .map_err(|_| crate::error::TransportError::JsonrpcError(RpcError::parse_error()))?;
-
-        writable_std.write_all(message_str.as_bytes()).await?;
+        writable_std.write_all(payload.as_bytes()).await?;
         writable_std.write_all(b"\n").await?; // new line
         writable_std.flush().await?;
+        Ok(())
+    }
+}
 
-        if let Some(rx) = rx_response {
-            match await_timeout(rx, request_timeout.unwrap_or(self.request_timeout)).await {
-                Ok(response) => Ok(Some(response)),
-                Err(error) => Err(error),
+// Server side dispatcher, Sends S and Returns R
+#[async_trait]
+impl McpDispatch<ClientMessages, ServerMessages, ClientMessage, ServerMessage>
+    for MessageDispatcher<ClientMessage>
+{
+    /// Sends a message from the server to the client and awaits a response if applicable.
+    ///
+    /// Serializes the `ServerMessages` to JSON, writes it to the transport, and waits for a
+    /// `ClientMessages` response if the message is a request. Notifications and responses return
+    /// `Ok(None)`.
+    ///
+    /// # Arguments
+    /// * `messages` - The client message to send, coulld be a single message or batch.
+    ///
+    /// # Returns
+    /// A `TransportResult` containing `Some(ClientMessages)` for requests with a response,
+    /// or `None` for notifications/responses, or an error if the operation fails.
+    ///
+    /// # Errors
+    /// Returns a `TransportError` if serialization, writing, or timeout occurs.
+    async fn send_message(
+        &self,
+        messages: ServerMessages,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<ClientMessages>> {
+        match messages {
+            ServerMessages::Single(message) => {
+                let rx_response: Option<tokio::sync::oneshot::Receiver<ClientMessage>> =
+                    self.store_pending_request_for_message(&message).await;
+
+                let message_payload = serde_json::to_string(&message).map_err(|_| {
+                    crate::error::TransportError::JsonrpcError(RpcError::parse_error())
+                })?;
+
+                self.write_str(message_payload.as_str()).await?;
+
+                if let Some(rx) = rx_response {
+                    match await_timeout(rx, request_timeout.unwrap_or(self.request_timeout)).await {
+                        Ok(response) => Ok(Some(ClientMessages::Single(response))),
+                        Err(error) => Err(error),
+                    }
+                } else {
+                    Ok(None)
+                }
             }
-        } else {
-            Ok(None)
+            ServerMessages::Batch(server_messages) => {
+                let (request_ids, pending_tasks): (Vec<_>, Vec<_>) = server_messages
+                    .iter()
+                    .filter(|message| message.is_request())
+                    .map(|message| {
+                        (
+                            message.request_id().unwrap(), // guranteed to have request_id
+                            self.store_pending_request_for_message(message),
+                        )
+                    })
+                    .unzip();
+
+                // send the batch messages to the client
+                let message_payload = serde_json::to_string(&server_messages).map_err(|_| {
+                    crate::error::TransportError::JsonrpcError(RpcError::parse_error())
+                })?;
+
+                self.write_str(message_payload.as_str()).await?;
+
+                // no request in the batch, no need to wait for the result
+                if pending_tasks.is_empty() {
+                    return Ok(None);
+                }
+
+                let tasks = join_all(pending_tasks).await;
+
+                let timeout_wrapped_futures = tasks.into_iter().filter_map(|rx| {
+                    rx.map(|rx| await_timeout(rx, request_timeout.unwrap_or(self.request_timeout)))
+                });
+
+                let results: Vec<_> = join_all(timeout_wrapped_futures)
+                    .await
+                    .into_iter()
+                    .zip(request_ids)
+                    .map(|(res, request_id)| match res {
+                        Ok(response) => response,
+                        Err(error) => ClientMessage::Error(JsonrpcError::new(
+                            RpcError::internal_error().with_message(error.to_string()),
+                            request_id.to_owned(),
+                        )),
+                    })
+                    .collect();
+
+                Ok(Some(ClientMessages::Batch(results)))
+            }
         }
+    }
+
+    async fn send(
+        &self,
+        message: ServerMessage,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<ClientMessage>> {
+        let response = self.send_message(message.into(), request_timeout).await?;
+        match response {
+            Some(r) => Ok(Some(r.as_single()?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn send_batch(
+        &self,
+        message: Vec<ServerMessage>,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<Vec<ClientMessage>>> {
+        let response = self.send_message(message.into(), request_timeout).await?;
+        match response {
+            Some(r) => Ok(Some(r.as_batch()?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Writes a string payload to the underlying asynchronous writable stream,
+    /// appending a newline character and flushing the stream afterward.
+    ///
+    async fn write_str(&self, payload: &str) -> TransportResult<()> {
+        let mut writable_std = self.writable_std.lock().await;
+        writable_std.write_all(payload.as_bytes()).await?;
+        writable_std.write_all(b"\n").await?; // new line
+        writable_std.flush().await?;
+        Ok(())
     }
 }

--- a/crates/rust-mcp-transport/src/stdio.rs
+++ b/crates/rust-mcp-transport/src/stdio.rs
@@ -1,20 +1,24 @@
-use crate::schema::schema_utils::{McpMessage, RpcMessage};
+use crate::schema::schema_utils::{
+    ClientMessage, ClientMessages, MessageFromServer, SdkError, ServerMessage, ServerMessages,
+};
 use crate::schema::RequestId;
 use async_trait::async_trait;
-use futures::Stream;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::process::Command;
-use tokio::sync::Mutex;
+use tokio::sync::oneshot::Sender;
+use tokio::sync::{oneshot, Mutex};
+use tokio::task::JoinHandle;
 
 use crate::error::{TransportError, TransportResult};
 use crate::mcp_stream::MCPStream;
 use crate::message_dispatcher::MessageDispatcher;
 use crate::transport::Transport;
 use crate::utils::CancellationTokenSource;
-use crate::{IoStream, McpDispatch, TransportOptions};
+use crate::{IoStream, McpDispatch, TransportDispatcher, TransportOptions};
 
 /// Implements a standard I/O transport for MCP communication.
 ///
@@ -25,7 +29,7 @@ use crate::{IoStream, McpDispatch, TransportOptions};
 /// operations, integrating with the MCP runtime ecosystem.
 pub struct StdioTransport<R>
 where
-    R: RpcMessage + Clone + Send + Sync + DeserializeOwned + 'static,
+    R: Clone + Send + Sync + DeserializeOwned + 'static,
 {
     command: Option<String>,
     args: Option<Vec<String>>,
@@ -33,13 +37,14 @@ where
     options: TransportOptions,
     shutdown_source: tokio::sync::RwLock<Option<CancellationTokenSource>>,
     is_shut_down: Mutex<bool>,
-    message_sender: tokio::sync::RwLock<Option<MessageDispatcher<R>>>,
+    message_sender: Arc<tokio::sync::RwLock<Option<MessageDispatcher<R>>>>,
     error_stream: tokio::sync::RwLock<Option<IoStream>>,
+    pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<R>>>>,
 }
 
 impl<R> StdioTransport<R>
 where
-    R: RpcMessage + Clone + Send + Sync + DeserializeOwned + 'static,
+    R: Clone + Send + Sync + DeserializeOwned + 'static,
 {
     /// Creates a new `StdioTransport` instance for MCP Server.
     ///
@@ -62,8 +67,9 @@ where
             options,
             shutdown_source: tokio::sync::RwLock::new(None),
             is_shut_down: Mutex::new(false),
-            message_sender: tokio::sync::RwLock::new(None),
+            message_sender: Arc::new(tokio::sync::RwLock::new(None)),
             error_stream: tokio::sync::RwLock::new(None),
+            pending_requests: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -95,8 +101,9 @@ where
             options,
             shutdown_source: tokio::sync::RwLock::new(None),
             is_shut_down: Mutex::new(false),
-            message_sender: tokio::sync::RwLock::new(None),
+            message_sender: Arc::new(tokio::sync::RwLock::new(None)),
             error_stream: tokio::sync::RwLock::new(None),
+            pending_requests: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -138,10 +145,13 @@ where
 }
 
 #[async_trait]
-impl<R, S> Transport<R, S> for StdioTransport<R>
+impl<R, S, M, OR, OM> Transport<R, S, M, OR, OM> for StdioTransport<M>
 where
-    R: RpcMessage + Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
-    S: McpMessage + Clone + Send + Sync + serde::Serialize + 'static,
+    R: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
+    S: Clone + Send + Sync + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
+    OR: Clone + Send + Sync + serde::Serialize + 'static,
+    OM: Clone + Send + Sync + serde::de::DeserializeOwned + 'static,
 {
     /// Starts the transport, initializing streams and the message dispatcher.
     ///
@@ -156,9 +166,9 @@ where
     ///
     /// # Errors
     /// Returns a `TransportError` if the subprocess fails to spawn or stdio streams cannot be accessed.
-    async fn start(&self) -> TransportResult<Pin<Box<dyn Stream<Item = R> + Send>>>
+    async fn start(&self) -> TransportResult<tokio_stream::wrappers::ReceiverStream<R>>
     where
-        MessageDispatcher<R>: McpDispatch<R, S>,
+        MessageDispatcher<M>: McpDispatch<R, OR, M, OM>,
     {
         // Create CancellationTokenSource and token
         let (cancellation_source, cancellation_token) = CancellationTokenSource::new();
@@ -200,14 +210,13 @@ where
                 .take()
                 .ok_or_else(|| TransportError::FromString("Unable to retrieve stderr.".into()))?;
 
-            let pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<R>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
-            let pending_requests_clone = Arc::clone(&pending_requests);
+            let pending_requests_clone1 = self.pending_requests.clone();
+            let pending_requests_clone2 = self.pending_requests.clone();
 
             tokio::spawn(async move {
                 let _ = process.wait().await;
                 // clean up pending requests to cancel waiting tasks
-                let mut pending_requests = pending_requests.lock().await;
+                let mut pending_requests = pending_requests_clone1.lock().await;
                 pending_requests.clear();
             });
 
@@ -215,7 +224,7 @@ where
                 Box::pin(stdout),
                 Mutex::new(Box::pin(stdin)),
                 IoStream::Readable(Box::pin(stderr)),
-                pending_requests_clone,
+                pending_requests_clone2,
                 self.options.timeout,
                 cancellation_token,
             );
@@ -228,7 +237,7 @@ where
 
             Ok(stream)
         } else {
-            let pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<R>>>> =
+            let pending_requests: Arc<Mutex<HashMap<RequestId, tokio::sync::oneshot::Sender<M>>>> =
                 Arc::new(Mutex::new(HashMap::new()));
             let (stream, sender, error_stream) = MCPStream::create(
                 Box::pin(tokio::io::stdin()),
@@ -248,18 +257,39 @@ where
         }
     }
 
+    async fn pending_request_tx(&self, request_id: &RequestId) -> Option<Sender<M>> {
+        let mut pending_requests = self.pending_requests.lock().await;
+        pending_requests.remove(request_id)
+    }
+
     /// Checks if the transport has been shut down.
     async fn is_shut_down(&self) -> bool {
         let result = self.is_shut_down.lock().await;
         *result
     }
 
-    async fn message_sender(&self) -> &tokio::sync::RwLock<Option<MessageDispatcher<R>>> {
-        &self.message_sender as _
+    fn message_sender(&self) -> Arc<tokio::sync::RwLock<Option<MessageDispatcher<M>>>> {
+        self.message_sender.clone() as _
     }
 
-    async fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
+    fn error_stream(&self) -> &tokio::sync::RwLock<Option<IoStream>> {
         &self.error_stream as _
+    }
+
+    async fn consume_string_payload(&self, _payload: &str) -> TransportResult<()> {
+        Err(TransportError::FromString(
+            "Invalid invocation of consume_string_payload() function in StdioTransport".to_string(),
+        ))
+    }
+
+    async fn keep_alive(
+        &self,
+        _interval: Duration,
+        _disconnect_tx: oneshot::Sender<()>,
+    ) -> TransportResult<JoinHandle<()>> {
+        Err(TransportError::FromString(
+            "Invalid invocation of keep_alive() function for StdioTransport".to_string(),
+        ))
     }
 
     // Shuts down the transport, terminating any subprocess and signaling closure.
@@ -284,4 +314,56 @@ where
         *is_shut_down_lock = true;
         Ok(())
     }
+}
+
+#[async_trait]
+impl McpDispatch<ClientMessages, ServerMessages, ClientMessage, ServerMessage>
+    for StdioTransport<ClientMessage>
+{
+    async fn send_message(
+        &self,
+        message: ServerMessages,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<ClientMessages>> {
+        let sender = self.message_sender.read().await;
+        let sender = sender.as_ref().ok_or(SdkError::connection_closed())?;
+        sender.send_message(message, request_timeout).await
+    }
+
+    async fn send(
+        &self,
+        message: ServerMessage,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<ClientMessage>> {
+        let sender = self.message_sender.read().await;
+        let sender = sender.as_ref().ok_or(SdkError::connection_closed())?;
+        sender.send(message, request_timeout).await
+    }
+
+    async fn send_batch(
+        &self,
+        message: Vec<ServerMessage>,
+        request_timeout: Option<Duration>,
+    ) -> TransportResult<Option<Vec<ClientMessage>>> {
+        let sender = self.message_sender.read().await;
+        let sender = sender.as_ref().ok_or(SdkError::connection_closed())?;
+        sender.send_batch(message, request_timeout).await
+    }
+
+    async fn write_str(&self, payload: &str) -> TransportResult<()> {
+        let sender = self.message_sender.read().await;
+        let sender = sender.as_ref().ok_or(SdkError::connection_closed())?;
+        sender.write_str(payload).await
+    }
+}
+
+impl
+    TransportDispatcher<
+        ClientMessages,
+        MessageFromServer,
+        ClientMessage,
+        ServerMessages,
+        ServerMessage,
+    > for StdioTransport<ClientMessage>
+{
 }

--- a/crates/rust-mcp-transport/src/utils/readable_channel.rs
+++ b/crates/rust-mcp-transport/src/utils/readable_channel.rs
@@ -101,6 +101,7 @@ mod tests {
         let mut buf2 = vec![0; 6];
         reader.read_exact(&mut buf2).await.unwrap();
         assert_eq!(&buf2, b" world");
+        drop(tx);
     }
 
     #[tokio::test]

--- a/crates/rust-mcp-transport/tests/check_imports.rs
+++ b/crates/rust-mcp-transport/tests/check_imports.rs
@@ -1,0 +1,85 @@
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::{self, Read};
+    use std::path::Path;
+
+    // List of files to exclude from the check
+    const EXCLUDED_FILES: &[&str] = &["src/schema.rs"];
+
+    // Check all .rs files for incorrect `use rust_mcp_schema` imports
+    #[test]
+    fn check_no_rust_mcp_schema_imports() {
+        let mut errors = Vec::new();
+
+        // Walk through the src directory
+        for entry in walk_src_dir("src").expect("Failed to read src directory") {
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            // only check files with .rs extension
+            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                let abs_path = path.to_string_lossy();
+                let relative_path = path.strip_prefix("src").unwrap_or(&path);
+                let path_str = relative_path.to_string_lossy();
+
+                // Skip excluded files
+                if EXCLUDED_FILES.iter().any(|&excluded| abs_path == excluded) {
+                    continue;
+                }
+
+                // Read the file content
+                match read_file(&path) {
+                    Ok(content) => {
+                        // Check for `use rust_mcp_schema`
+                        if content.contains("use rust_mcp_schema") {
+                            errors.push(format!(
+                                "File {} contains `use rust_mcp_schema`. Use `use crate::schema` instead.",
+                                abs_path
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        errors.push(format!("Failed to read file `{}`: {}", path_str, e));
+                    }
+                }
+            }
+        }
+
+        // If there are any errors, fail the test with all error messages
+        if !errors.is_empty() {
+            panic!(
+                "Found {} incorrect imports:\n{}\n\n",
+                errors.len(),
+                errors.join("\n")
+            );
+        }
+    }
+
+    // Helper function to walk the src directory
+    fn walk_src_dir<P: AsRef<Path>>(
+        path: P,
+    ) -> io::Result<impl Iterator<Item = io::Result<std::fs::DirEntry>>> {
+        Ok(std::fs::read_dir(path)?.flat_map(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                // Recursively walk subdirectories
+                walk_src_dir(&path)
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            } else {
+                vec![Ok(entry)]
+            }
+        }))
+    }
+
+    // Helper function to read file content
+    fn read_file(path: &Path) -> io::Result<String> {
+        let mut file = File::open(path)?;
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        Ok(content)
+    }
+}

--- a/crates/rust-mcp-transport/tests/check_imports.rs
+++ b/crates/rust-mcp-transport/tests/check_imports.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::fs::File;
     use std::io::{self, Read};
-    use std::path::Path;
+    use std::path::{Path, MAIN_SEPARATOR_STR};
 
     // List of files to exclude from the check
     const EXCLUDED_FILES: &[&str] = &["src/schema.rs"];
@@ -24,7 +24,10 @@ mod tests {
                 let path_str = relative_path.to_string_lossy();
 
                 // Skip excluded files
-                if EXCLUDED_FILES.iter().any(|&excluded| abs_path == excluded) {
+                if EXCLUDED_FILES
+                    .iter()
+                    .any(|&excluded| abs_path.replace(MAIN_SEPARATOR_STR, "/") == excluded)
+                {
                     continue;
                 }
 

--- a/examples/hello-world-server-core-sse/src/main.rs
+++ b/examples/hello-world-server-core-sse/src/main.rs
@@ -17,8 +17,7 @@ async fn main() -> SdkResult<()> {
     // initialize tracing
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")).into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/hello-world-server-sse/src/main.rs
+++ b/examples/hello-world-server-sse/src/main.rs
@@ -24,8 +24,7 @@ async fn main() -> SdkResult<()> {
     // initialize tracing
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")).into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/simple-mcp-client-core-sse/src/main.rs
+++ b/examples/simple-mcp-client-core-sse/src/main.rs
@@ -21,8 +21,7 @@ const MCP_SERVER_URL: &str = "http://localhost:3001/sse";
 async fn main() -> SdkResult<()> {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")).into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/simple-mcp-client-sse/src/main.rs
+++ b/examples/simple-mcp-client-sse/src/main.rs
@@ -21,8 +21,7 @@ const MCP_SERVER_URL: &str = "http://localhost:3001/sse";
 async fn main() -> SdkResult<()> {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")).into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();


### PR DESCRIPTION
### 📌 Summary

This PR introduces several enhancements and refactorings to the sdk:

✨ Major Feature:
- Added support for Streamable HTTP for MCP Servers, to align with protocol specifications such as support of long-lived connections as well as none-streamable responses, batch messages, and DNS Rebinding protection.

🛠 Refactoring & Structural Improvements:
- Refactored transport layer and associated traits
    Improved the separation of concerns and modularity by restructuring transport logic and key traits.

🔐 Security Enhancements:
- Introduced DNS rebinding protection middleware
    Middleware added for both SSE and Streamable HTTP to mitigate DNS rebinding attacks.

✅ Testing & Compliance:

- Implemented unit tests for HTTP streaming
    Tests ensure compliance with the official protocol and validate stream behavior under various conditions.


### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- Partially addresses #62 


### 💡 Additional Notes
_Readme and examples will be updated in following pull requests.
Streamable HTTP support for client will be released soon._
