### PR TITLE
fix: ensure server-initiated requests include a valid request_id

### DIFF
--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -51,6 +51,7 @@ pub trait ServerHandler: Send + Sync + 'static {
 
         runtime
             .set_client_details(initialize_request.params.clone())
+            .await
             .map_err(|err| RpcError::internal_error().with_message(format!("{err}")))?;
 
         Ok(server_info)

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
@@ -76,6 +76,7 @@ impl McpServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
             // keep a copy of the InitializeRequestParams which includes client_info and capabilities
             runtime
                 .set_client_details(initialize_request.params.clone())
+                .await
                 .map_err(|err| RpcError::internal_error().with_message(format!("{err}")))?;
         }
 

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
@@ -23,9 +23,11 @@ use crate::{error::SdkResult, utils::format_assertion_message};
 #[async_trait]
 pub trait McpServer: Sync + Send {
     async fn start(&self) -> SdkResult<()>;
-    fn set_client_details(&self, client_details: InitializeRequestParams) -> SdkResult<()>;
+    async fn set_client_details(&self, client_details: InitializeRequestParams) -> SdkResult<()>;
     fn server_info(&self) -> &InitializeResult;
     fn client_info(&self) -> Option<InitializeRequestParams>;
+
+    async fn wait_for_initialization(&self);
 
     #[deprecated(since = "0.2.0", note = "Use `client_info()` instead.")]
     fn get_client_info(&self) -> Option<InitializeRequestParams> {


### PR DESCRIPTION
### 📌 Summary
This PR fixes an issue where server-initiated requests were being sent without a valid request_id, which caused an assertion error. The fix ensures that a new request_id is always generated for server-initiated requests.


### ✨ Changes Made
- Updated send() to guarantee that server-initiated requests always generate a valid request_id.
- Replaced RwLock with tokio::sync::watch in set_client_details() for more efficient state updates.
- Added a new wait_for_initialization() function that allows awaiting the completion of the server initialization process (when used).
