### PR TITLE
fix: missing client_info initialization and abort keep-alive task on drop

### DIFF
--- a/crates/rust-mcp-sdk/src/utils.rs
+++ b/crates/rust-mcp-sdk/src/utils.rs
@@ -4,6 +4,23 @@ use crate::error::{McpSdkError, SdkResult};
 use crate::schema::ProtocolVersion;
 use std::cmp::Ordering;
 
+/// A guard type that automatically aborts a Tokio task when dropped.
+///
+/// This ensures that the associated task does not outlive the scope
+/// of this struct, preventing runaway or leaked background tasks.
+///
+pub struct AbortTaskOnDrop {
+    /// The handle used to abort the spawned Tokio task.
+    pub handle: tokio::task::AbortHandle,
+}
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        // Automatically abort the associated task when this guard is dropped.
+        self.handle.abort();
+    }
+}
+
 /// Formats an assertion error message for unsupported capabilities.
 ///
 /// Constructs a string describing that a specific entity (e.g., server or client) lacks


### PR DESCRIPTION
### 📌 Summary
This PR fixes an issue where client_info was mistakenly returning None, causing initialization problems. It also introduces an AbortTaskOnDrop guard to ensure that the keep-alive task is properly aborted when no longer needed, preventing potential task leaks.