### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "crates/rust-mcp-sdk": "0.5.2",
+  "crates/rust-mcp-sdk": "0.5.3",
   "crates/rust-mcp-macros": "0.5.1",
   "crates/rust-mcp-transport": "0.4.1",
-  "examples/hello-world-mcp-server": "0.1.26",
-  "examples/hello-world-mcp-server-core": "0.1.17",
-  "examples/simple-mcp-client": "0.1.26",
-  "examples/simple-mcp-client-core": "0.1.26",
-  "examples/hello-world-server-core-streamable-http": "0.1.17",
-  "examples/hello-world-server-streamable-http": "0.1.26",
-  "examples/simple-mcp-client-core-sse": "0.1.17",
-  "examples/simple-mcp-client-sse": "0.1.17"
+  "examples/hello-world-mcp-server": "0.1.27",
+  "examples/hello-world-mcp-server-core": "0.1.18",
+  "examples/simple-mcp-client": "0.1.27",
+  "examples/simple-mcp-client-core": "0.1.27",
+  "examples/hello-world-server-core-streamable-http": "0.1.18",
+  "examples/hello-world-server-streamable-http": "0.1.27",
+  "examples/simple-mcp-client-core-sse": "0.1.18",
+  "examples/simple-mcp-client-sse": "0.1.18"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-streamable-http"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "async-trait",
  "futures",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "async-trait",
  "colored",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "async-trait",
  "colored",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "colored",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.5.2...rust-mcp-sdk-v0.5.3) (2025-08-19)
+
+
+### 🐛 Bug Fixes
+
+* Handle missing client details and abort keep-alive task on drop ([#83](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/83)) ([308b1db](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/308b1dbd1744ff06046902303d8bcd6c3a92ffbe))
+
 ## [0.5.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.5.1...rust-mcp-sdk-v0.5.2) (2025-08-16)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-core-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-streamable-http"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.27</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.18</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-streamable-http: 0.1.18</summary>

### Dependencies


</details>

<details><summary>hello-world-server-streamable-http: 0.1.27</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.5.3</summary>

## [0.5.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.5.2...rust-mcp-sdk-v0.5.3) (2025-08-19)


### 🐛 Bug Fixes

* Handle missing client details and abort keep-alive task on drop ([#83](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/83)) ([308b1db](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/308b1dbd1744ff06046902303d8bcd6c3a92ffbe))
</details>

<details><summary>simple-mcp-client: 0.1.27</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.27</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.18</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.18</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).