### PR TITLE
fix: session ID access in handlers and add helper for listing active sessions

### DIFF
--- a/crates/rust-mcp-sdk/src/hyper_servers/hyper_runtime.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/hyper_runtime.rs
@@ -70,6 +70,12 @@ impl HyperRuntime {
         result.map_err(|err| err.into())
     }
 
+    /// Returns a list of active session IDs from the session store.
+    pub async fn sessions(&self) -> Vec<String> {
+        self.state.session_store.keys().await
+    }
+
+    /// Retrieves the runtime associated with the given session ID from the session store.
     pub async fn runtime_by_session(
         &self,
         session_id: &SessionId,

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
@@ -172,10 +172,7 @@ pub async fn start_new_session(
         session_id.to_owned(),
     ));
 
-    tracing::info!(
-        "a new client joined : {}",
-        runtime.session_id().await.unwrap_or_default().to_owned()
-    );
+    tracing::info!("a new client joined : {}", &session_id);
 
     let response = create_sse_stream(
         runtime.clone(),

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -197,6 +197,11 @@ impl McpServer for ServerRuntime {
         }
         Ok(())
     }
+
+    #[cfg(feature = "hyper-server")]
+    fn session_id(&self) -> Option<SessionId> {
+        self.session_id.to_owned()
+    }
 }
 
 impl ServerRuntime {
@@ -433,11 +438,6 @@ impl ServerRuntime {
                 }
             }
         }
-    }
-
-    #[cfg(feature = "hyper-server")]
-    pub(crate) async fn session_id(&self) -> Option<SessionId> {
-        self.session_id.to_owned()
     }
 
     #[cfg(feature = "hyper-server")]

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use crate::schema::{
     schema_utils::{
         ClientMessage, McpMessage, MessageFromServer, NotificationFromServer, RequestFromServer,
@@ -16,6 +14,8 @@ use crate::schema::{
     SetLevelRequest, ToolListChangedNotification, ToolListChangedNotificationParams,
 };
 use async_trait::async_trait;
+use rust_mcp_transport::SessionId;
+use std::time::Duration;
 
 use crate::{error::SdkResult, utils::format_assertion_message};
 
@@ -405,4 +405,7 @@ pub trait McpServer: Sync + Send {
         }
         Ok(())
     }
+
+    #[cfg(feature = "hyper-server")]
+    fn session_id(&self) -> Option<SessionId>;
 }


### PR DESCRIPTION

### 📌 Summary

This PR includes a fix that makes the `session_id` accessible in the handler methods, and also a helper function to retrieve active sessions.

### 🔍 Related Issues

- #89 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Made `session_id` of the runtime(s) accessible in the handler methods
- Add sessions() helper function to retrieve active session IDs
