### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "crates/rust-mcp-sdk": "0.6.0",
+  "crates/rust-mcp-sdk": "0.6.1",
   "crates/rust-mcp-macros": "0.5.1",
   "crates/rust-mcp-transport": "0.5.0",
-  "examples/hello-world-mcp-server": "0.1.28",
-  "examples/hello-world-mcp-server-core": "0.1.19",
-  "examples/simple-mcp-client": "0.1.28",
-  "examples/simple-mcp-client-core": "0.1.28",
-  "examples/hello-world-server-core-streamable-http": "0.1.19",
-  "examples/hello-world-server-streamable-http": "0.1.28",
-  "examples/simple-mcp-client-core-sse": "0.1.19",
-  "examples/simple-mcp-client-sse": "0.1.19"
+  "examples/hello-world-mcp-server": "0.1.29",
+  "examples/hello-world-mcp-server-core": "0.1.20",
+  "examples/simple-mcp-client": "0.1.29",
+  "examples/simple-mcp-client-core": "0.1.29",
+  "examples/hello-world-server-core-streamable-http": "0.1.20",
+  "examples/hello-world-server-streamable-http": "0.1.29",
+  "examples/simple-mcp-client-core-sse": "0.1.20",
+  "examples/simple-mcp-client-sse": "0.1.20"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-streamable-http"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "async-trait",
  "futures",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "async-trait",
  "colored",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "async-trait",
  "colored",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "colored",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.0...rust-mcp-sdk-v0.6.1) (2025-08-28)
+
+
+### 🐛 Bug Fixes
+
+* Session ID access in handlers and add helper for listing active ([#90](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/90)) ([f2f0afb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f2f0afb542f6ff036a28cf01e102b27ce940665b))
+
 ## [0.6.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.5.3...rust-mcp-sdk-v0.6.0) (2025-08-19)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-core-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-streamable-http"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.29</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.20</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-streamable-http: 0.1.20</summary>

### Dependencies


</details>

<details><summary>hello-world-server-streamable-http: 0.1.29</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.6.1</summary>

## [0.6.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.0...rust-mcp-sdk-v0.6.1) (2025-08-28)


### 🐛 Bug Fixes

* Session ID access in handlers and add helper for listing active ([#90](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/90)) ([f2f0afb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f2f0afb542f6ff036a28cf01e102b27ce940665b))
</details>

<details><summary>simple-mcp-client: 0.1.29</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.29</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.20</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.20</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).