### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "crates/rust-mcp-sdk": "0.6.1",
+  "crates/rust-mcp-sdk": "0.6.2",
   "crates/rust-mcp-macros": "0.5.1",
   "crates/rust-mcp-transport": "0.5.0",
-  "examples/hello-world-mcp-server": "0.1.29",
-  "examples/hello-world-mcp-server-core": "0.1.20",
-  "examples/simple-mcp-client": "0.1.29",
-  "examples/simple-mcp-client-core": "0.1.29",
-  "examples/hello-world-server-core-streamable-http": "0.1.20",
-  "examples/hello-world-server-streamable-http": "0.1.29",
-  "examples/simple-mcp-client-core-sse": "0.1.20",
-  "examples/simple-mcp-client-sse": "0.1.20"
+  "examples/hello-world-mcp-server": "0.1.30",
+  "examples/hello-world-mcp-server-core": "0.1.21",
+  "examples/simple-mcp-client": "0.1.30",
+  "examples/simple-mcp-client-core": "0.1.30",
+  "examples/hello-world-server-core-streamable-http": "0.1.21",
+  "examples/hello-world-server-streamable-http": "0.1.30",
+  "examples/simple-mcp-client-core-sse": "0.1.21",
+  "examples/simple-mcp-client-sse": "0.1.21"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-streamable-http"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "async-trait",
  "futures",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "async-trait",
  "colored",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "async-trait",
  "colored",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "colored",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "colored",

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.1...rust-mcp-sdk-v0.6.2) (2025-08-30)
+
+
+### 🐛 Bug Fixes
+
+* Tool-box macro panic on invalid requests ([#92](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/92)) ([54cc8ed](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/54cc8edb55c41455dd9211f296560e7a792a7b9c))
+
 ## [0.6.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.0...rust-mcp-sdk-v0.6.1) (2025-08-28)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-core-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-streamable-http"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.30</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.21</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-streamable-http: 0.1.21</summary>

### Dependencies


</details>

<details><summary>hello-world-server-streamable-http: 0.1.30</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.6.2</summary>

## [0.6.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.1...rust-mcp-sdk-v0.6.2) (2025-08-30)


### 🐛 Bug Fixes

* Tool-box macro panic on invalid requests ([#92](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/92)) ([54cc8ed](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/54cc8edb55c41455dd9211f296560e7a792a7b9c))
</details>

<details><summary>simple-mcp-client: 0.1.30</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.30</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.21</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.21</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).