### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "crates/rust-mcp-sdk": "0.6.2",
+  "crates/rust-mcp-sdk": "0.6.3",
   "crates/rust-mcp-macros": "0.5.1",
-  "crates/rust-mcp-transport": "0.5.0",
-  "examples/hello-world-mcp-server": "0.1.30",
-  "examples/hello-world-mcp-server-core": "0.1.21",
-  "examples/simple-mcp-client": "0.1.30",
-  "examples/simple-mcp-client-core": "0.1.30",
-  "examples/hello-world-server-core-streamable-http": "0.1.21",
-  "examples/hello-world-server-streamable-http": "0.1.30",
-  "examples/simple-mcp-client-core-sse": "0.1.21",
-  "examples/simple-mcp-client-sse": "0.1.21"
+  "crates/rust-mcp-transport": "0.5.1",
+  "examples/hello-world-mcp-server": "0.1.31",
+  "examples/hello-world-mcp-server-core": "0.1.22",
+  "examples/simple-mcp-client": "0.1.31",
+  "examples/simple-mcp-client-core": "0.1.31",
+  "examples/hello-world-server-core-streamable-http": "0.1.22",
+  "examples/hello-world-server-streamable-http": "0.1.31",
+  "examples/simple-mcp-client-core-sse": "0.1.22",
+  "examples/simple-mcp-client-sse": "0.1.22"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hello-world-mcp-server"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "async-trait",
  "futures",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-mcp-server-core"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "async-trait",
  "futures",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "async-trait",
  "futures",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-server-streamable-http"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "async-trait",
  "futures",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "async-trait",
  "colored",
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "async-trait",
  "colored",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-core-sse"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "async-trait",
  "colored",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "simple-mcp-client-sse"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "async-trait",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.5.0", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-transport = { version = "0.5.1", path = "crates/rust-mcp-transport", default-features = false }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.5.1", path = "crates/rust-mcp-macros", default-features = false }
 

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.6.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.2...rust-mcp-sdk-v0.6.3) (2025-08-31)
+
 ## [0.6.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.1...rust-mcp-sdk-v0.6.2) (2025-08-30)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.5.0...rust-mcp-transport-v0.5.1) (2025-08-31)
+
+
+### 🐛 Bug Fixes
+
+* Correct pending_requests instance ([#94](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/94)) ([9d8c1fb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9d8c1fbdf3ddb7c67ce1fb7dcb8e50b8ba2e1202))
+
 ## [0.5.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.4.1...rust-mcp-transport-v0.5.0) (2025-08-19)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."

--- a/examples/hello-world-mcp-server-core/Cargo.toml
+++ b/examples/hello-world-mcp-server-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server-core"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-mcp-server/Cargo.toml
+++ b/examples/hello-world-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-mcp-server"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-core-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-core-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-core-streamable-http"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/hello-world-server-streamable-http/Cargo.toml
+++ b/examples/hello-world-server-streamable-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-world-server-streamable-http"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core-sse/Cargo.toml
+++ b/examples/simple-mcp-client-core-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core-sse"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-core/Cargo.toml
+++ b/examples/simple-mcp-client-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-core"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client-sse/Cargo.toml
+++ b/examples/simple-mcp-client-sse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client-sse"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/examples/simple-mcp-client/Cargo.toml
+++ b/examples/simple-mcp-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-mcp-client"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 publish = false
 license = "MIT"


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>hello-world-mcp-server: 0.1.31</summary>

### Dependencies


</details>

<details><summary>hello-world-mcp-server-core: 0.1.22</summary>

### Dependencies


</details>

<details><summary>hello-world-server-core-streamable-http: 0.1.22</summary>

### Dependencies


</details>

<details><summary>hello-world-server-streamable-http: 0.1.31</summary>

### Dependencies


</details>

<details><summary>rust-mcp-sdk: 0.6.3</summary>

## [0.6.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.6.2...rust-mcp-sdk-v0.6.3) (2025-08-31)
</details>

<details><summary>rust-mcp-transport: 0.5.1</summary>

## [0.5.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.5.0...rust-mcp-transport-v0.5.1) (2025-08-31)


### 🐛 Bug Fixes

* Correct pending_requests instance ([#94](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/94)) ([9d8c1fb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9d8c1fbdf3ddb7c67ce1fb7dcb8e50b8ba2e1202))
</details>

<details><summary>simple-mcp-client: 0.1.31</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core: 0.1.31</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-core-sse: 0.1.22</summary>

### Dependencies


</details>

<details><summary>simple-mcp-client-sse: 0.1.22</summary>

### Dependencies


</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).