### PR TITLE
feat!: update ServerHandler and ServerHandlerCore traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ pub struct MyServerHandler;
 #[async_trait]
 impl ServerHandler for MyServerHandler {
     // Handle ListToolsRequest, return list of available tools as ListToolsResult
-    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn McpServer) -> Result<ListToolsResult, RpcError> {
+    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: Arc<dyn McpServer>) -> Result<ListToolsResult, RpcError> {
 
         Ok(ListToolsResult {
             tools: vec![SayHelloTool::tool()],
@@ -191,7 +191,7 @@ impl ServerHandler for MyServerHandler {
     }
 
     /// Handles requests to call a specific tool.
-    async fn handle_call_tool_request( &self, request: CallToolRequest, runtime: &dyn McpServer, ) -> Result<CallToolResult, CallToolError> {
+    async fn handle_call_tool_request( &self, request: CallToolRequest, runtime: Arc<dyn McpServer>, ) -> Result<CallToolResult, CallToolError> {
 
         if request.tool_name() == SayHelloTool::tool_name() {
             Ok( CallToolResult::text_content( vec![TextContent::from("Hello World!".to_string())]  ))

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -180,7 +180,7 @@ pub struct MyServerHandler;
 #[async_trait]
 impl ServerHandler for MyServerHandler {
     // Handle ListToolsRequest, return list of available tools as ListToolsResult
-    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: &dyn McpServer) -> Result<ListToolsResult, RpcError> {
+    async fn handle_list_tools_request(&self, request: ListToolsRequest, runtime: Arc<dyn McpServer>) -> Result<ListToolsResult, RpcError> {
 
         Ok(ListToolsResult {
             tools: vec![SayHelloTool::tool()],
@@ -191,7 +191,7 @@ impl ServerHandler for MyServerHandler {
     }
 
     /// Handles requests to call a specific tool.
-    async fn handle_call_tool_request( &self, request: CallToolRequest, runtime: &dyn McpServer, ) -> Result<CallToolResult, CallToolError> {
+    async fn handle_call_tool_request( &self, request: CallToolRequest, runtime: Arc<dyn McpServer> ) -> Result<CallToolResult, CallToolError> {
 
         if request.tool_name() == SayHelloTool::tool_name() {
             Ok( CallToolResult::text_content( vec![TextContent::from("Hello World!".to_string())]  ))

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/hyper_utils.rs
@@ -166,11 +166,11 @@ pub async fn start_new_session(
 
     let h: Arc<dyn McpServerHandler> = state.handler.clone();
     // create a new server instance with unique session_id and
-    let runtime: Arc<ServerRuntime> = Arc::new(server_runtime::create_server_instance(
+    let runtime: Arc<ServerRuntime> = server_runtime::create_server_instance(
         Arc::clone(&state.server_details),
         h,
         session_id.to_owned(),
-    ));
+    );
 
     tracing::info!("a new client joined : {}", &session_id);
 

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/sse_routes.rs
@@ -99,11 +99,11 @@ pub async fn handle_sse(
     .unwrap();
     let h: Arc<dyn McpServerHandler> = state.handler.clone();
     // create a new server instance with unique session_id and
-    let server: Arc<ServerRuntime> = Arc::new(server_runtime::create_server_instance(
+    let server: Arc<ServerRuntime> = server_runtime::create_server_instance(
         Arc::clone(&state.server_details),
         h,
         session_id.to_owned(),
-    ));
+    );
 
     state
         .session_store

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -1,6 +1,7 @@
 use crate::schema::{schema_utils::CallToolError, *};
 use async_trait::async_trait;
 use serde_json::Value;
+use std::sync::Arc;
 
 use crate::{mcp_traits::mcp_server::McpServer, utils::enforce_compatible_protocol_version};
 
@@ -15,7 +16,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     /// The `runtime` parameter provides access to the server's runtime environment, allowing
     /// interaction with the server's capabilities.
     /// The default implementation does nothing.
-    async fn on_initialized(&self, runtime: &dyn McpServer) {}
+    async fn on_initialized(&self, runtime: Arc<dyn McpServer>) {}
 
     /// Handles the InitializeRequest from a client.
     ///
@@ -29,7 +30,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_initialize_request(
         &self,
         initialize_request: InitializeRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<InitializeResult, RpcError> {
         let mut server_info = runtime.server_info().to_owned();
         // Provide compatibility for clients using older MCP protocol versions.
@@ -65,7 +66,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_ping_request(
         &self,
         _: PingRequest,
-        _: &dyn McpServer,
+        _: Arc<dyn McpServer>,
     ) -> std::result::Result<Result, RpcError> {
         Ok(Result::default())
     }
@@ -77,7 +78,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_resources_request(
         &self,
         request: ListResourcesRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListResourcesResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -93,7 +94,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_resource_templates_request(
         &self,
         request: ListResourceTemplatesRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListResourceTemplatesResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -109,7 +110,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_read_resource_request(
         &self,
         request: ReadResourceRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ReadResourceResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -125,7 +126,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_subscribe_request(
         &self,
         request: SubscribeRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<Result, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -141,7 +142,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_unsubscribe_request(
         &self,
         request: UnsubscribeRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<Result, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -157,7 +158,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_prompts_request(
         &self,
         request: ListPromptsRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListPromptsResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -173,7 +174,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_get_prompt_request(
         &self,
         request: GetPromptRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<GetPromptResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -189,7 +190,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_list_tools_request(
         &self,
         request: ListToolsRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListToolsResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -205,7 +206,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_call_tool_request(
         &self,
         request: CallToolRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         runtime
             .assert_server_request_capabilities(request.method())
@@ -220,7 +221,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_set_level_request(
         &self,
         request: SetLevelRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<Result, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -236,7 +237,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_complete_request(
         &self,
         request: CompleteRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<CompleteResult, RpcError> {
         runtime.assert_server_request_capabilities(request.method())?;
         Err(RpcError::method_not_found().with_message(format!(
@@ -252,7 +253,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_custom_request(
         &self,
         request: Value,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<Value, RpcError> {
         Err(RpcError::method_not_found()
             .with_message("No handler is implemented for custom requests.".to_string()))
@@ -265,7 +266,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_initialized_notification(
         &self,
         notification: InitializedNotification,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -275,7 +276,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_cancelled_notification(
         &self,
         notification: CancelledNotification,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -285,7 +286,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_progress_notification(
         &self,
         notification: ProgressNotification,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -295,7 +296,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_roots_list_changed_notification(
         &self,
         notification: RootsListChangedNotification,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -320,7 +321,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     async fn handle_error(
         &self,
         error: &RpcError,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -329,7 +330,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ///
     /// Sends a "Server started successfully" message to stderr.
     /// Customize this function in your specific handler to implement behavior tailored to your MCP server's capabilities and requirements.
-    async fn on_server_started(&self, runtime: &dyn McpServer) {
+    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
         let _ = runtime
             .stderr_message("Server started successfully".into())
             .await;

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -325,14 +325,4 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
-
-    /// Called when the server has successfully started.
-    ///
-    /// Sends a "Server started successfully" message to stderr.
-    /// Customize this function in your specific handler to implement behavior tailored to your MCP server's capabilities and requirements.
-    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
-        let _ = runtime
-            .stderr_message("Server started successfully".into())
-            .await;
-    }
 }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
@@ -48,9 +48,4 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
         error: &RpcError,
         runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError>;
-    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
-        let _ = runtime
-            .stderr_message("Server started successfully".into())
-            .await;
-    }
 }

--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler_core.rs
@@ -1,8 +1,8 @@
+use crate::mcp_traits::mcp_server::McpServer;
 use crate::schema::schema_utils::*;
 use crate::schema::*;
 use async_trait::async_trait;
-
-use crate::mcp_traits::mcp_server::McpServer;
+use std::sync::Arc;
 
 /// Defines the `ServerHandlerCore` trait for handling Model Context Protocol (MCP) server operations.
 /// Unlike `ServerHandler`, this trait offers no default implementations, providing full control over MCP message handling
@@ -14,7 +14,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     /// The `runtime` parameter provides access to the server's runtime environment, allowing
     /// interaction with the server's capabilities.
     /// The default implementation does nothing.
-    async fn on_initialized(&self, _runtime: &dyn McpServer) {}
+    async fn on_initialized(&self, _runtime: Arc<dyn McpServer>) {}
 
     /// Asynchronously handles an incoming request from the client.
     ///
@@ -26,7 +26,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     async fn handle_request(
         &self,
         request: RequestFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ResultFromServer, RpcError>;
 
     /// Asynchronously handles an incoming notification from the client.
@@ -36,7 +36,7 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     async fn handle_notification(
         &self,
         notification: NotificationFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError>;
 
     /// Asynchronously handles an error received from the client.
@@ -46,9 +46,9 @@ pub trait ServerHandlerCore: Send + Sync + 'static {
     async fn handle_error(
         &self,
         error: &RpcError,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError>;
-    async fn on_server_started(&self, runtime: &dyn McpServer) {
+    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
         let _ = runtime
             .stderr_message("Server started successfully".into())
             .await;

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -55,8 +55,6 @@ pub struct ServerRuntime {
 impl McpServer for ServerRuntime {
     /// Set the client details, storing them in client_details
     async fn set_client_details(&self, client_details: InitializeRequestParams) -> SdkResult<()> {
-        // self.handler.on_server_started(self).await;
-
         self.client_details_tx
             .send(Some(client_details))
             .map_err(|_| {

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -521,8 +521,6 @@ impl ServerRuntime {
                         // Drop tx to close the channel and collect remaining results
                         drop(tx);
                         while let Some(result) = rx.recv().await {
-                            println!(">>> 3000 {:?} ", result);
-
                             result?; // Propagate errors
                         }
                         return  Ok(());

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -49,7 +49,7 @@ pub fn create_server(
         ServerMessage,
     >,
     handler: impl ServerHandler,
-) -> ServerRuntime {
+) -> Arc<ServerRuntime> {
     ServerRuntime::new(
         server_details,
         transport,
@@ -62,7 +62,7 @@ pub(crate) fn create_server_instance(
     server_details: Arc<InitializeResult>,
     handler: Arc<dyn McpServerHandler>,
     session_id: SessionId,
-) -> ServerRuntime {
+) -> Arc<ServerRuntime> {
     ServerRuntime::new_instance(server_details, handler, session_id)
 }
 
@@ -80,7 +80,7 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
     async fn handle_request(
         &self,
         client_jsonrpc_request: RequestFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ResultFromServer, RpcError> {
         match client_jsonrpc_request {
             schema_utils::RequestFromClient::ClientRequest(client_request) => {
@@ -178,7 +178,7 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
     async fn handle_error(
         &self,
         jsonrpc_error: &RpcError,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> SdkResult<()> {
         self.handler.handle_error(jsonrpc_error, runtime).await?;
         Ok(())
@@ -187,7 +187,7 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
     async fn handle_notification(
         &self,
         client_jsonrpc_notification: NotificationFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> SdkResult<()> {
         match client_jsonrpc_notification {
             schema_utils::NotificationFromClient::ClientNotification(client_notification) => {
@@ -199,7 +199,10 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
                     }
                     ClientNotification::InitializedNotification(initialized_notification) => {
                         self.handler
-                            .handle_initialized_notification(initialized_notification, runtime)
+                            .handle_initialized_notification(
+                                initialized_notification,
+                                runtime.clone(),
+                            )
                             .await?;
                         self.handler.on_initialized(runtime).await;
                     }
@@ -227,7 +230,7 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
         Ok(())
     }
 
-    async fn on_server_started(&self, runtime: &dyn McpServer) {
+    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
         self.handler.on_server_started(runtime).await;
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime.rs
@@ -229,8 +229,4 @@ impl McpServerHandler for ServerRuntimeInternalHandler<Box<dyn ServerHandler>> {
         }
         Ok(())
     }
-
-    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
-        self.handler.on_server_started(runtime).await;
-    }
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime/mcp_server_runtime_core.rs
@@ -109,7 +109,4 @@ impl McpServerHandler for RuntimeCoreInternalHandler<Box<dyn ServerHandlerCore>>
             .await?;
         Ok(())
     }
-    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
-        self.handler.on_server_started(runtime).await;
-    }
 }

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
@@ -18,7 +18,6 @@ use super::mcp_server::McpServer;
 #[cfg(feature = "server")]
 #[async_trait]
 pub trait McpServerHandler: Send + Sync {
-    async fn on_server_started(&self, runtime: Arc<dyn McpServer>);
     async fn handle_request(
         &self,
         client_jsonrpc_request: RequestFromClient,

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_handler.rs
@@ -6,9 +6,9 @@ use crate::schema::schema_utils::{NotificationFromClient, RequestFromClient, Res
 #[cfg(feature = "client")]
 use crate::schema::schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient};
 
-use crate::schema::RpcError;
-
 use crate::error::SdkResult;
+use crate::schema::RpcError;
+use std::sync::Arc;
 
 #[cfg(feature = "client")]
 use super::mcp_client::McpClient;
@@ -18,21 +18,21 @@ use super::mcp_server::McpServer;
 #[cfg(feature = "server")]
 #[async_trait]
 pub trait McpServerHandler: Send + Sync {
-    async fn on_server_started(&self, runtime: &dyn McpServer);
+    async fn on_server_started(&self, runtime: Arc<dyn McpServer>);
     async fn handle_request(
         &self,
         client_jsonrpc_request: RequestFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ResultFromServer, RpcError>;
     async fn handle_error(
         &self,
         jsonrpc_error: &RpcError,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> SdkResult<()>;
     async fn handle_notification(
         &self,
         client_jsonrpc_notification: NotificationFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> SdkResult<()>;
 }
 

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_server.rs
@@ -13,16 +13,15 @@ use crate::schema::{
     ResourceUpdatedNotification, ResourceUpdatedNotificationParams, RpcError, ServerCapabilities,
     SetLevelRequest, ToolListChangedNotification, ToolListChangedNotificationParams,
 };
+use crate::{error::SdkResult, utils::format_assertion_message};
 use async_trait::async_trait;
 use rust_mcp_transport::SessionId;
-use std::time::Duration;
-
-use crate::{error::SdkResult, utils::format_assertion_message};
+use std::{sync::Arc, time::Duration};
 
 //TODO: support options , such as enforceStrictCapabilities
 #[async_trait]
 pub trait McpServer: Sync + Send {
-    async fn start(&self) -> SdkResult<()>;
+    async fn start(self: Arc<Self>) -> SdkResult<()>;
     async fn set_client_details(&self, client_details: InitializeRequestParams) -> SdkResult<()>;
     fn server_info(&self) -> &InitializeResult;
     fn client_info(&self) -> Option<InitializeRequestParams>;

--- a/crates/rust-mcp-sdk/tests/common/test_server.rs
+++ b/crates/rust-mcp-sdk/tests/common/test_server.rs
@@ -17,7 +17,7 @@ pub mod test_server_common {
         mcp_server::{hyper_server, HyperServer, HyperServerOptions, IdGenerator, ServerHandler},
         McpServer, SessionId,
     };
-    use std::sync::RwLock;
+    use std::sync::{Arc, RwLock};
     use std::time::Duration;
     use tokio::time::timeout;
 
@@ -71,7 +71,7 @@ pub mod test_server_common {
 
     #[async_trait]
     impl ServerHandler for TestServerHandler {
-        async fn on_server_started(&self, runtime: &dyn McpServer) {
+        async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
             let _ = runtime
                 .stderr_message("Server started successfully".into())
                 .await;
@@ -80,7 +80,7 @@ pub mod test_server_common {
         async fn handle_list_tools_request(
             &self,
             request: ListToolsRequest,
-            runtime: &dyn McpServer,
+            runtime: Arc<dyn McpServer>,
         ) -> std::result::Result<ListToolsResult, RpcError> {
             runtime.assert_server_request_capabilities(request.method())?;
 
@@ -94,7 +94,7 @@ pub mod test_server_common {
         async fn handle_call_tool_request(
             &self,
             request: CallToolRequest,
-            runtime: &dyn McpServer,
+            runtime: Arc<dyn McpServer>,
         ) -> std::result::Result<CallToolResult, CallToolError> {
             runtime
                 .assert_server_request_capabilities(request.method())

--- a/crates/rust-mcp-sdk/tests/common/test_server.rs
+++ b/crates/rust-mcp-sdk/tests/common/test_server.rs
@@ -71,12 +71,6 @@ pub mod test_server_common {
 
     #[async_trait]
     impl ServerHandler for TestServerHandler {
-        async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {
-            let _ = runtime
-                .stderr_message("Server started successfully".into())
-                .await;
-        }
-
         async fn handle_list_tools_request(
             &self,
             request: ListToolsRequest,

--- a/crates/rust-mcp-sdk/tests/test_protocol_compatibility.rs
+++ b/crates/rust-mcp-sdk/tests/test_protocol_compatibility.rs
@@ -30,7 +30,7 @@ mod protocol_compatibility_on_server {
         );
 
         handler
-            .handle_initialize_request(InitializeRequest::new(initialize_request), &runtime)
+            .handle_initialize_request(InitializeRequest::new(initialize_request), runtime)
             .await
     }
 

--- a/crates/rust-mcp-transport/src/stdio.rs
+++ b/crates/rust-mcp-transport/src/stdio.rs
@@ -210,13 +210,12 @@ where
                 .take()
                 .ok_or_else(|| TransportError::FromString("Unable to retrieve stderr.".into()))?;
 
-            let pending_requests_clone1 = self.pending_requests.clone();
-            let pending_requests_clone2 = self.pending_requests.clone();
+            let pending_requests_clone = self.pending_requests.clone();
 
             tokio::spawn(async move {
                 let _ = process.wait().await;
                 // clean up pending requests to cancel waiting tasks
-                let mut pending_requests = pending_requests_clone1.lock().await;
+                let mut pending_requests = pending_requests_clone.lock().await;
                 pending_requests.clear();
             });
 
@@ -224,7 +223,7 @@ where
                 Box::pin(stdout),
                 Mutex::new(Box::pin(stdin)),
                 IoStream::Readable(Box::pin(stderr)),
-                pending_requests_clone2,
+                self.pending_requests.clone(),
                 self.options.timeout,
                 cancellation_token,
             );

--- a/doc/getting-started-mcp-server.md
+++ b/doc/getting-started-mcp-server.md
@@ -160,7 +160,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_list_tools_request(
         &self,
         _request: ListToolsRequest,
-        _runtime: &dyn McpServer,
+        _runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListToolsResult, RpcError> {
         Ok(ListToolsResult {
             meta: None,
@@ -173,7 +173,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_call_tool_request(
         &self,
         request: CallToolRequest,
-        _runtime: &dyn McpServer,
+        _runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         // Attempt to convert request parameters into GreetingTools enum
         let tool_params: GreetingTools =

--- a/examples/hello-world-mcp-server-core/src/handler.rs
+++ b/examples/hello-world-mcp-server-core/src/handler.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use rust_mcp_sdk::schema::{
@@ -22,7 +24,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_request(
         &self,
         request: RequestFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ResultFromServer, RpcError> {
         let method_name = &request.method().to_owned();
         match request {
@@ -90,7 +92,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_notification(
         &self,
         notification: NotificationFromClient,
-        _: &dyn McpServer,
+        _: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -99,7 +101,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_error(
         &self,
         error: &RpcError,
-        _: &dyn McpServer,
+        _: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }

--- a/examples/hello-world-mcp-server/src/handler.rs
+++ b/examples/hello-world-mcp-server/src/handler.rs
@@ -4,6 +4,7 @@ use rust_mcp_sdk::schema::{
     ListToolsResult, RpcError,
 };
 use rust_mcp_sdk::{mcp_server::ServerHandler, McpServer};
+use std::sync::Arc;
 
 use crate::tools::GreetingTools;
 
@@ -20,7 +21,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_list_tools_request(
         &self,
         request: ListToolsRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListToolsResult, RpcError> {
         Ok(ListToolsResult {
             meta: None,
@@ -33,7 +34,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_call_tool_request(
         &self,
         request: CallToolRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         // Attempt to convert request parameters into GreetingTools enum
         let tool_params: GreetingTools =

--- a/examples/hello-world-mcp-server/src/main.rs
+++ b/examples/hello-world-mcp-server/src/main.rs
@@ -1,6 +1,8 @@
 mod handler;
 mod tools;
 
+use std::sync::Arc;
+
 use handler::MyServerHandler;
 use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
@@ -40,7 +42,8 @@ async fn main() -> SdkResult<()> {
     let handler = MyServerHandler {};
 
     // STEP 4: create a MCP server
-    let server: ServerRuntime = server_runtime::create_server(server_details, transport, handler);
+    let server: Arc<ServerRuntime> =
+        server_runtime::create_server(server_details, transport, handler);
 
     // STEP 5: Start the server
     if let Err(start_error) = server.start().await {

--- a/examples/hello-world-server-core-streamable-http/src/handler.rs
+++ b/examples/hello-world-server-core-streamable-http/src/handler.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use rust_mcp_sdk::schema::{
@@ -22,7 +24,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_request(
         &self,
         request: RequestFromClient,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ResultFromServer, RpcError> {
         let method_name = &request.method().to_owned();
         match request {
@@ -95,7 +97,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_notification(
         &self,
         notification: NotificationFromClient,
-        _: &dyn McpServer,
+        _: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }
@@ -104,7 +106,7 @@ impl ServerHandlerCore for MyServerHandler {
     async fn handle_error(
         &self,
         error: &RpcError,
-        _: &dyn McpServer,
+        _: Arc<dyn McpServer>,
     ) -> std::result::Result<(), RpcError> {
         Ok(())
     }

--- a/examples/hello-world-server-streamable-http/src/handler.rs
+++ b/examples/hello-world-server-streamable-http/src/handler.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use rust_mcp_sdk::schema::{
     schema_utils::CallToolError, CallToolRequest, CallToolResult, ListToolsRequest,
@@ -20,7 +22,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_list_tools_request(
         &self,
         request: ListToolsRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<ListToolsResult, RpcError> {
         Ok(ListToolsResult {
             meta: None,
@@ -33,7 +35,7 @@ impl ServerHandler for MyServerHandler {
     async fn handle_call_tool_request(
         &self,
         request: CallToolRequest,
-        runtime: &dyn McpServer,
+        runtime: Arc<dyn McpServer>,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         // Attempt to convert request parameters into GreetingTools enum
         let tool_params: GreetingTools =
@@ -46,5 +48,5 @@ impl ServerHandler for MyServerHandler {
         }
     }
 
-    async fn on_server_started(&self, runtime: &dyn McpServer) {}
+    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {}
 }

--- a/examples/hello-world-server-streamable-http/src/handler.rs
+++ b/examples/hello-world-server-streamable-http/src/handler.rs
@@ -47,6 +47,4 @@ impl ServerHandler for MyServerHandler {
             GreetingTools::SayGoodbyeTool(say_goodbye_tool) => say_goodbye_tool.call_tool(),
         }
     }
-
-    async fn on_server_started(&self, runtime: Arc<dyn McpServer>) {}
 }


### PR DESCRIPTION
### 📌 Summary
This PR refactors the signature of handler functions in `ServerHandler` and `ServerHandlerCore` to accept an Arc<dyn McpServer> instead of a &dyn McpServer. 
This PR also refactors the start function in `server_runtime.rs` to prevent the stream loop from being blocked by handle_message calls.

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Updated handler functions to accept an `Arc<dyn McpServer>` instead of a `&dyn McpServer`
- Removed `on_server_started` in favor of `on_initialized`
- Unblock Stream Loop in start Function with Task Spawning 

### ⚠ BREAKING CHANGE:
- Any implementations or overrides of the `ServerHandler` and `ServerHandlerCore` functions must update their signatures to accept `Arc<dyn McpServer>` instead of `&dyn McpServer`
- `on_initialized()` should be used instead of `on_server_started()`
