### PR TITLE
feat: add tls-no-provider feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ The `rust-mcp-sdk` crate provides several features that can be enabled or disabl
 - `hyper-server`:  This feature enables the **sse** transport for MCP servers, supporting multiple simultaneous client connections out of the box.
 - `ssl`: This feature enables TLS/SSL support for the **sse** transport when used with the `hyper-server`.
 - `macros`: Provides procedural macros for simplifying the creation and manipulation of MCP Tool structures.
+- `tls-no-provider`: Enables TLS without a crypto provider. This is useful if you are already using a different crypto provider than the aws-lc default.
 
 #### MCP Protocol Versions with Corresponding Features
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -67,6 +67,7 @@ hyper-server = [
     "rust-mcp-transport/sse",
 ]
 ssl = ["axum-server/tls-rustls"]
+tls-no-provider = ["axum-server/tls-rustls-no-provider"]
 macros = ["rust-mcp-macros/sdk"]
 
 # enables mcp protocol version 2025_06_18


### PR DESCRIPTION
### 📌 Summary
Adds a tls-no-provider feature as currently enabling tls support pulls in the aws-lc crate which causes conflicts if you are using another crypto provider.


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Adds a tls-no-provider feature

### 🛠️ Testing Steps
Add the rust-mcp-stack to a project with no existing dependancy on aws-lc with the ssl feature disabeld and the tls-no-provider feature enabled. Check that when you build the project that the aws-lc crates aren't pulled in to the Cargo.lock file.


