### PR TITLE
feat(client_runtime): add method to check server autocompletion support

### DIFF
--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_client.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_client.rs
@@ -131,6 +131,22 @@ pub trait McpClient: Sync + Send {
             .map(|server_details| server_details.capabilities.logging.is_some())
     }
 
+    /// Checks if the server supports argument autocompletion suggestions.
+    ///
+    /// This function retrieves the server information and checks if the
+    /// server has completions capabilities listed. If the server info has
+    /// not been retrieved yet, it returns `None`. Otherwise, it returns
+    /// `Some(true)` if completions is supported, or `Some(false)` if not.
+    ///
+    /// # Returns
+    /// - `None` if server information is not yet available.
+    /// - `Some(true)` if completions is supported by the server.
+    /// - `Some(false)` if completions is not supported by the server.
+    fn server_supports_completion(&self) -> Option<bool> {
+        self.server_info()
+            .map(|server_details| server_details.capabilities.completions.is_some())
+    }
+
     fn instructions(&self) -> Option<String> {
         self.server_info()?.instructions
     }

--- a/crates/rust-mcp-sdk/src/schema.rs
+++ b/crates/rust-mcp-sdk/src/schema.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "2025_06_18")]
 pub use rust_mcp_schema::*;
 
+#[cfg(not(feature = "2025_06_18"))]
+pub use rust_mcp_schema::{ParseProtocolVersionError, ProtocolVersion};
+
 #[cfg(all(
     feature = "2025_03_26",
     not(any(feature = "2024_11_05", feature = "2025_06_18"))

--- a/examples/hello-world-mcp-server-stdio/src/main.rs
+++ b/examples/hello-world-mcp-server-stdio/src/main.rs
@@ -1,19 +1,17 @@
 mod handler;
 mod tools;
 
-use std::sync::Arc;
-
 use handler::MyServerHandler;
 use rust_mcp_sdk::schema::{
     Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
     LATEST_PROTOCOL_VERSION,
 };
-
 use rust_mcp_sdk::{
     error::SdkResult,
     mcp_server::{server_runtime, ServerRuntime},
     McpServer, StdioTransport, TransportOptions,
 };
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> SdkResult<()> {


### PR DESCRIPTION
### 📌 Summary
This change introduces the `server_supports_completion()` method, which checks whether the connected server supports argument autocompletion capabilities.


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Added server_supports_completion() method to the client runtime
- Fixed a bug where ProtocolVersion enum was not exported when using older version of the protocol

### 🛠️ Testing Steps
```
cargo run make
```
