### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,8 +1,8 @@
 {
-  "crates/rust-mcp-sdk": "0.8.0",
+  "crates/rust-mcp-sdk": "0.8.1",
   "crates/rust-mcp-macros": "0.8.0",
   "crates/rust-mcp-transport": "0.8.0",
-  "crates/rust-mcp-extra": "0.2.0",
+  "crates/rust-mcp-extra": "0.2.1",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.0...rust-mcp-extra-v0.2.1) (2026-01-01)
+
 ## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.1.4...rust-mcp-extra-v0.2.0) (2026-01-01)
 
 

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "0.8.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","hyper-server","macros"] }
+rust-mcp-sdk = {  version = "0.8.1" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","hyper-server","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.4", optional=true}

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.0...rust-mcp-sdk-v0.8.1) (2026-01-01)
+
+
+### 🐛 Bug Fixes
+
+* Make streamable-http feature enabled with hyper-server feature ([ed6b60c](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ed6b60c581d373358b50872cdbaad670da0e2bab))
+
 ## [0.8.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.7.4...rust-mcp-sdk-v0.8.0) (2026-01-01)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>rust-mcp-extra: 0.2.1</summary>

## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.0...rust-mcp-extra-v0.2.1) (2026-01-01)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 0.8.0 to 0.8.1
</details>

<details><summary>rust-mcp-sdk: 0.8.1</summary>

## [0.8.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.0...rust-mcp-sdk-v0.8.1) (2026-01-01)


### 🐛 Bug Fixes

* Make streamable-http feature enabled with hyper-server feature ([ed6b60c](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ed6b60c581d373358b50872cdbaad670da0e2bab))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).