### PR TITLE
feat: add support for imported serde_json::Number in JsonSchema derive

### DIFF
--- a/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
@@ -1,0 +1,16 @@
+use rust_mcp_macros::JsonSchema;
+use serde_json::Number;
+
+#[test]
+fn test_schema_number() {
+    #[allow(unused)]
+    #[derive(JsonSchema)]
+    struct TestStruct {
+        pub b: Number,
+    }
+
+    assert_eq!(
+        serde_json::to_string(&TestStruct::json_schema()).unwrap(),
+        r#"{"properties":{"b":{"type":"number"}},"required":["b"],"type":"object"}"#
+    )
+}


### PR DESCRIPTION
### 📌 Summary
This PR adds reliable support for `serde_json::Number` in the `JsonSchema` derive macro, covering both the fully qualified path (`serde_json::Number`) and the imported alias (`Number` via `use serde_json::Number;`).

### 🔍 Related Issues
- The fully qualified `serde_json::Number` was already handled correctly as a JSON Schema `"number"`.
- When `serde_json::Number` is imported as `Number`, the single-segment path was previously caught by the `might_be_struct` heuristic, causing the macro to attempt calling a non-existent `Number::json_schema()` method and resulting in a compile error.

### ✨ Changes Made
- minimum, maximum, and default attributes continue to work as before (using serde_json::Number construction).
- Added an explicit early check for single-segment `ident == "Number"` to correctly emit a `"number"` schema.
- Retained and clarified the existing 2-segment path handling for `serde_json::Number`.
- Both cases now produce identical JSON Schema output


### 🛠️ Testing Steps
```
cargo make check
```
