### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,8 +1,8 @@
 {
-  "crates/rust-mcp-sdk": "0.8.3",
-  "crates/rust-mcp-macros": "0.8.1",
-  "crates/rust-mcp-transport": "0.8.0",
-  "crates/rust-mcp-extra": "0.2.3",
+  "crates/rust-mcp-sdk": "0.9.0",
+  "crates/rust-mcp-macros": "0.9.0",
+  "crates/rust-mcp-transport": "0.9.0",
+  "crates/rust-mcp-extra": "0.2.4",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.8.0", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-transport = { version = "0.9.0", path = "crates/rust-mcp-transport", default-features = false }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "0.8.1", path = "crates/rust-mcp-macros", default-features = false }
+rust-mcp-macros = { version = "0.9.0", path = "crates/rust-mcp-macros", default-features = false }
 rust-mcp-extra = { version="0.1.0", path = "crates/rust-mcp-extra", default-features = false }
 
 # External crates

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.2.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.3...rust-mcp-extra-v0.2.4) (2026-03-13)
+
 ## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.2...rust-mcp-extra-v0.2.3) (2026-02-01)
 
 ## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.1...rust-mcp-extra-v0.2.2) (2026-01-18)

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "0.8.3" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","hyper-server","macros"] }
+rust-mcp-sdk = {  version = "0.9.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","hyper-server","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.4", optional=true}

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.8.1...rust-mcp-macros-v0.9.0) (2026-03-13)
+
+
+### ⚠ BREAKING CHANGES
+
+* update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137))
+
+### 🚀 Features
+
+* Update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137)) ([2e6df18](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2e6df18de13d590a5dae527e90e115c81c658900))
+
+
+### 🐛 Bug Fixes
+
+* Upgrade dependencies to fix security vulnerabilities ([19473ee](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/19473ee0e9e51a18a4ee80ce23881f61346d7d17))
+
 ## [0.8.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.8.0...rust-mcp-macros-v0.8.1) (2026-02-01)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.3...rust-mcp-sdk-v0.9.0) (2026-03-13)
+
+
+### ⚠ BREAKING CHANGES
+
+* update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137))
+* introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136))
+
+### 🚀 Features
+
+* Introduce health check handler support ([#135](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/135)) ([88f908e](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/88f908ea4dc9d62c7a4b435660cf28bf1f7a69f8))
+* Introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136)) ([58df88f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/58df88f9855224a4395fc092937a9f513f2ead39))
+* Update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137)) ([2e6df18](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2e6df18de13d590a5dae527e90e115c81c658900))
+
+
+### 🐛 Bug Fixes
+
+* ServerHandler task handling method return types ([#132](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/132)) ([45f1305](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/45f1305784fbec0dff58a42141f0a76f02c02509))
+
 ## [0.8.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.2...rust-mcp-sdk-v0.8.3) (2026-02-01)
 
 ## [0.8.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.1...rust-mcp-sdk-v0.8.2) (2026-01-18)

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.8.0...rust-mcp-transport-v0.9.0) (2026-03-13)
+
+
+### ⚠ BREAKING CHANGES
+
+* introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136))
+
+### 🚀 Features
+
+* Introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136)) ([58df88f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/58df88f9855224a4395fc092937a9f513f2ead39))
+
 ## [0.8.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.6.3...rust-mcp-transport-v0.8.0) (2026-01-01)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>rust-mcp-extra: 0.2.4</summary>

## [0.2.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.3...rust-mcp-extra-v0.2.4) (2026-03-13)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 0.8.3 to 0.9.0
</details>

<details><summary>rust-mcp-macros: 0.9.0</summary>

## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.8.1...rust-mcp-macros-v0.9.0) (2026-03-13)


### ⚠ BREAKING CHANGES

* update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137))

### 🚀 Features

* Update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137)) ([2e6df18](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2e6df18de13d590a5dae527e90e115c81c658900))


### 🐛 Bug Fixes

* Upgrade dependencies to fix security vulnerabilities ([19473ee](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/19473ee0e9e51a18a4ee80ce23881f61346d7d17))
</details>

<details><summary>rust-mcp-sdk: 0.9.0</summary>

## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.3...rust-mcp-sdk-v0.9.0) (2026-03-13)


### ⚠ BREAKING CHANGES

* update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137))
* introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136))

### 🚀 Features

* Introduce health check handler support ([#135](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/135)) ([88f908e](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/88f908ea4dc9d62c7a4b435660cf28bf1f7a69f8))
* Introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136)) ([58df88f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/58df88f9855224a4395fc092937a9f513f2ead39))
* Update to rust-mcp-schema 0.10 with BTreeMap for deterministic serialization ([#137](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/137)) ([2e6df18](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2e6df18de13d590a5dae527e90e115c81c658900))

#### Related Issues
 - Fixes #133 
- rust-mcp-stack/rust-mcp-schema#105
 
### 🐛 Bug Fixes

* ServerHandler task handling method return types ([#132](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/132)) ([45f1305](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/45f1305784fbec0dff58a42141f0a76f02c02509))
</details>

<details><summary>rust-mcp-transport: 0.9.0</summary>

## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.8.0...rust-mcp-transport-v0.9.0) (2026-03-13)


### ⚠ BREAKING CHANGES

* introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136))

### 🚀 Features

* Introduce McpObserver for telemetry and message monitoring ([#136](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/136)) ([58df88f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/58df88f9855224a4395fc092937a9f513f2ead39))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).