### PR TITLE
Add AgentRank score badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Rust MCP SDK
 
+[![AgentRank](https://agentrank-ai.com/api/badge/tool/rust-mcp-stack--rust-mcp-sdk)](https://agentrank-ai.com/tool/rust-mcp-stack--rust-mcp-sdk/)
+
 [<img alt="crates.io" src="https://img.shields.io/crates/v/rust-mcp-sdk?style=for-the-badge&logo=rust&color=FE965D" height="22">](https://crates.io/crates/rust-mcp-sdk)
 [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-rust_mcp_SDK-0ECDAB?style=for-the-badge&logo=docs.rs" height="22">](https://docs.rs/rust-mcp-sdk)
 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/rust-mcp-stack/rust-mcp-sdk/ci.yml?style=for-the-badge" height="22">


### PR DESCRIPTION
Hi! Your tool ranks in the top 20 on [AgentRank](https://agentrank-ai.com/tool/rust-mcp-stack--rust-mcp-sdk/), a ranked index of MCP servers and agent tools scored daily from real GitHub signals. **rust-mcp-sdk** currently scores **70.36/100**.

This PR adds a score badge to your README so visitors can see how the tool stacks up in the ecosystem:

[![AgentRank](https://agentrank-ai.com/api/badge/tool/rust-mcp-stack--rust-mcp-sdk)](https://agentrank-ai.com/tool/rust-mcp-stack--rust-mcp-sdk/)

Happy to adjust placement. No pressure to merge — just wanted to let you know you're ranking well.