### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,10 +1,10 @@
 {
-  "crates/rust-mcp-sdk": "0.9.0",
-  "crates/rust-mcp-macros": "0.9.0",
-  "crates/rust-mcp-transport": "0.9.0",
-  "crates/rust-mcp-extra": "0.2.4",
-  "crates/rust-mcp-axum": "0.1.0",
-  "crates/rust-mcp-actix": "0.1.0",
+  "crates/rust-mcp-sdk": "0.10.0",
+  "crates/rust-mcp-macros": "0.9.1",
+  "crates/rust-mcp-transport": "0.9.1",
+  "crates/rust-mcp-extra": "0.3.0",
+  "crates/rust-mcp-axum": "0.2.0",
+  "crates/rust-mcp-actix": "0.1.1",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",
@@ -15,5 +15,7 @@
   "examples/simple-mcp-client-sse": "0.1.27",
   "examples/simple-mcp-client-streamable-http": "0.1.5",
   "examples/simple-mcp-client-streamable-http-core": "0.1.5",
-  "examples/auth/server-oauth-remote": "0.1.35"
+  "examples/auth/server-oauth-remote": "0.1.35",
+  "crates/conformance-client": "0.1.1",
+  "crates/conformance-server": "0.1.1"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-actix"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-axum"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.9.0", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-transport = { version = "0.9.1", path = "crates/rust-mcp-transport", default-features = false }
 rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "0.9.0", path = "crates/rust-mcp-macros", default-features = false }
+rust-mcp-macros = { version = "0.9.1", path = "crates/rust-mcp-macros", default-features = false }
 rust-mcp-extra = { version="0.1.0", path = "crates/rust-mcp-extra", default-features = false }
-rust-mcp-axum = { version = "0.1.0", path = "crates/rust-mcp-axum" }
-rust-mcp-actix = { version = "0.1.0", path = "crates/rust-mcp-actix" }
+rust-mcp-axum = { version = "0.2.0", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "0.1.1", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version="0.10",  default-features = false }

--- a/crates/conformance-client/Cargo.toml
+++ b/crates/conformance-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test client — runs the official MCP client conformance suite against the rust-mcp-sdk client runtime."

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test server — implements all scenarios from the MCP conformance suite. Also serves as a reference implementation showing how to build a fully-featured MCP server with rust-mcp-sdk."

--- a/crates/rust-mcp-actix/CHANGELOG.md
+++ b/crates/rust-mcp-actix/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.1.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.0...rust-mcp-actix-v0.1.1) (2026-06-24)
+
+
+### 🚀 Features
+
+* Enforce request body size limits with shared McpMountOptions ([#163](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/163)) ([8dd749a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd749aa9aa5cac9aef8d7a931bb16e947e01a42))
+* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
+* **session:** Make session store injectable with bounded default ([#167](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/167)) ([af601b5](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/af601b56e236fe0e10bb5659e7f6ed6b90917d51))
+
+
+### 🐛 Bug Fixes
+
+* **http:** Auto-derive DNS rebinding allowed_hosts from bind address ([#165](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/165)) ([55d8a03](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/55d8a03764921329e0e81f0d406452ca3313bffd))
+
+
+### ⚡ Performance Improvements
+
+* Extract POST body as Bytes ([#166](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/166)) ([352a5fd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/352a5fd890378181dda1f893e91ef4a5e16d6b63))
+
+
+### 📚 Documentation
+
+* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
+* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-actix"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ali Hashemi"]
 description = "Actix-web HTTP server integration for rust-mcp-sdk"
 repository = "https://github.com/rust-mcp-stack/rust-mcp-sdk"

--- a/crates/rust-mcp-axum/CHANGELOG.md
+++ b/crates/rust-mcp-axum/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.1.0...rust-mcp-axum-v0.2.0) (2026-06-24)
+
+
+### ⚠ BREAKING CHANGES
+
+* extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146))
+* extract Axum to standalone rust-mcp-axum crate
+
+### 🚀 Features
+
+* Enforce request body size limits with shared McpMountOptions ([#163](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/163)) ([8dd749a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd749aa9aa5cac9aef8d7a931bb16e947e01a42))
+* Extract Axum to standalone rust-mcp-axum crate ([0bd6cf6](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0bd6cf6721b25c1066c702d2bdf752143ad2ecf3))
+* Extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146)) ([ddc5600](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ddc56001cd561aef0eccadd0c3bb788c176575ff))
+* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
+* **session:** Make session store injectable with bounded default ([#167](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/167)) ([af601b5](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/af601b56e236fe0e10bb5659e7f6ed6b90917d51))
+
+
+### 🐛 Bug Fixes
+
+* **http:** Auto-derive DNS rebinding allowed_hosts from bind address ([#165](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/165)) ([55d8a03](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/55d8a03764921329e0e81f0d406452ca3313bffd))
+
+
+### ⚡ Performance Improvements
+
+* Extract POST body as Bytes ([#166](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/166)) ([352a5fd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/352a5fd890378181dda1f893e91ef4a5e16d6b63))
+
+
+### 📚 Documentation
+
+* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
+* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-axum"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "Axum HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.4...rust-mcp-extra-v0.3.0) (2026-06-24)
+
+
+### ⚠ BREAKING CHANGES
+
+* extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146))
+* extract Axum to standalone rust-mcp-axum crate
+
+### 🚀 Features
+
+* Add allowlist override for JWKS algorithms ([ee680a8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ee680a8e3ffd4cc5e3c742c619b63c1cba063e43))
+* Extract Axum to standalone rust-mcp-axum crate ([0bd6cf6](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0bd6cf6721b25c1066c702d2bdf752143ad2ecf3))
+* Extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146)) ([ddc5600](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ddc56001cd561aef0eccadd0c3bb788c176575ff))
+
+
+### 🐛 Bug Fixes
+
+* **auth:** Pin JWT validation algorithms to an allowlist ([#148](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/148)) ([c1ee180](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c1ee1808145fb29ef95b273fdb30bb7139e959eb))
+* **auth:** Validate token audience by default ([#149](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/149)) ([1f714bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1f714bf728caefcc1f4c07d853ce90b2622456a1))
+* Update getting started document ([#162](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/162)) ([3e22cfe](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/3e22cfee318a104f5c3a0e28a8e0b04410612c32))
+
+
+### ⚡ Performance Improvements
+
+* **auth:** Reuse a shared reqwest::Client with timeouts ([#172](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/172)) ([c644426](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c64442644076d5dbcd9437245aecff5c36b4fb32))
+
+
+### 📚 Documentation
+
+* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
+
+
+### 🚜 Code Refactoring
+
+* Switch mcp http to framework-agnostic McpHttpError  ([#144](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/144)) ([e0c44c0](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0c44c0e4f8aaed9bfc59b9274d11c346646a635))
+* Switch mcp_http layer to framework-agnostic McpHttpError ([afaf4b1](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/afaf4b1ebfe070f565a1857ed707da678b9d16ae))
+
 ## [0.2.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.3...rust-mcp-extra-v0.2.4) (2026-03-13)
 
 ## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.2...rust-mcp-extra-v0.2.3) (2026-02-01)

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "0.9.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
+rust-mcp-sdk = {  version = "0.10.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.5", optional=true}

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.9.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.9.0...rust-mcp-macros-v0.9.1) (2026-06-24)
+
+
+### 📚 Documentation
+
+* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
+* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))
+
 ## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.8.1...rust-mcp-macros-v0.9.0) (2026-03-13)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [0.10.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.9.0...rust-mcp-sdk-v0.10.0) (2026-06-24)
+
+
+### ⚠ BREAKING CHANGES
+
+* extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146))
+* extract Axum to standalone rust-mcp-axum crate
+
+### 🚀 Features
+
+* 100% MCP server and client conformance ([#185](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/185)) ([9c0c6ef](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9c0c6ef0d1b8a08c9d406e4890ae99fa06ba9c1b))
+* Add allowlist override for JWKS algorithms ([ee680a8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ee680a8e3ffd4cc5e3c742c619b63c1cba063e43))
+* Add MCP conformance server, CI workflow ([#176](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/176)) ([4422d5d](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4422d5d1f9fc2b39acfbf5e16f71c6237a4ff6af))
+* Add McpAuthClient for client-side OAuth 2.0 support ([#184](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/184)) ([9d9be73](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9d9be73aadfc7e23b3417f94db89c2e033b10555))
+* Enforce request body size limits with shared McpMountOptions ([#163](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/163)) ([8dd749a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd749aa9aa5cac9aef8d7a931bb16e947e01a42))
+* Extract Axum to standalone rust-mcp-axum crate ([0bd6cf6](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0bd6cf6721b25c1066c702d2bdf752143ad2ecf3))
+* Extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146)) ([ddc5600](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ddc56001cd561aef0eccadd0c3bb788c176575ff))
+* Introduce framework-agnostic McpHttpError type ([4199845](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/41998454b9b99b74be090b66aa862211ecfd420b))
+* Introduce framework-agnostic McpHttpError type ([#143](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/143)) ([2e3c4ca](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2e3c4ca25dc2c0eb1d21e7b1be3a2fee7edee8b3))
+* **session:** Make session store injectable with bounded default ([#167](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/167)) ([af601b5](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/af601b56e236fe0e10bb5659e7f6ed6b90917d51))
+
+
+### 🐛 Bug Fixes
+
+* **auth:** Pin JWT validation algorithms to an allowlist ([#148](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/148)) ([c1ee180](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c1ee1808145fb29ef95b273fdb30bb7139e959eb))
+* **auth:** Validate token audience by default ([#149](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/149)) ([1f714bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1f714bf728caefcc1f4c07d853ce90b2622456a1))
+* Drop lock before sleep, configurable options ([#170](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/170)) ([0f15e56](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0f15e56c7d8a323237a1b463d4735ddc40ac3287))
+* **http:** Auto-derive DNS rebinding allowed_hosts from bind address ([#165](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/165)) ([55d8a03](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/55d8a03764921329e0e81f0d406452ca3313bffd))
+* **http:** Validate session-id and last-event-id headers ([#169](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/169)) ([67e5a2d](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/67e5a2dacef249191e9355a6fcd4b2bb22e2bb5c))
+
+
+### ⚡ Performance Improvements
+
+* **auth:** Reuse a shared reqwest::Client with timeouts ([#172](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/172)) ([c644426](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c64442644076d5dbcd9437245aecff5c36b4fb32))
+* Extract POST body as Bytes ([#166](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/166)) ([352a5fd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/352a5fd890378181dda1f893e91ef4a5e16d6b63))
+* Shard session store lock with monotonic time and O(1) capacity check ([#168](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/168)) ([a5181a9](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/a5181a9c62ec95420edd79485654cacd532dbf73))
+
+
+### 📚 Documentation
+
+* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
+* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))
+
+
+### 🚜 Code Refactoring
+
+* Switch mcp http to framework-agnostic McpHttpError  ([#144](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/144)) ([e0c44c0](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0c44c0e4f8aaed9bfc59b9274d11c346646a635))
+* Switch mcp_http layer to framework-agnostic McpHttpError ([afaf4b1](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/afaf4b1ebfe070f565a1857ed707da678b9d16ae))
+
 ## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.8.3...rust-mcp-sdk-v0.9.0) (2026-03-13)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.9.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.9.0...rust-mcp-transport-v0.9.1) (2026-06-24)
+
+
+### 🚀 Features
+
+* 100% MCP server and client conformance ([#185](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/185)) ([9c0c6ef](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9c0c6ef0d1b8a08c9d406e4890ae99fa06ba9c1b))
+
+
+### 🐛 Bug Fixes
+
+* **transport:** Cap transport line length ([#164](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/164)) ([344e9ee](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/344e9ee8486f403472622075583844223d738402))
+* **transport:** Make message channel capacity configurable for all transports ([#171](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/171)) ([f4edef4](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f4edef44fa0dc54408a7932f2cb33c829bfc2b91))
+
+
+### 📚 Documentation
+
+* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
+
 ## [0.9.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.8.0...rust-mcp-transport-v0.9.0) (2026-03-13)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>conformance-client: 0.1.1</summary>

### Dependencies


</details>

<details><summary>conformance-server: 0.1.1</summary>

### Dependencies


</details>

<details><summary>rust-mcp-actix: 0.1.1</summary>

## [0.1.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.0...rust-mcp-actix-v0.1.1) (2026-06-24)


### 🚀 Features

* Enforce request body size limits with shared McpMountOptions ([#163](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/163)) ([8dd749a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd749aa9aa5cac9aef8d7a931bb16e947e01a42))
* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
* **session:** Make session store injectable with bounded default ([#167](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/167)) ([af601b5](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/af601b56e236fe0e10bb5659e7f6ed6b90917d51))


### 🐛 Bug Fixes

* **http:** Auto-derive DNS rebinding allowed_hosts from bind address ([#165](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/165)) ([55d8a03](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/55d8a03764921329e0e81f0d406452ca3313bffd))


### ⚡ Performance Improvements

* Extract POST body as Bytes ([#166](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/166)) ([352a5fd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/352a5fd890378181dda1f893e91ef4a5e16d6b63))


### 📚 Documentation

* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))
</details>

<details><summary>rust-mcp-axum: 0.2.0</summary>

## [0.2.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.1.0...rust-mcp-axum-v0.2.0) (2026-06-24)


### ⚠ BREAKING CHANGES

* extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146))
* extract Axum to standalone rust-mcp-axum crate

### 🚀 Features

* Enforce request body size limits with shared McpMountOptions ([#163](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/163)) ([8dd749a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd749aa9aa5cac9aef8d7a931bb16e947e01a42))
* Extract Axum to standalone rust-mcp-axum crate ([0bd6cf6](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0bd6cf6721b25c1066c702d2bdf752143ad2ecf3))
* Extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146)) ([ddc5600](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ddc56001cd561aef0eccadd0c3bb788c176575ff))
* Initial release v0.1.0 ([4c08beb](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4c08beb73b102c77e65b724b284008071b7f5ef4))
* **session:** Make session store injectable with bounded default ([#167](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/167)) ([af601b5](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/af601b56e236fe0e10bb5659e7f6ed6b90917d51))


### 🐛 Bug Fixes

* **http:** Auto-derive DNS rebinding allowed_hosts from bind address ([#165](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/165)) ([55d8a03](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/55d8a03764921329e0e81f0d406452ca3313bffd))


### ⚡ Performance Improvements

* Extract POST body as Bytes ([#166](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/166)) ([352a5fd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/352a5fd890378181dda1f893e91ef4a5e16d6b63))


### 📚 Documentation

* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))
</details>

<details><summary>rust-mcp-extra: 0.3.0</summary>

## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.4...rust-mcp-extra-v0.3.0) (2026-06-24)


### ⚠ BREAKING CHANGES

* extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146))
* extract Axum to standalone rust-mcp-axum crate

### 🚀 Features

* Add allowlist override for JWKS algorithms ([ee680a8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ee680a8e3ffd4cc5e3c742c619b63c1cba063e43))
* Extract Axum to standalone rust-mcp-axum crate ([0bd6cf6](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0bd6cf6721b25c1066c702d2bdf752143ad2ecf3))
* Extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146)) ([ddc5600](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ddc56001cd561aef0eccadd0c3bb788c176575ff))


### 🐛 Bug Fixes

* **auth:** Pin JWT validation algorithms to an allowlist ([#148](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/148)) ([c1ee180](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c1ee1808145fb29ef95b273fdb30bb7139e959eb))
* **auth:** Validate token audience by default ([#149](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/149)) ([1f714bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1f714bf728caefcc1f4c07d853ce90b2622456a1))
* Update getting started document ([#162](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/162)) ([3e22cfe](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/3e22cfee318a104f5c3a0e28a8e0b04410612c32))


### ⚡ Performance Improvements

* **auth:** Reuse a shared reqwest::Client with timeouts ([#172](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/172)) ([c644426](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c64442644076d5dbcd9437245aecff5c36b4fb32))


### 📚 Documentation

* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))


### 🚜 Code Refactoring

* Switch mcp http to framework-agnostic McpHttpError  ([#144](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/144)) ([e0c44c0](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0c44c0e4f8aaed9bfc59b9274d11c346646a635))
* Switch mcp_http layer to framework-agnostic McpHttpError ([afaf4b1](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/afaf4b1ebfe070f565a1857ed707da678b9d16ae))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 0.9.0 to 0.10.0
</details>

<details><summary>rust-mcp-macros: 0.9.1</summary>

## [0.9.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.9.0...rust-mcp-macros-v0.9.1) (2026-06-24)


### 📚 Documentation

* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))
</details>

<details><summary>rust-mcp-sdk: 0.10.0</summary>

## [0.10.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.9.0...rust-mcp-sdk-v0.10.0) (2026-06-24)


### ⚠ BREAKING CHANGES

* extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146))
* extract Axum to standalone rust-mcp-axum crate

### 🚀 Features

* 100% MCP server and client conformance ([#185](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/185)) ([9c0c6ef](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9c0c6ef0d1b8a08c9d406e4890ae99fa06ba9c1b))
* Add allowlist override for JWKS algorithms ([ee680a8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ee680a8e3ffd4cc5e3c742c619b63c1cba063e43))
* Add MCP conformance server, CI workflow ([#176](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/176)) ([4422d5d](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4422d5d1f9fc2b39acfbf5e16f71c6237a4ff6af))
* Add McpAuthClient for client-side OAuth 2.0 support ([#184](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/184)) ([9d9be73](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9d9be73aadfc7e23b3417f94db89c2e033b10555))
* Enforce request body size limits with shared McpMountOptions ([#163](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/163)) ([8dd749a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/8dd749aa9aa5cac9aef8d7a931bb16e947e01a42))
* Extract Axum to standalone rust-mcp-axum crate ([0bd6cf6](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0bd6cf6721b25c1066c702d2bdf752143ad2ecf3))
* Extract Axum to standalone rust-mcp-axum crate ([#146](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/146)) ([ddc5600](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/ddc56001cd561aef0eccadd0c3bb788c176575ff))
* Introduce framework-agnostic McpHttpError type ([4199845](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/41998454b9b99b74be090b66aa862211ecfd420b))
* Introduce framework-agnostic McpHttpError type ([#143](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/143)) ([2e3c4ca](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/2e3c4ca25dc2c0eb1d21e7b1be3a2fee7edee8b3))
* **session:** Make session store injectable with bounded default ([#167](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/167)) ([af601b5](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/af601b56e236fe0e10bb5659e7f6ed6b90917d51))


### 🐛 Bug Fixes

* **auth:** Pin JWT validation algorithms to an allowlist ([#148](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/148)) ([c1ee180](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c1ee1808145fb29ef95b273fdb30bb7139e959eb))
* **auth:** Validate token audience by default ([#149](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/149)) ([1f714bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1f714bf728caefcc1f4c07d853ce90b2622456a1))
* Drop lock before sleep, configurable options ([#170](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/170)) ([0f15e56](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0f15e56c7d8a323237a1b463d4735ddc40ac3287))
* **http:** Auto-derive DNS rebinding allowed_hosts from bind address ([#165](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/165)) ([55d8a03](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/55d8a03764921329e0e81f0d406452ca3313bffd))
* **http:** Validate session-id and last-event-id headers ([#169](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/169)) ([67e5a2d](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/67e5a2dacef249191e9355a6fcd4b2bb22e2bb5c))


### ⚡ Performance Improvements

* **auth:** Reuse a shared reqwest::Client with timeouts ([#172](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/172)) ([c644426](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/c64442644076d5dbcd9437245aecff5c36b4fb32))
* Extract POST body as Bytes ([#166](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/166)) ([352a5fd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/352a5fd890378181dda1f893e91ef4a5e16d6b63))
* Shard session store lock with monotonic time and O(1) capacity check ([#168](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/168)) ([a5181a9](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/a5181a9c62ec95420edd79485654cacd532dbf73))


### 📚 Documentation

* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
* Prepare v0.10.0 release ,upgrading.md, and migration guide ([#175](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/175)) ([4086a08](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4086a08742b1d46ff8abb17ce3796727de8e6ec3))


### 🚜 Code Refactoring

* Switch mcp http to framework-agnostic McpHttpError  ([#144](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/144)) ([e0c44c0](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0c44c0e4f8aaed9bfc59b9274d11c346646a635))
* Switch mcp_http layer to framework-agnostic McpHttpError ([afaf4b1](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/afaf4b1ebfe070f565a1857ed707da678b9d16ae))
</details>

<details><summary>rust-mcp-transport: 0.9.1</summary>

## [0.9.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.9.0...rust-mcp-transport-v0.9.1) (2026-06-24)


### 🚀 Features

* 100% MCP server and client conformance ([#185](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/185)) ([9c0c6ef](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/9c0c6ef0d1b8a08c9d406e4890ae99fa06ba9c1b))


### 🐛 Bug Fixes

* **transport:** Cap transport line length ([#164](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/164)) ([344e9ee](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/344e9ee8486f403472622075583844223d738402))
* **transport:** Make message channel capacity configurable for all transports ([#171](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/171)) ([f4edef4](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/f4edef44fa0dc54408a7932f2cb33c829bfc2b91))


### 📚 Documentation

* Documentation audit, examples upgrade, and test stabilization ([#174](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/174)) ([667e522](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/667e522f407291b34ec16b8fbd4068586207f2b6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).