### PR TITLE
feat!: add rust-mcp-actix crate, McpHttpServer trait

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -49,6 +49,8 @@ jobs:
           echo "Updating root Cargo.toml"
           sed -i -e "s/rust-mcp-macros = { version = \"[^\"]*\",/rust-mcp-macros = { version = \"$(grep '^version = ' crates/rust-mcp-macros/Cargo.toml | cut -d' ' -f3 | tr -d '\"')\",/" \
           -e "s/rust-mcp-transport = { version = \"[^\"]*\",/rust-mcp-transport = { version = \"$(grep '^version = ' crates/rust-mcp-transport/Cargo.toml | cut -d' ' -f3 | tr -d '\"')\",/" \
+          -e "s/rust-mcp-axum = { version = \"[^\"]*\",/rust-mcp-axum = { version = \"$(grep '^version = ' crates/rust-mcp-axum/Cargo.toml | cut -d' ' -f3 | tr -d '\"')\",/" \
+          -e "s/rust-mcp-actix = { version = \"[^\"]*\",/rust-mcp-actix = { version = \"$(grep '^version = ' crates/rust-mcp-actix/Cargo.toml | cut -d' ' -f3 | tr -d '\"')\",/" \
           -e "s/rust-mcp-extra = { version = \"[^\"]*\",/rust-mcp-extra = { version = \"$(grep '^version = ' crates/rust-mcp-extra/Cargo.toml | cut -d' ' -f3 | tr -d '\"')\",/" \
           Cargo.toml
 

--- a/.release-config.json
+++ b/.release-config.json
@@ -122,6 +122,34 @@
           "path": "CHANGELOG.md"
         }
       ]
+    },
+    "crates/rust-mcp-axum": {
+      "release-type": "rust",
+      "draft": false,
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelogPath": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "CHANGELOG.md"
+        }
+      ]
+    },
+    "crates/rust-mcp-actix": {
+      "release-type": "rust",
+      "draft": false,
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelogPath": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "CHANGELOG.md"
+        }
+      ]
     }
   }
 }

--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -3,6 +3,8 @@
   "crates/rust-mcp-macros": "0.9.0",
   "crates/rust-mcp-transport": "0.9.0",
   "crates/rust-mcp-extra": "0.2.4",
+  "crates/rust-mcp-axum": "0.1.0",
+  "crates/rust-mcp-actix": "0.1.0",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,10 +2271,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body-util",
+ "rust-mcp-schema",
  "rust-mcp-sdk",
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "base64",
  "bitflags",
@@ -122,6 +123,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6176099de3f58fbddac916a7f8c6db297e021d706e7a6b99947785fee14abe9f"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "impl-more",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +164,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "bytes",
@@ -2273,6 +2294,8 @@ dependencies = [
  "http-body-util",
  "rust-mcp-schema",
  "rust-mcp-sdk",
+ "rustls",
+ "rustls-pemfile",
  "serde_json",
  "tokio",
  "tracing",
@@ -2439,6 +2462,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,217 @@
 version = 4
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "base64",
+ "bitflags",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "foldhash",
+ "futures-core",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "actix-macros",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie 0.16.2",
+ "derive_more",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.6.3",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -112,7 +317,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -143,7 +348,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -164,7 +369,7 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "hyper-util",
@@ -204,6 +409,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +449,15 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "cc"
@@ -238,6 +482,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -287,6 +542,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,7 +584,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
- "cookie",
+ "cookie 0.18.1",
  "document-features",
  "idna",
  "log",
@@ -351,6 +632,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +663,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -390,7 +698,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -405,14 +713,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -519,6 +861,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -706,8 +1058,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -721,7 +1093,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -758,6 +1130,17 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -773,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -784,7 +1167,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -802,6 +1185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,8 +1203,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
+ "h2 0.4.14",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -829,7 +1221,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -865,14 +1257,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1014,6 +1406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1525,23 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "local-channel"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -1181,12 +1602,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1321,7 +1753,7 @@ dependencies = [
  "dotenvy",
  "envy",
  "futures",
- "http",
+ "http 1.4.0",
  "jsonwebtoken",
  "once_cell",
  "rand 0.8.6",
@@ -1549,7 +1981,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -1586,7 +2018,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1634,6 +2066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +2113,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -1714,6 +2163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,13 +2182,13 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "cookie",
+ "cookie 0.18.1",
  "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.4.14",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1789,8 +2244,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -1804,13 +2259,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-mcp-actix"
+version = "0.1.0"
+dependencies = [
+ "actix-http",
+ "actix-rt",
+ "actix-web",
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "http 1.4.0",
+ "http-body-util",
+ "rust-mcp-sdk",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rust-mcp-axum"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "axum-server",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "rust-mcp-sdk",
  "serde_json",
@@ -1829,7 +2304,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "nanoid",
@@ -1879,7 +2354,7 @@ dependencies = [
  "bytes",
  "colored",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "jsonwebtoken",
@@ -1926,6 +2401,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2122,14 +2606,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2163,9 +2658,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -2190,6 +2691,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2393,7 +2904,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2518,7 +3029,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags",
  "bytes",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "pin-project-lite",
@@ -2536,7 +3047,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -2642,6 +3153,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -3124,7 +3641,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3359,3 +3876,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/rust-mcp-transport",
     "crates/rust-mcp-extra",
     "crates/rust-mcp-axum",
+    "crates/rust-mcp-actix",
 ]
 
 [workspace.package]
@@ -18,6 +19,7 @@ rust-mcp-sdk = { path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.9.0", path = "crates/rust-mcp-macros", default-features = false }
 rust-mcp-extra = { version="0.1.0", path = "crates/rust-mcp-extra", default-features = false }
 rust-mcp-axum = { version = "0.1.0", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "0.1.0", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version="0.10",  default-features = false }

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -22,6 +22,11 @@ bytes = { workspace = true }
 http-body-util = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 serde_json = { workspace = true }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "aws_lc_rs"] }
+rustls-pemfile = { version = "2", optional = true }
+
+[features]
+ssl = ["actix-web/rustls-0_23", "dep:rustls", "dep:rustls-pemfile"]
 
 [dev-dependencies]
 actix-http = "3"

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "rust-mcp-actix"
+version = "0.1.0"
+authors = ["Ali Hashemi"]
+description = "Actix-web HTTP server integration for rust-mcp-sdk"
+repository = "https://github.com/rust-mcp-stack/rust-mcp-sdk"
+documentation = "https://docs.rs/rust-mcp-actix"
+keywords = ["rust-mcp-stack", "model", "context", "protocol", "sdk", "actix"]
+license = "MIT"
+edition = "2021"
+rust-version = { workspace = true }
+
+[dependencies]
+rust-mcp-sdk = { workspace = true, features = ["server", "streamable-http", "sse", "auth"] }
+actix-web = "4"
+actix-rt = "2"
+async-trait = { workspace = true }
+futures = { workspace = true }
+tracing = { workspace = true }
+http = { workspace = true }
+bytes = { workspace = true }
+http-body-util = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+actix-http = "3"
+futures-util = "0.3"
+
+[lints]
+workspace = true

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -26,6 +26,8 @@ serde_json = { workspace = true }
 [dev-dependencies]
 actix-http = "3"
 futures-util = "0.3"
+tracing-subscriber = { workspace = true }
+rust-mcp-schema = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rust-mcp-actix/README.md
+++ b/crates/rust-mcp-actix/README.md
@@ -4,8 +4,8 @@ Actix-web HTTP server integration for [rust-mcp-sdk](https://github.com/rust-mcp
 
 ## Features
 
-- **Turnkey server** — `create_actix_server().start().await`
-- **BYO-server** — `mcp_scope()` to mount MCP endpoints on any existing Actix app
+- **Turnkey server**: `create_actix_server().start().await`
+- **BYO-server**: `mcp_scope()` to mount MCP endpoints on any existing Actix app
 - **Streamable HTTP** + **SSE** transports
 - **Authentication** (OAuth via `AuthProvider`)
 - **Health check** endpoint

--- a/crates/rust-mcp-actix/README.md
+++ b/crates/rust-mcp-actix/README.md
@@ -1,0 +1,54 @@
+# rust-mcp-actix
+
+Actix-web HTTP server integration for [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk).
+
+## Features
+
+- **Turnkey server** — `create_actix_server().start().await`
+- **BYO-server** — `mcp_scope()` to mount MCP endpoints on any existing Actix app
+- **Streamable HTTP** + **SSE** transports
+- **Authentication** (OAuth via `AuthProvider`)
+- **Health check** endpoint
+- **Session management** with `ActixRuntime`
+- **Framework-agnostic** via `McpHttpServer` trait
+
+## Quick Start
+
+### Turnkey
+
+```rust
+use rust_mcp_actix::{create_actix_server, ActixServerOptions};
+
+let server = create_actix_server(server_details, handler, ActixServerOptions::default());
+server.start().await?;
+```
+
+### BYO-server (mount on existing Actix app)
+
+```rust
+use rust_mcp_actix::{mcp_scope, ActixMountOptions};
+
+let mount = ActixMountOptions {
+    streamable_http_endpoint: "/mcp".into(),
+    sse_endpoint: "/sse".into(),
+    sse_messages_endpoint: "/messages".into(),
+    health_endpoint: Some("/health".into()),
+};
+
+HttpServer::new(move || {
+    App::new()
+        .service(web::scope("/api").route("", web::get().to(my_handler)))
+        .service(rust_mcp_actix::mcp_scope(state.clone(), handler.clone(), &mount))
+})
+.bind("127.0.0.1:8080")?
+.run()
+.await?;
+```
+
+## Cargo Features
+
+No feature flags. All functionality is always enabled since Actix has no optional TLS crate split.
+
+## License
+
+MIT

--- a/crates/rust-mcp-actix/examples/byo-server.rs
+++ b/crates/rust-mcp-actix/examples/byo-server.rs
@@ -1,0 +1,75 @@
+use actix_web::{web, App, HttpServer};
+use rust_mcp_actix::{mcp_scope, ActixMountOptions};
+use rust_mcp_sdk::id_generator::{FastIdGenerator, UuidGenerator};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use rust_mcp_sdk::mcp_icon;
+use rust_mcp_sdk::mcp_server::ServerHandler;
+use rust_mcp_sdk::schema::{
+    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerCapabilitiesTools,
+};
+use rust_mcp_sdk::session_store::InMemorySessionStore;
+use rust_mcp_sdk::ToMcpServerHandler;
+use std::sync::Arc;
+
+struct HelloHandler;
+#[async_trait::async_trait]
+impl ServerHandler for HelloHandler {}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let state = Arc::new(McpAppState {
+        session_store: Arc::new(InMemorySessionStore::new()),
+        id_generator: Arc::new(UuidGenerator {}),
+        stream_id_gen: Arc::new(FastIdGenerator::new(Some("s_"))),
+        server_details: Arc::new(InitializeResult {
+            server_info: Implementation {
+                name: "MCP Server Actix BYO".into(),
+                version: "0.1.0".into(),
+                title: None,
+                description: None,
+                icons: vec![mcp_icon!(
+                    src = "https://raw.githubusercontent.com/rust-mcp-stack/rust-mcp-sdk/main/assets/rust-mcp-icon.png",
+                    mime_type = "image/png",
+                    sizes = ["128x128"],
+                    theme = "dark"
+                )],
+                website_url: None,
+            },
+            capabilities: ServerCapabilities {
+                tools: Some(ServerCapabilitiesTools { list_changed: None }),
+                ..Default::default()
+            },
+            meta: None,
+            instructions: None,
+            protocol_version: ProtocolVersion::V2025_11_25.into(),
+        }),
+        handler: HelloHandler.to_mcp_server_handler(),
+        ping_interval: std::time::Duration::from_secs(12),
+        transport_options: Default::default(),
+        enable_json_response: false,
+        event_store: None,
+        task_store: None,
+        client_task_store: None,
+        message_observer: None,
+    });
+    let http_handler = Arc::new(McpHttpHandler::new(None, vec![], None));
+
+    let mount_opts = ActixMountOptions {
+        streamable_http_endpoint: "/mcp".into(),
+        sse_endpoint: "/sse".into(),
+        sse_messages_endpoint: "/messages".into(),
+        health_endpoint: Some("/health".into()),
+    };
+
+    println!("Starting BYO-server Actix app at http://127.0.0.1:8080");
+    HttpServer::new(move || {
+        App::new()
+            .service(web::scope("/api").route("", web::get().to(|| async { "custom-api" })))
+            .service(mcp_scope(state.clone(), http_handler.clone(), &mount_opts))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}

--- a/crates/rust-mcp-actix/examples/hello-world-server.rs
+++ b/crates/rust-mcp-actix/examples/hello-world-server.rs
@@ -1,0 +1,82 @@
+use rust_mcp_actix::{create_actix_server, ActixServerOptions};
+use rust_mcp_schema::{
+    schema_utils::CallToolError, CallToolRequestParams, CallToolResult, ListToolsResult,
+    PaginatedRequestParams, RpcError,
+};
+use rust_mcp_sdk::mcp_icon;
+use rust_mcp_sdk::mcp_server::ServerHandler;
+use rust_mcp_sdk::schema::{
+    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerCapabilitiesTools,
+};
+use rust_mcp_sdk::{error::SdkResult, ToMcpServerHandler};
+use std::sync::Arc;
+
+struct HelloHandler;
+#[async_trait::async_trait]
+impl ServerHandler for HelloHandler {
+    async fn handle_list_tools_request(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> std::result::Result<ListToolsResult, RpcError> {
+        Ok(ListToolsResult {
+            tools: vec![],
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn handle_call_tool_request(
+        &self,
+        params: CallToolRequestParams,
+        _runtime: Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> std::result::Result<CallToolResult, CallToolError> {
+        Ok(CallToolResult::text_content(vec![
+            rust_mcp_schema::TextContent::new(
+                format!("Hello from Actix MCP! You asked: {}", params.name),
+                None,
+                None,
+            ),
+        ]))
+    }
+}
+
+#[tokio::main]
+async fn main() -> SdkResult<()> {
+    tracing_subscriber::fmt::init();
+
+    let server_details = InitializeResult {
+        server_info: Implementation {
+            name: "Hello World MCP Server (Actix)".into(),
+            version: "0.1.0".into(),
+            title: Some("Hello World MCP (Actix)".into()),
+            description: Some("test server, by Rust MCP SDK + Actix".into()),
+            icons: vec![mcp_icon!(
+                src = "https://raw.githubusercontent.com/rust-mcp-stack/rust-mcp-sdk/main/assets/rust-mcp-icon.png",
+                mime_type = "image/png",
+                sizes = ["128x128"],
+                theme = "dark"
+            )],
+            website_url: Some("https://github.com/rust-mcp-stack/rust-mcp-sdk".into()),
+        },
+        capabilities: ServerCapabilities {
+            tools: Some(ServerCapabilitiesTools { list_changed: None }),
+            ..Default::default()
+        },
+        meta: None,
+        instructions: Some("server instructions...".into()),
+        protocol_version: ProtocolVersion::V2025_11_25.into(),
+    };
+
+    let server = create_actix_server(
+        server_details,
+        HelloHandler.to_mcp_server_handler(),
+        ActixServerOptions {
+            host: "127.0.0.1".into(),
+            health_endpoint: Some("/health".into()),
+            ..Default::default()
+        },
+    );
+
+    server.start().await
+}

--- a/crates/rust-mcp-actix/src/bridge.rs
+++ b/crates/rust-mcp-actix/src/bridge.rs
@@ -44,7 +44,7 @@ pub(crate) async fn to_actix_response(res: http::Response<GenericBody>) -> HttpR
         return builder.streaming(stream);
     }
 
-    // Standard response — drain body to bytes
+    // Standard response: drain body to bytes
     let bytes = body
         .collect()
         .await

--- a/crates/rust-mcp-actix/src/bridge.rs
+++ b/crates/rust-mcp-actix/src/bridge.rs
@@ -1,0 +1,74 @@
+use actix_web::HttpResponse;
+use http_body_util::BodyExt;
+use rust_mcp_sdk::mcp_http::GenericBody;
+
+/// Converts an `http::Response<GenericBody>` into an Actix `HttpResponse`.
+///
+/// Drains the body bytes asynchronously and copies status/headers.
+pub(crate) async fn to_actix_response(res: http::Response<GenericBody>) -> HttpResponse {
+    let (parts, body) = res.into_parts();
+
+    let status = actix_web::http::StatusCode::from_u16(parts.status.as_u16())
+        .unwrap_or(actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
+
+    let bytes = body
+        .collect()
+        .await
+        .map(|collected| collected.to_bytes())
+        .unwrap_or_default();
+
+    let mut builder = HttpResponse::build(status);
+    for (name, value) in parts.headers.iter() {
+        if let Ok(v) = value.to_str() {
+            builder.insert_header((name.as_str(), v));
+        }
+    }
+    builder.body(bytes.to_vec())
+}
+
+/// Converts an actix `HttpRequest` into an `http::Request<&str>`.
+///
+/// Extracts method, URI, headers, and optional body for use with `McpHttpHandler`.
+pub(crate) fn from_actix_request<'a>(
+    req: &'a actix_web::HttpRequest,
+    body: Option<&'a str>,
+) -> http::Request<&'a str> {
+    let method =
+        http::Method::from_bytes(req.method().as_str().as_bytes()).unwrap_or(http::Method::GET);
+
+    let uri: http::Uri = req
+        .uri()
+        .to_string()
+        .parse()
+        .unwrap_or_else(|_| "/".parse().unwrap());
+
+    let mut headers = http::HeaderMap::new();
+    for (name, value) in req.headers().iter() {
+        if let (Ok(name), Ok(value)) = (
+            http::HeaderName::from_bytes(name.as_str().as_bytes()),
+            http::HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            headers.insert(name, value);
+        }
+    }
+
+    rust_mcp_sdk::mcp_http::McpHttpHandler::create_request(method, uri, headers, body)
+}
+
+/// Converts an `McpHttpError` into an Actix `HttpResponse` with a JSON error body.
+pub(crate) fn to_actix_error(err: rust_mcp_sdk::mcp_http::McpHttpError) -> HttpResponse {
+    let status = match &err {
+        rust_mcp_sdk::mcp_http::McpHttpError::SessionIdMissing => {
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        }
+        rust_mcp_sdk::mcp_http::McpHttpError::SessionIdInvalid(_) => {
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+        }
+        _ => actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+    };
+
+    let body = serde_json::json!({ "error": err.to_string() });
+    HttpResponse::build(status)
+        .content_type("application/json")
+        .json(body)
+}

--- a/crates/rust-mcp-actix/src/bridge.rs
+++ b/crates/rust-mcp-actix/src/bridge.rs
@@ -1,16 +1,50 @@
 use actix_web::HttpResponse;
+use bytes::Bytes;
+use futures::StreamExt;
 use http_body_util::BodyExt;
+use http_body_util::BodyStream;
 use rust_mcp_sdk::mcp_http::GenericBody;
 
 /// Converts an `http::Response<GenericBody>` into an Actix `HttpResponse`.
 ///
-/// Drains the body bytes asynchronously and copies status/headers.
+/// Handles two response modes:
+/// - **SSE streams** (`content-type: text/event-stream`): uses `HttpResponse::streaming()` to
+///   forward body frames as-is, preserving the long-lived connection.
+/// - **Standard responses**: drains body bytes asynchronously and copies status/headers.
 pub(crate) async fn to_actix_response(res: http::Response<GenericBody>) -> HttpResponse {
     let (parts, body) = res.into_parts();
 
     let status = actix_web::http::StatusCode::from_u16(parts.status.as_u16())
         .unwrap_or(actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
 
+    let is_sse = parts
+        .headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|ct| ct.starts_with("text/event-stream"))
+        .unwrap_or(false);
+
+    if is_sse {
+        let stream = BodyStream::new(body).map(|result| match result {
+            Ok(frame) => {
+                let data = frame
+                    .into_data()
+                    .unwrap_or_else(|_| Bytes::from_static(b""));
+                Ok(data)
+            }
+            Err(err) => Err(actix_web::error::ErrorInternalServerError(err.to_string())),
+        });
+
+        let mut builder = HttpResponse::build(status);
+        for (name, value) in parts.headers.iter() {
+            if let Ok(v) = value.to_str() {
+                builder.insert_header((name.as_str(), v));
+            }
+        }
+        return builder.streaming(stream);
+    }
+
+    // Standard response — drain body to bytes
     let bytes = body
         .collect()
         .await
@@ -56,15 +90,22 @@ pub(crate) fn from_actix_request<'a>(
 }
 
 /// Converts an `McpHttpError` into an Actix `HttpResponse` with a JSON error body.
+///
+/// Maps error variants to appropriate HTTP status codes:
+/// - `SessionIdMissing` → 400 Bad Request
+/// - `SessionIdInvalid` → 404 Not Found
+/// - `StreamIoError` → 500 Internal Server Error
+/// - `HttpError` → 500 Internal Server Error
+/// - `TransportError` → 502 Bad Gateway
 pub(crate) fn to_actix_error(err: rust_mcp_sdk::mcp_http::McpHttpError) -> HttpResponse {
+    use rust_mcp_sdk::mcp_http::McpHttpError;
+
     let status = match &err {
-        rust_mcp_sdk::mcp_http::McpHttpError::SessionIdMissing => {
-            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
-        }
-        rust_mcp_sdk::mcp_http::McpHttpError::SessionIdInvalid(_) => {
-            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
-        }
-        _ => actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+        McpHttpError::SessionIdMissing => actix_web::http::StatusCode::BAD_REQUEST,
+        McpHttpError::SessionIdInvalid(_) => actix_web::http::StatusCode::NOT_FOUND,
+        McpHttpError::StreamIoError(_) => actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+        McpHttpError::HttpError(_) => actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+        McpHttpError::TransportError(_) => actix_web::http::StatusCode::BAD_GATEWAY,
     };
 
     let body = serde_json::json!({ "error": err.to_string() });

--- a/crates/rust-mcp-actix/src/error.rs
+++ b/crates/rust-mcp-actix/src/error.rs
@@ -1,0 +1,26 @@
+use actix_web::{HttpResponse, ResponseError};
+use rust_mcp_sdk::mcp_http::McpHttpError;
+use std::fmt;
+
+/// Wrapper that implements `actix_web::ResponseError` for `McpHttpError`,
+/// allowing `?` propagation in Actix route handlers that return `HttpResponse`.
+#[derive(Debug)]
+pub struct McpActixError(pub McpHttpError);
+
+impl fmt::Display for McpActixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl ResponseError for McpActixError {
+    fn error_response(&self) -> HttpResponse {
+        crate::bridge::to_actix_error(self.0.clone())
+    }
+}
+
+impl From<McpHttpError> for McpActixError {
+    fn from(err: McpHttpError) -> Self {
+        McpActixError(err)
+    }
+}

--- a/crates/rust-mcp-actix/src/factory.rs
+++ b/crates/rust-mcp-actix/src/factory.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 /// Creates a new `ActixServer` with the given server details, handler, and options.
 ///
-/// This is the **turnkey** entry point — a single function call that returns
+/// This is the **turnkey** entry point: a single function call that returns
 /// a ready-to-start server:
 ///
 /// ```ignore

--- a/crates/rust-mcp-actix/src/factory.rs
+++ b/crates/rust-mcp-actix/src/factory.rs
@@ -1,0 +1,26 @@
+use crate::server::ActixServer;
+use crate::ActixServerOptions;
+use rust_mcp_sdk::mcp_server::McpServerHandler;
+use rust_mcp_sdk::schema::InitializeResult;
+use std::sync::Arc;
+
+/// Creates a new `ActixServer` with the given server details, handler, and options.
+///
+/// This is the **turnkey** entry point — a single function call that returns
+/// a ready-to-start server:
+///
+/// ```ignore
+/// let server = rust_mcp_actix::create_actix_server(
+///     server_details,
+///     handler.to_mcp_server_handler(),
+///     ActixServerOptions::default(),
+/// );
+/// server.start().await?;
+/// ```
+pub fn create_actix_server(
+    server_details: InitializeResult,
+    handler: Arc<dyn McpServerHandler + 'static>,
+    server_options: ActixServerOptions,
+) -> ActixServer {
+    ActixServer::new(server_details, handler, server_options)
+}

--- a/crates/rust-mcp-actix/src/lib.rs
+++ b/crates/rust-mcp-actix/src/lib.rs
@@ -1,7 +1,15 @@
 mod bridge;
 mod error;
+mod factory;
 mod mount;
+mod options;
 pub mod routes;
+mod runtime;
+mod server;
 
 pub use error::*;
+pub use factory::*;
 pub use mount::*;
+pub use options::*;
+pub use runtime::*;
+pub use server::*;

--- a/crates/rust-mcp-actix/src/lib.rs
+++ b/crates/rust-mcp-actix/src/lib.rs
@@ -1,0 +1,7 @@
+mod bridge;
+mod error;
+mod mount;
+pub mod routes;
+
+pub use error::*;
+pub use mount::*;

--- a/crates/rust-mcp-actix/src/mount.rs
+++ b/crates/rust-mcp-actix/src/mount.rs
@@ -1,0 +1,88 @@
+use actix_web::{web, Scope};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use std::sync::Arc;
+
+/// Lightweight mount configuration for BYO-server scenarios with Actix.
+///
+/// Use with [`mcp_scope()`] to mount MCP endpoints on an existing Actix application.
+pub struct ActixMountOptions {
+    pub streamable_http_endpoint: String,
+    pub sse_endpoint: String,
+    pub sse_messages_endpoint: String,
+    pub health_endpoint: Option<String>,
+}
+
+impl Default for ActixMountOptions {
+    fn default() -> Self {
+        Self {
+            streamable_http_endpoint: "/mcp".to_string(),
+            sse_endpoint: "/sse".to_string(),
+            sse_messages_endpoint: "/messages".to_string(),
+            health_endpoint: None,
+        }
+    }
+}
+
+/// Builds an Actix [`Scope`] with all MCP endpoint routes mounted.
+///
+/// This is the **BYO-server** mount function:
+///
+/// ```ignore
+/// HttpServer::new(move || {
+///     App::new()
+///         .service(web::scope("/api").route("", web::get().to(my_handler)))
+///         .service(rust_mcp_actix::mcp_scope(state.clone(), handler.clone(), &opts))
+/// })
+/// .bind("127.0.0.1:8080")?
+/// .run()
+/// .await?;
+/// ```
+pub fn mcp_scope(
+    state: Arc<McpAppState>,
+    http_handler: Arc<McpHttpHandler>,
+    opts: &ActixMountOptions,
+) -> Scope {
+    let sse_message_endpoint = opts.sse_messages_endpoint.clone();
+
+    let scope = web::scope("")
+        .app_data(web::Data::new(state))
+        .app_data(web::Data::from(http_handler.clone()))
+        .app_data(web::Data::new(crate::routes::sse::SseMessageEndpoint(
+            sse_message_endpoint,
+        )))
+        .service(
+            web::resource(&opts.streamable_http_endpoint)
+                .route(web::get().to(crate::routes::streamable_http::handle_streamable_http_get))
+                .route(web::post().to(crate::routes::streamable_http::handle_streamable_http_post))
+                .route(
+                    web::delete().to(crate::routes::streamable_http::handle_streamable_http_delete),
+                ),
+        )
+        .service(
+            web::resource(&opts.sse_endpoint).route(web::get().to(crate::routes::sse::handle_sse)),
+        )
+        .service(
+            web::resource(&opts.sse_messages_endpoint)
+                .route(web::post().to(crate::routes::messages::handle_messages)),
+        );
+
+    // Mount auth routes
+    let scope = if let Some(auth_scope) = crate::routes::auth::auth_routes(http_handler) {
+        scope.service(auth_scope)
+    } else {
+        scope
+    };
+
+    // Mount health check if enabled
+    let scope = if let Some(ref endpoint) = opts.health_endpoint {
+        scope.service(
+            web::resource(endpoint)
+                .route(web::get().to(crate::routes::health::handle_health_check)),
+        )
+    } else {
+        scope
+    };
+
+    // Fallback for unmatched routes
+    scope.default_service(web::route().to(crate::routes::fallback::not_found))
+}

--- a/crates/rust-mcp-actix/src/mount.rs
+++ b/crates/rust-mcp-actix/src/mount.rs
@@ -12,6 +12,17 @@ pub struct ActixMountOptions {
     pub health_endpoint: Option<String>,
 }
 
+impl Clone for ActixMountOptions {
+    fn clone(&self) -> Self {
+        Self {
+            streamable_http_endpoint: self.streamable_http_endpoint.clone(),
+            sse_endpoint: self.sse_endpoint.clone(),
+            sse_messages_endpoint: self.sse_messages_endpoint.clone(),
+            health_endpoint: self.health_endpoint.clone(),
+        }
+    }
+}
+
 impl Default for ActixMountOptions {
     fn default() -> Self {
         Self {

--- a/crates/rust-mcp-actix/src/mount.rs
+++ b/crates/rust-mcp-actix/src/mount.rs
@@ -2,7 +2,7 @@ use actix_web::{web, Scope};
 use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
 use std::sync::Arc;
 
-/// Lightweight mount configuration for BYO-server scenarios with Actix.
+/// Mount configuration for BYO-server scenarios with Actix.
 ///
 /// Use with [`mcp_scope()`] to mount MCP endpoints on an existing Actix application.
 pub struct ActixMountOptions {

--- a/crates/rust-mcp-actix/src/options.rs
+++ b/crates/rust-mcp-actix/src/options.rs
@@ -1,0 +1,155 @@
+use rust_mcp_sdk::auth::AuthProvider;
+use rust_mcp_sdk::event_store::EventStore;
+use rust_mcp_sdk::id_generator::IdGenerator;
+use rust_mcp_sdk::mcp_http::HealthHandler;
+use rust_mcp_sdk::mcp_http::{
+    DEFAULT_MESSAGES_ENDPOINT, DEFAULT_SSE_ENDPOINT, DEFAULT_STREAMABLE_HTTP_ENDPOINT,
+};
+use rust_mcp_sdk::schema::schema_utils::{ClientMessage, ServerMessage};
+use rust_mcp_sdk::task_store::{ClientTaskStore, ServerTaskStore};
+use rust_mcp_sdk::McpObserver;
+use rust_mcp_sdk::SessionId;
+use rust_mcp_sdk::TransportOptions;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::Duration;
+
+const DEFAULT_CLIENT_PING_INTERVAL: Duration = Duration::from_secs(12);
+
+/// Configuration for the Actix MCP server.
+///
+/// Used to configure the turnkey server created via
+/// [`create_actix_server()`](crate::create_actix_server).
+pub struct ActixServerOptions {
+    /// Hostname or IP address the server will bind to (default: `"127.0.0.1"`)
+    pub host: String,
+    /// TCP port (default: `8080`)
+    pub port: u16,
+    /// Optional session ID generator
+    pub session_id_generator: Option<Arc<dyn IdGenerator<SessionId>>>,
+    /// Custom Streamable HTTP endpoint path (default: `/mcp`)
+    pub custom_streamable_http_endpoint: Option<String>,
+    /// Shared transport configuration
+    pub transport_options: Arc<TransportOptions>,
+    /// Event store for resumability support
+    pub event_store: Option<Arc<dyn EventStore>>,
+    /// Task store for server-side tasks
+    pub task_store: Option<Arc<ServerTaskStore>>,
+    /// Task store for client-side tasks
+    pub client_task_store: Option<Arc<ClientTaskStore>>,
+    /// If true, return JSON instead of SSE stream
+    pub enable_json_response: Option<bool>,
+    /// Interval between keep-alive pings
+    pub ping_interval: Duration,
+    /// Enable SSE transport support (default: true)
+    pub sse_support: bool,
+    /// Custom SSE endpoint path (default: `/sse`)
+    pub custom_sse_endpoint: Option<String>,
+    /// Custom SSE messages endpoint path (default: `/messages`)
+    pub custom_messages_endpoint: Option<String>,
+    /// Optional authentication provider
+    pub auth: Option<Arc<dyn AuthProvider>>,
+    /// Health check endpoint path (None disables)
+    pub health_endpoint: Option<String>,
+    /// Custom health check handler
+    pub health_handler: Option<Arc<dyn HealthHandler>>,
+    /// Optional message observer for telemetry
+    pub message_observer: Option<Arc<dyn McpObserver<ClientMessage, ServerMessage>>>,
+}
+
+impl ActixServerOptions {
+    /// Validates the server configuration.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.host.is_empty() {
+            return Err("host must not be empty".into());
+        }
+        Ok(())
+    }
+
+    /// Resolves the `SocketAddr` from host and port.
+    pub fn resolve_server_address(&self) -> Result<SocketAddr, String> {
+        self.validate()?;
+
+        let host = self
+            .host
+            .strip_prefix("http://")
+            .or_else(|| self.host.strip_prefix("https://"))
+            .unwrap_or(&self.host)
+            .to_string();
+
+        let mut iter = (host.as_str(), self.port)
+            .to_socket_addrs()
+            .map_err(|e| format!("Failed to resolve address: {}", e))?;
+
+        iter.next()
+            .ok_or_else(|| format!("Could not resolve: {}:{}", self.host, self.port))
+    }
+
+    pub fn base_url(&self) -> String {
+        format!("http://{}:{}", self.host, self.port)
+    }
+
+    pub fn streamable_http_url(&self) -> String {
+        format!("{}{}", self.base_url(), self.streamable_http_endpoint())
+    }
+
+    pub fn sse_url(&self) -> String {
+        format!("{}{}", self.base_url(), self.sse_endpoint())
+    }
+
+    pub fn sse_message_url(&self) -> String {
+        format!("{}{}", self.base_url(), self.sse_messages_endpoint())
+    }
+
+    pub fn sse_endpoint(&self) -> &str {
+        self.custom_sse_endpoint
+            .as_deref()
+            .unwrap_or(DEFAULT_SSE_ENDPOINT)
+    }
+
+    pub fn sse_messages_endpoint(&self) -> &str {
+        self.custom_messages_endpoint
+            .as_deref()
+            .unwrap_or(DEFAULT_MESSAGES_ENDPOINT)
+    }
+
+    pub fn streamable_http_endpoint(&self) -> &str {
+        self.custom_streamable_http_endpoint
+            .as_deref()
+            .unwrap_or(DEFAULT_STREAMABLE_HTTP_ENDPOINT)
+    }
+
+    /// Resolves mount options from this server configuration.
+    pub fn resolve_mount_options(&self) -> crate::mount::ActixMountOptions {
+        crate::mount::ActixMountOptions {
+            streamable_http_endpoint: self.streamable_http_endpoint().to_string(),
+            sse_endpoint: self.sse_endpoint().to_string(),
+            sse_messages_endpoint: self.sse_messages_endpoint().to_string(),
+            health_endpoint: self.health_endpoint.clone(),
+        }
+    }
+}
+
+impl Default for ActixServerOptions {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".into(),
+            port: 8080,
+            session_id_generator: None,
+            custom_streamable_http_endpoint: None,
+            transport_options: Default::default(),
+            event_store: None,
+            task_store: None,
+            client_task_store: None,
+            enable_json_response: None,
+            ping_interval: DEFAULT_CLIENT_PING_INTERVAL,
+            sse_support: true,
+            custom_sse_endpoint: None,
+            custom_messages_endpoint: None,
+            auth: None,
+            health_endpoint: None,
+            health_handler: None,
+            message_observer: None,
+        }
+    }
+}

--- a/crates/rust-mcp-actix/src/options.rs
+++ b/crates/rust-mcp-actix/src/options.rs
@@ -69,13 +69,11 @@ impl ActixServerOptions {
         if self.host.is_empty() {
             return Err("host must not be empty".into());
         }
-        if self.enable_ssl {
-            if self.ssl_cert_path.is_none() || self.ssl_key_path.is_none() {
-                return Err(
-                    "Both 'ssl_cert_path' and 'ssl_key_path' must be provided when SSL is enabled."
-                        .into(),
-                );
-            }
+        if self.enable_ssl && (self.ssl_cert_path.is_none() || self.ssl_key_path.is_none()) {
+            return Err(
+                "Both 'ssl_cert_path' and 'ssl_key_path' must be provided when SSL is enabled."
+                    .into(),
+            );
         }
         Ok(())
     }

--- a/crates/rust-mcp-actix/src/options.rs
+++ b/crates/rust-mcp-actix/src/options.rs
@@ -55,6 +55,12 @@ pub struct ActixServerOptions {
     pub health_handler: Option<Arc<dyn HealthHandler>>,
     /// Optional message observer for telemetry
     pub message_observer: Option<Arc<dyn McpObserver<ClientMessage, ServerMessage>>>,
+    /// Enable TLS/SSL (requires `ssl` feature, default: false)
+    pub enable_ssl: bool,
+    /// Path to TLS certificate PEM file
+    pub ssl_cert_path: Option<String>,
+    /// Path to TLS private key PEM file
+    pub ssl_key_path: Option<String>,
 }
 
 impl ActixServerOptions {
@@ -62,6 +68,14 @@ impl ActixServerOptions {
     pub fn validate(&self) -> Result<(), String> {
         if self.host.is_empty() {
             return Err("host must not be empty".into());
+        }
+        if self.enable_ssl {
+            if self.ssl_cert_path.is_none() || self.ssl_key_path.is_none() {
+                return Err(
+                    "Both 'ssl_cert_path' and 'ssl_key_path' must be provided when SSL is enabled."
+                        .into(),
+                );
+            }
         }
         Ok(())
     }
@@ -86,7 +100,12 @@ impl ActixServerOptions {
     }
 
     pub fn base_url(&self) -> String {
-        format!("http://{}:{}", self.host, self.port)
+        format!(
+            "{}://{}:{}",
+            if self.enable_ssl { "https" } else { "http" },
+            self.host,
+            self.port
+        )
     }
 
     pub fn streamable_http_url(&self) -> String {
@@ -150,6 +169,9 @@ impl Default for ActixServerOptions {
             health_endpoint: None,
             health_handler: None,
             message_observer: None,
+            enable_ssl: false,
+            ssl_cert_path: None,
+            ssl_key_path: None,
         }
     }
 }

--- a/crates/rust-mcp-actix/src/routes/auth.rs
+++ b/crates/rust-mcp-actix/src/routes/auth.rs
@@ -1,0 +1,40 @@
+use actix_web::{web, HttpRequest, Scope};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use std::sync::Arc;
+
+pub fn auth_routes(http_handler: Arc<McpHttpHandler>) -> Option<Scope> {
+    let endpoints: Vec<String> = http_handler
+        .oauth_endppoints()
+        .unwrap_or_default()
+        .into_iter()
+        .cloned()
+        .collect();
+
+    if endpoints.is_empty() {
+        return None;
+    }
+
+    let mut scope = web::scope("");
+    for endpoint in endpoints {
+        let handler = http_handler.clone();
+        scope = scope.route(
+            &endpoint,
+            web::route().to(
+                move |req: HttpRequest, state: web::Data<Arc<McpAppState>>, payload: String| {
+                    let handler = handler.clone();
+                    async move {
+                        let request = crate::bridge::from_actix_request(&req, Some(&payload));
+                        match handler
+                            .handle_auth_requests(request, state.get_ref().clone())
+                            .await
+                        {
+                            Ok(res) => crate::bridge::to_actix_response(res).await,
+                            Err(err) => crate::bridge::to_actix_error(err),
+                        }
+                    }
+                },
+            ),
+        );
+    }
+    Some(scope)
+}

--- a/crates/rust-mcp-actix/src/routes/fallback.rs
+++ b/crates/rust-mcp-actix/src/routes/fallback.rs
@@ -1,0 +1,8 @@
+use actix_web::{HttpRequest, HttpResponse};
+
+pub async fn not_found(req: HttpRequest) -> HttpResponse {
+    HttpResponse::NotFound().body(format!(
+        "The requested uri does not exist:\r\nuri: {}",
+        req.uri()
+    ))
+}

--- a/crates/rust-mcp-actix/src/routes/health.rs
+++ b/crates/rust-mcp-actix/src/routes/health.rs
@@ -1,0 +1,13 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use rust_mcp_sdk::mcp_http::McpHttpHandler;
+
+pub async fn handle_health_check(
+    req: HttpRequest,
+    handler: web::Data<McpHttpHandler>,
+) -> HttpResponse {
+    let request = super::super::bridge::from_actix_request(&req, None);
+    match handler.handle_health(request).await {
+        Ok(res) => super::super::bridge::to_actix_response(res).await,
+        Err(err) => super::super::bridge::to_actix_error(err),
+    }
+}

--- a/crates/rust-mcp-actix/src/routes/messages.rs
+++ b/crates/rust-mcp-actix/src/routes/messages.rs
@@ -1,0 +1,19 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use std::sync::Arc;
+
+pub async fn handle_messages(
+    req: HttpRequest,
+    state: web::Data<Arc<McpAppState>>,
+    handler: web::Data<McpHttpHandler>,
+    payload: String,
+) -> HttpResponse {
+    let request = crate::bridge::from_actix_request(&req, Some(&payload));
+    match handler
+        .handle_sse_message(request, state.get_ref().clone())
+        .await
+    {
+        Ok(res) => crate::bridge::to_actix_response(res).await,
+        Err(err) => crate::bridge::to_actix_error(err),
+    }
+}

--- a/crates/rust-mcp-actix/src/routes/mod.rs
+++ b/crates/rust-mcp-actix/src/routes/mod.rs
@@ -1,0 +1,6 @@
+pub mod auth;
+pub mod fallback;
+pub mod health;
+pub mod messages;
+pub mod sse;
+pub mod streamable_http;

--- a/crates/rust-mcp-actix/src/routes/sse.rs
+++ b/crates/rust-mcp-actix/src/routes/sse.rs
@@ -1,0 +1,23 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use std::sync::Arc;
+
+/// Passes the SSE message endpoint path to the SSE handler.
+#[derive(Clone)]
+pub struct SseMessageEndpoint(pub String);
+
+pub async fn handle_sse(
+    req: HttpRequest,
+    state: web::Data<Arc<McpAppState>>,
+    handler: web::Data<McpHttpHandler>,
+    sse_msg: web::Data<SseMessageEndpoint>,
+) -> HttpResponse {
+    let request = crate::bridge::from_actix_request(&req, None);
+    match handler
+        .handle_sse_connection(request, state.get_ref().clone(), Some(&sse_msg.0))
+        .await
+    {
+        Ok(res) => crate::bridge::to_actix_response(res).await,
+        Err(err) => crate::bridge::to_actix_error(err),
+    }
+}

--- a/crates/rust-mcp-actix/src/routes/streamable_http.rs
+++ b/crates/rust-mcp-actix/src/routes/streamable_http.rs
@@ -1,0 +1,49 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use std::sync::Arc;
+
+pub async fn handle_streamable_http_get(
+    req: HttpRequest,
+    state: web::Data<Arc<McpAppState>>,
+    handler: web::Data<McpHttpHandler>,
+) -> HttpResponse {
+    let request = crate::bridge::from_actix_request(&req, None);
+    match handler
+        .handle_streamable_http(request, state.get_ref().clone())
+        .await
+    {
+        Ok(res) => crate::bridge::to_actix_response(res).await,
+        Err(err) => crate::bridge::to_actix_error(err),
+    }
+}
+
+pub async fn handle_streamable_http_post(
+    req: HttpRequest,
+    state: web::Data<Arc<McpAppState>>,
+    handler: web::Data<McpHttpHandler>,
+    payload: String,
+) -> HttpResponse {
+    let request = crate::bridge::from_actix_request(&req, Some(&payload));
+    match handler
+        .handle_streamable_http(request, state.get_ref().clone())
+        .await
+    {
+        Ok(res) => crate::bridge::to_actix_response(res).await,
+        Err(err) => crate::bridge::to_actix_error(err),
+    }
+}
+
+pub async fn handle_streamable_http_delete(
+    req: HttpRequest,
+    state: web::Data<Arc<McpAppState>>,
+    handler: web::Data<McpHttpHandler>,
+) -> HttpResponse {
+    let request = crate::bridge::from_actix_request(&req, None);
+    match handler
+        .handle_streamable_http(request, state.get_ref().clone())
+        .await
+    {
+        Ok(res) => crate::bridge::to_actix_response(res).await,
+        Err(err) => crate::bridge::to_actix_error(err),
+    }
+}

--- a/crates/rust-mcp-actix/src/runtime.rs
+++ b/crates/rust-mcp-actix/src/runtime.rs
@@ -60,12 +60,41 @@ impl ActixRuntime {
                 handler.clone(),
                 &mount_options,
             ))
-        })
-        .bind(addr)
-        .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
-            description: e.to_string(),
-        })?
-        .run();
+        });
+
+        #[cfg(feature = "ssl")]
+        let srv = if server.options().enable_ssl {
+            let config = load_rustls_config(
+                server
+                    .options()
+                    .ssl_cert_path
+                    .as_deref()
+                    .unwrap_or_default(),
+                server.options().ssl_key_path.as_deref().unwrap_or_default(),
+            )
+            .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
+                description: e.to_string(),
+            })?;
+            srv.bind_rustls_0_23(addr, config).map_err(|e| {
+                rust_mcp_sdk::error::McpSdkError::Internal {
+                    description: e.to_string(),
+                }
+            })?
+        } else {
+            srv.bind(addr)
+                .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
+                    description: e.to_string(),
+                })?
+        };
+
+        #[cfg(not(feature = "ssl"))]
+        let srv = srv
+            .bind(addr)
+            .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
+                description: e.to_string(),
+            })?;
+
+        let srv = srv.run();
 
         let server_handle = srv.handle();
         let server_task = tokio::spawn(srv);
@@ -520,4 +549,29 @@ impl McpHttpServer for ActixRuntime {
     async fn runtime_by_session(&self, id: &SessionId) -> SdkResult<Arc<ServerRuntime>> {
         ActixRuntime::runtime_by_session(self, id).await
     }
+}
+
+#[cfg(feature = "ssl")]
+fn load_rustls_config(cert_path: &str, key_path: &str) -> std::io::Result<rustls::ServerConfig> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let cert_file = File::open(cert_path)?;
+    let mut cert_reader = BufReader::new(cert_file);
+    let certs: Vec<rustls::pki_types::CertificateDer> = rustls_pemfile::certs(&mut cert_reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+
+    let key_file = File::open(key_path)?;
+    let mut key_reader = BufReader::new(key_file);
+    let key = rustls_pemfile::private_key(&mut key_reader)?.ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "no private key found")
+    })?;
+
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+
+    Ok(config)
 }

--- a/crates/rust-mcp-actix/src/runtime.rs
+++ b/crates/rust-mcp-actix/src/runtime.rs
@@ -1,0 +1,523 @@
+use crate::server::ActixServer;
+use actix_web::dev::ServerHandle;
+use rust_mcp_sdk::session_store::SessionStore;
+use rust_mcp_sdk::task_store::{ClientTaskStore, ServerTaskStore, TaskStatusPoller};
+use rust_mcp_sdk::{
+    error::SdkResult,
+    mcp_http::McpAppState,
+    schema::{
+        schema_utils::{NotificationFromServer, RequestFromServer, ResultFromClient},
+        CreateMessageRequestParams, CreateMessageResult, ElicitRequestParams, ElicitResult,
+        GenericResult, GetTaskParams, GetTaskResult, InitializeRequestParams, ListRootsResult,
+        LoggingMessageNotificationParams, NotificationParams, RequestParams,
+        ResourceUpdatedNotificationParams,
+    },
+    McpServer,
+};
+use rust_mcp_sdk::{
+    schema::{
+        schema_utils::{ClientTaskResult, CustomNotification, CustomRequest},
+        CancelTaskParams, CancelTaskResult, CancelledNotificationParams, CreateTaskResult,
+        ElicitCompleteParams, GetTaskPayloadParams, ProgressNotificationParams, RpcError,
+        TaskStatusNotificationParams,
+    },
+    SessionId,
+};
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+/// Runtime handle for a running Actix MCP server.
+///
+/// Provides session management, graceful shutdown, and per-session request/notification
+/// methods. Implements [`McpHttpServer`] for framework-agnostic usage.
+pub struct ActixRuntime {
+    pub(crate) state: Arc<McpAppState>,
+    pub(crate) server_task: JoinHandle<io::Result<()>>,
+    pub(crate) server_handle: ServerHandle,
+}
+
+impl ActixRuntime {
+    /// Creates and starts a new runtime from an `ActixServer`.
+    pub async fn create(server: ActixServer) -> SdkResult<Self> {
+        let addr = server
+            .options()
+            .resolve_server_address()
+            .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal { description: e })?;
+
+        let state = server.state();
+        let info = server.server_info(Some(addr)).unwrap_or_default();
+        tracing::info!("{}", info);
+
+        let state_clone = state.clone();
+        let handler = server.handler.clone();
+        let mount_options = server.options().resolve_mount_options();
+
+        let srv = actix_web::HttpServer::new(move || {
+            actix_web::App::new().service(crate::mcp_scope(
+                state_clone.clone(),
+                handler.clone(),
+                &mount_options,
+            ))
+        })
+        .bind(addr)
+        .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
+            description: e.to_string(),
+        })?
+        .run();
+
+        let server_handle = srv.handle();
+        let server_task = tokio::spawn(srv);
+
+        // Task store notification forwarding
+        use futures::StreamExt;
+        if let Some(task_store) = state.task_store.clone() {
+            if let Some(mut stream) = task_store.subscribe() {
+                let state_clone = state.clone();
+                tokio::spawn(async move {
+                    while let Some((params, session_id_opt)) = stream.next().await {
+                        if let Some(session_id) = session_id_opt.as_ref() {
+                            if let Some(transport) = state_clone.session_store.get(session_id).await
+                            {
+                                let _ = transport.notify_task_status(params).await;
+                            }
+                        }
+                    }
+                });
+            }
+        }
+
+        // Task polling for server-initiated tasks
+        if let Some(client_task_store) = state.client_task_store.clone() {
+            let session_store = state.session_store.clone();
+            let callback = task_poller_callback(Arc::clone(&client_task_store), session_store);
+            let _ = client_task_store.start_task_polling(callback);
+        }
+
+        Ok(Self {
+            state,
+            server_task,
+            server_handle,
+        })
+    }
+
+    /// Gracefully stops the server.
+    pub fn graceful_shutdown(&self, _timeout: Option<Duration>) {
+        let handle = self.server_handle.clone();
+        tokio::spawn(async move {
+            let _ = handle.stop(true).await;
+        });
+    }
+
+    /// Awaits server completion (typically until shutdown).
+    pub async fn await_server(self) -> SdkResult<()> {
+        self.server_task
+            .await
+            .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
+                description: e.to_string(),
+            })?
+            .map_err(|e| rust_mcp_sdk::error::McpSdkError::Internal {
+                description: e.to_string(),
+            })
+    }
+
+    /// Returns all active session IDs.
+    pub async fn sessions(&self) -> Vec<String> {
+        self.state.session_store.keys().await
+    }
+
+    /// Returns the runtime for a given session.
+    pub async fn runtime_by_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Arc<ServerRuntime>, rust_mcp_sdk::error::McpSdkError> {
+        self.state
+            .session_store
+            .get(session_id)
+            .await
+            .ok_or_else(|| rust_mcp_sdk::error::McpSdkError::Internal {
+                description: format!("Session not found: {}", session_id),
+            })
+    }
+
+    // --- Request methods ---
+
+    pub async fn send_request(
+        &self,
+        session_id: &SessionId,
+        request: RequestFromServer,
+        timeout: Option<Duration>,
+    ) -> SdkResult<ResultFromClient> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        runtime.request(request, timeout).await
+    }
+
+    pub async fn send_notification(
+        &self,
+        session_id: &SessionId,
+        notification: NotificationFromServer,
+    ) -> SdkResult<()> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        runtime.send_notification(notification).await
+    }
+
+    pub async fn client_info(
+        &self,
+        session_id: &SessionId,
+    ) -> SdkResult<Option<InitializeRequestParams>> {
+        let runtime = self.runtime_by_session(session_id).await?;
+        Ok(runtime.client_info())
+    }
+
+    pub async fn request_elicitation(
+        &self,
+        session_id: &SessionId,
+        params: ElicitRequestParams,
+    ) -> SdkResult<ElicitResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_elicitation(params)
+            .await
+    }
+
+    pub async fn request_root_list(
+        &self,
+        session_id: &SessionId,
+        params: Option<RequestParams>,
+    ) -> SdkResult<ListRootsResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_root_list(params)
+            .await
+    }
+
+    pub async fn ping(
+        &self,
+        session_id: &SessionId,
+        params: Option<RequestParams>,
+        timeout: Option<Duration>,
+    ) -> SdkResult<rust_mcp_sdk::schema::Result> {
+        self.runtime_by_session(session_id)
+            .await?
+            .ping(params, timeout)
+            .await
+    }
+
+    pub async fn request_message_creation(
+        &self,
+        session_id: &SessionId,
+        params: CreateMessageRequestParams,
+    ) -> SdkResult<CreateMessageResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_message_creation(params)
+            .await
+    }
+
+    pub async fn request_get_task(
+        &self,
+        session_id: &SessionId,
+        params: GetTaskParams,
+    ) -> SdkResult<GetTaskResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_get_task(params)
+            .await
+    }
+
+    pub async fn request_custom(
+        &self,
+        session_id: &SessionId,
+        params: CustomRequest,
+    ) -> SdkResult<GenericResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_custom(params)
+            .await
+    }
+
+    // --- Notification methods ---
+
+    pub async fn notify_log_message(
+        &self,
+        session_id: &SessionId,
+        params: LoggingMessageNotificationParams,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_log_message(params)
+            .await
+    }
+
+    pub async fn notify_tool_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<NotificationParams>,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_tool_list_changed(params)
+            .await
+    }
+
+    pub async fn notify_resource_updated(
+        &self,
+        session_id: &SessionId,
+        params: ResourceUpdatedNotificationParams,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_resource_updated(params)
+            .await
+    }
+
+    pub async fn notify_resource_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<NotificationParams>,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_resource_list_changed(params)
+            .await
+    }
+
+    pub async fn notify_prompt_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<NotificationParams>,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_prompt_list_changed(params)
+            .await
+    }
+
+    pub async fn notify_task_status(
+        &self,
+        session_id: &SessionId,
+        params: TaskStatusNotificationParams,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_task_status(params)
+            .await
+    }
+
+    pub async fn notify_cancellation(
+        &self,
+        session_id: &SessionId,
+        params: CancelledNotificationParams,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_cancellation(params)
+            .await
+    }
+
+    pub async fn notify_progress(
+        &self,
+        session_id: &SessionId,
+        params: ProgressNotificationParams,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_progress(params)
+            .await
+    }
+
+    pub async fn notify_elicitation_completed(
+        &self,
+        session_id: &SessionId,
+        params: ElicitCompleteParams,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_elicitation_completed(params)
+            .await
+    }
+
+    pub async fn notify_custom(
+        &self,
+        session_id: &SessionId,
+        params: CustomNotification,
+    ) -> SdkResult<()> {
+        self.runtime_by_session(session_id)
+            .await?
+            .notify_custom(params)
+            .await
+    }
+
+    // --- Additional request methods (parity with AxumRuntime) ---
+
+    pub async fn request_elicitation_task(
+        &self,
+        session_id: &SessionId,
+        params: ElicitRequestParams,
+    ) -> SdkResult<CreateTaskResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_elicitation_task(params)
+            .await
+    }
+
+    pub async fn request_get_task_payload(
+        &self,
+        session_id: &SessionId,
+        params: GetTaskPayloadParams,
+    ) -> SdkResult<ClientTaskResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_get_task_payload(params)
+            .await
+    }
+
+    pub async fn request_task_cancellation(
+        &self,
+        session_id: &SessionId,
+        params: CancelTaskParams,
+    ) -> SdkResult<CancelTaskResult> {
+        self.runtime_by_session(session_id)
+            .await?
+            .request_task_cancellation(params)
+            .await
+    }
+
+    // --- Getters ---
+
+    pub fn task_store(&self) -> Option<Arc<ServerTaskStore>> {
+        self.state.task_store.clone()
+    }
+
+    pub fn client_task_store(&self) -> Option<Arc<ClientTaskStore>> {
+        self.state.client_task_store.clone()
+    }
+
+    // --- Deprecated aliases ---
+
+    #[deprecated(since = "0.8.0", note = "Use `request_root_list()` instead.")]
+    pub async fn list_roots(
+        &self,
+        session_id: &SessionId,
+        params: Option<RequestParams>,
+    ) -> SdkResult<ListRootsResult> {
+        self.request_root_list(session_id, params).await
+    }
+
+    #[deprecated(since = "0.8.0", note = "Use `request_elicitation()` instead.")]
+    pub async fn elicit_input(
+        &self,
+        session_id: &SessionId,
+        params: ElicitRequestParams,
+    ) -> SdkResult<ElicitResult> {
+        self.request_elicitation(session_id, params).await
+    }
+
+    #[deprecated(since = "0.8.0", note = "Use `request_message_creation()` instead.")]
+    pub async fn create_message(
+        &self,
+        session_id: &SessionId,
+        params: CreateMessageRequestParams,
+    ) -> SdkResult<CreateMessageResult> {
+        self.request_message_creation(session_id, params).await
+    }
+
+    #[deprecated(since = "0.8.0", note = "Use `notify_tool_list_changed()` instead.")]
+    pub async fn send_tool_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<NotificationParams>,
+    ) -> SdkResult<()> {
+        self.notify_tool_list_changed(session_id, params).await
+    }
+
+    #[deprecated(since = "0.8.0", note = "Use `notify_resource_updated()` instead.")]
+    pub async fn send_resource_updated(
+        &self,
+        session_id: &SessionId,
+        params: ResourceUpdatedNotificationParams,
+    ) -> SdkResult<()> {
+        self.notify_resource_updated(session_id, params).await
+    }
+
+    #[deprecated(
+        since = "0.8.0",
+        note = "Use `notify_resource_list_changed()` instead."
+    )]
+    pub async fn send_resource_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<NotificationParams>,
+    ) -> SdkResult<()> {
+        self.notify_resource_list_changed(session_id, params).await
+    }
+
+    #[deprecated(since = "0.8.0", note = "Use `notify_prompt_list_changed()` instead.")]
+    pub async fn send_prompt_list_changed(
+        &self,
+        session_id: &SessionId,
+        params: Option<NotificationParams>,
+    ) -> SdkResult<()> {
+        self.notify_prompt_list_changed(session_id, params).await
+    }
+
+    #[deprecated(since = "0.8.0", note = "Use `notify_log_message()` instead.")]
+    pub async fn send_logging_message(
+        &self,
+        session_id: &SessionId,
+        params: LoggingMessageNotificationParams,
+    ) -> SdkResult<()> {
+        self.notify_log_message(session_id, params).await
+    }
+}
+
+fn task_poller_callback(
+    client_task_store: Arc<ClientTaskStore>,
+    session_store: Arc<dyn SessionStore>,
+) -> TaskStatusPoller {
+    let session_store = session_store.clone();
+    let task_store_clone = client_task_store.clone();
+
+    let callback: TaskStatusPoller = Box::new(move |task_id, session_id| {
+        let session_store_clone = session_store.clone();
+        let task_store_clone = task_store_clone.clone();
+        Box::pin(async move {
+            let Some(session) = session_id.as_ref() else {
+                return Err(RpcError::invalid_request()
+                    .with_message("No session id provided!".to_string())
+                    .into());
+            };
+
+            let Some(runtime) = session_store_clone.get(session).await else {
+                return Err(RpcError::invalid_request()
+                    .with_message("Invalid or broken session!".to_string())
+                    .into());
+            };
+
+            runtime
+                .poll_task_status(task_id, session_id, task_store_clone)
+                .await
+        })
+    });
+    callback
+}
+
+use async_trait::async_trait;
+use rust_mcp_sdk::mcp_server::ServerRuntime;
+use rust_mcp_sdk::McpHttpServer;
+
+#[async_trait]
+impl McpHttpServer for ActixRuntime {
+    async fn graceful_shutdown(&self) {
+        self.graceful_shutdown(None);
+    }
+
+    async fn sessions(&self) -> Vec<SessionId> {
+        ActixRuntime::sessions(self).await
+    }
+
+    async fn runtime_by_session(&self, id: &SessionId) -> SdkResult<Arc<ServerRuntime>> {
+        ActixRuntime::runtime_by_session(self, id).await
+    }
+}

--- a/crates/rust-mcp-actix/src/server.rs
+++ b/crates/rust-mcp-actix/src/server.rs
@@ -1,0 +1,107 @@
+use crate::options::ActixServerOptions;
+use crate::ActixRuntime;
+use rust_mcp_sdk::mcp_http::middleware::AuthMiddleware;
+use rust_mcp_sdk::mcp_http::Middleware;
+use rust_mcp_sdk::{
+    error::SdkResult,
+    id_generator::{FastIdGenerator, UuidGenerator},
+    mcp_http::McpAppState,
+    mcp_http::McpHttpHandler,
+    mcp_server::McpServerHandler,
+    schema::InitializeResult,
+    session_store::InMemorySessionStore,
+};
+use std::sync::Arc;
+
+/// Turnkey Actix MCP server.
+///
+/// Created via [`create_actix_server()`](crate::create_actix_server) and started
+/// with `.start()` or `.start_runtime()`.
+pub struct ActixServer {
+    pub(crate) state: Arc<McpAppState>,
+    pub(crate) handler: Arc<McpHttpHandler>,
+    pub(crate) options: ActixServerOptions,
+}
+
+impl ActixServer {
+    /// Creates a new `ActixServer` instance.
+    pub fn new(
+        server_details: InitializeResult,
+        handler: Arc<dyn McpServerHandler + 'static>,
+        mut server_options: ActixServerOptions,
+    ) -> Self {
+        let state: Arc<McpAppState> = Arc::new(McpAppState {
+            session_store: Arc::new(InMemorySessionStore::new()),
+            id_generator: server_options
+                .session_id_generator
+                .take()
+                .map_or(Arc::new(UuidGenerator {}), |g| Arc::clone(&g)),
+            stream_id_gen: Arc::new(FastIdGenerator::new(Some("s_"))),
+            server_details: Arc::new(server_details),
+            handler,
+            ping_interval: server_options.ping_interval,
+            transport_options: Arc::clone(&server_options.transport_options),
+            enable_json_response: server_options.enable_json_response.unwrap_or(false),
+            event_store: server_options.event_store.as_ref().map(Arc::clone),
+            task_store: server_options.task_store.take(),
+            client_task_store: server_options.client_task_store.take(),
+            message_observer: server_options.message_observer.take(),
+        });
+
+        let mut middlewares: Vec<Arc<dyn Middleware>> = vec![];
+        if let Some(auth_provider) = server_options.auth.take() {
+            middlewares.push(Arc::new(AuthMiddleware::new(auth_provider)));
+        }
+
+        let http_handler = Arc::new(McpHttpHandler::new(
+            None,
+            middlewares,
+            server_options.health_handler.clone(),
+        ));
+
+        ActixServer {
+            state,
+            handler: http_handler,
+            options: server_options,
+        }
+    }
+
+    /// Returns a shared reference to the application state.
+    pub fn state(&self) -> Arc<McpAppState> {
+        self.state.clone()
+    }
+
+    /// Returns the server configuration.
+    pub fn options(&self) -> &ActixServerOptions {
+        &self.options
+    }
+
+    /// Generates the server info string for startup logging.
+    pub fn server_info(&self, addr: Option<std::net::SocketAddr>) -> Result<String, String> {
+        let addr = addr.unwrap_or(self.options.resolve_server_address()?);
+        let mut info = format!(
+            "\n\u{2022} Streamable HTTP Server is available at http://{}{}",
+            addr,
+            self.options.streamable_http_endpoint()
+        );
+        if self.options.sse_support {
+            info.push_str(&format!(
+                "\n\u{2022} SSE Server is available at http://{}{}",
+                addr,
+                self.options.sse_endpoint()
+            ));
+        }
+        Ok(info)
+    }
+
+    /// Starts the server and blocks until shutdown.
+    pub async fn start(self) -> SdkResult<()> {
+        let runtime = ActixRuntime::create(self).await?;
+        runtime.await_server().await
+    }
+
+    /// Starts the server and returns a runtime handle.
+    pub async fn start_runtime(self) -> SdkResult<ActixRuntime> {
+        ActixRuntime::create(self).await
+    }
+}

--- a/crates/rust-mcp-actix/src/server.rs
+++ b/crates/rust-mcp-actix/src/server.rs
@@ -80,13 +80,13 @@ impl ActixServer {
     pub fn server_info(&self, addr: Option<std::net::SocketAddr>) -> Result<String, String> {
         let addr = addr.unwrap_or(self.options.resolve_server_address()?);
         let mut info = format!(
-            "\n\u{2022} Streamable HTTP Server is available at http://{}{}",
+            "\n  Streamable HTTP Server is available at http://{}{}",
             addr,
             self.options.streamable_http_endpoint()
         );
         if self.options.sse_support {
             info.push_str(&format!(
-                "\n\u{2022} SSE Server is available at http://{}{}",
+                "\n  SSE Server is available at http://{}{}",
                 addr,
                 self.options.sse_endpoint()
             ));

--- a/crates/rust-mcp-actix/tests/integration_tests.rs
+++ b/crates/rust-mcp-actix/tests/integration_tests.rs
@@ -1,0 +1,209 @@
+use actix_web::{test, App};
+use rust_mcp_actix::{mcp_scope, ActixMountOptions};
+use rust_mcp_sdk::id_generator::{FastIdGenerator, UuidGenerator};
+use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
+use rust_mcp_sdk::mcp_server::ServerHandler;
+use rust_mcp_sdk::schema::{Implementation, InitializeResult, ProtocolVersion, ServerCapabilities};
+use rust_mcp_sdk::session_store::InMemorySessionStore;
+use rust_mcp_sdk::ToMcpServerHandler;
+use std::sync::Arc;
+
+fn test_server_details() -> InitializeResult {
+    InitializeResult {
+        server_info: Implementation {
+            name: "test-server".into(),
+            version: "0.1.0".into(),
+            title: None,
+            description: None,
+            icons: vec![],
+            website_url: None,
+        },
+        capabilities: ServerCapabilities::default(),
+        meta: None,
+        instructions: None,
+        protocol_version: ProtocolVersion::V2025_11_25.into(),
+    }
+}
+
+#[derive(Default)]
+struct DummyHandler;
+impl ServerHandler for DummyHandler {}
+
+fn make_state() -> (Arc<McpAppState>, Arc<McpHttpHandler>) {
+    let state = Arc::new(McpAppState {
+        session_store: Arc::new(InMemorySessionStore::new()),
+        id_generator: Arc::new(UuidGenerator {}),
+        stream_id_gen: Arc::new(FastIdGenerator::new(Some("s_"))),
+        server_details: Arc::new(test_server_details()),
+        handler: DummyHandler::default().to_mcp_server_handler(),
+        ping_interval: std::time::Duration::from_secs(12),
+        transport_options: Default::default(),
+        enable_json_response: false,
+        event_store: None,
+        task_store: None,
+        client_task_store: None,
+        message_observer: None,
+    });
+    let handler = Arc::new(McpHttpHandler::new(None, vec![], None));
+    (state, handler)
+}
+
+fn default_mount() -> ActixMountOptions {
+    ActixMountOptions {
+        streamable_http_endpoint: "/mcp".into(),
+        sse_endpoint: "/sse".into(),
+        sse_messages_endpoint: "/messages".into(),
+        health_endpoint: Some("/health".into()),
+    }
+}
+
+// =====================================================================
+// Integration tests (actix runtime required)
+// =====================================================================
+
+#[actix_web::test]
+async fn test_mcp_scope_routes_health() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::get().uri("/health").to_request();
+    let resp = test::call_service(&app, req).await;
+    // Health endpoint should be registered when health_endpoint is Some
+    assert!(
+        resp.status().is_success() || resp.status() != 404,
+        "Health route should not 404, got {}",
+        resp.status()
+    );
+}
+
+#[actix_web::test]
+async fn test_health_endpoint_returns_200() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::get().uri("/health").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["status"], "ok");
+    assert!(body["server"].is_string());
+    assert!(body["version"].is_string());
+}
+
+#[actix_web::test]
+async fn test_health_endpoint_disabled_when_none() {
+    let (state, handler) = make_state();
+    let opts = ActixMountOptions {
+        health_endpoint: None,
+        ..default_mount()
+    };
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::get().uri("/health").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 404);
+}
+
+#[actix_web::test]
+async fn test_unknown_path_returns_404() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/non-existent-path")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 404);
+}
+
+#[actix_web::test]
+async fn test_streamable_http_get_returns_error_without_session() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::get().uri("/mcp").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(!resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_streamable_http_post_invalid_body() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/mcp")
+        .set_payload("not-valid-json")
+        .insert_header(("Content-Type", "application/json"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(!resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_streamable_http_delete_returns_error_without_session() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::delete().uri("/mcp").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(!resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_sse_endpoint_registered() {
+    // Verify that mcp_scope can be constructed and app initialized without panicking.
+    // SSE connections are long-lived streams not suited for the synchronous test client.
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let _app = test::init_service(App::new().service(scope)).await;
+}
+
+#[actix_web::test]
+async fn test_messages_endpoint_rejects_invalid_session() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/messages")
+        .set_payload("{}")
+        .insert_header(("Content-Type", "application/json"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(!resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_error_bridge_session_id_missing() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/messages")
+        .set_payload("{}")
+        .insert_header(("Content-Type", "application/json"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 500);
+}

--- a/crates/rust-mcp-actix/tests/integration_tests.rs
+++ b/crates/rust-mcp-actix/tests/integration_tests.rs
@@ -205,5 +205,5 @@ async fn test_error_bridge_session_id_missing() {
         .to_request();
     let resp = test::call_service(&app, req).await;
 
-    assert_eq!(resp.status(), 500);
+    assert_eq!(resp.status(), 400);
 }

--- a/crates/rust-mcp-actix/tests/integration_tests.rs
+++ b/crates/rust-mcp-actix/tests/integration_tests.rs
@@ -3,9 +3,7 @@ use rust_mcp_actix::{mcp_scope, ActixMountOptions};
 use rust_mcp_sdk::id_generator::{FastIdGenerator, UuidGenerator};
 use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
 use rust_mcp_sdk::mcp_server::ServerHandler;
-use rust_mcp_sdk::schema::{
-    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
-};
+use rust_mcp_sdk::schema::{Implementation, InitializeResult, ProtocolVersion, ServerCapabilities};
 use rust_mcp_sdk::session_store::InMemorySessionStore;
 use rust_mcp_sdk::ToMcpServerHandler;
 use std::sync::Arc;
@@ -123,7 +121,9 @@ async fn test_unknown_path_returns_404() {
     let scope = mcp_scope(state, handler, &opts);
     let app = test::init_service(App::new().service(scope)).await;
 
-    let req = test::TestRequest::get().uri("/non-existent-path").to_request();
+    let req = test::TestRequest::get()
+        .uri("/non-existent-path")
+        .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 404);
 }
@@ -191,10 +191,16 @@ async fn test_sse_endpoint_returns_event_stream() {
     let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), 200);
-    let content_type = resp.headers().get("content-type")
-        .and_then(|v| v.to_str().ok()).unwrap_or("");
-    assert!(content_type.starts_with("text/event-stream"),
-        "Expected text/event-stream, got: {}", content_type);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "Expected text/event-stream, got: {}",
+        content_type
+    );
 }
 
 #[actix_web::test]
@@ -215,8 +221,14 @@ async fn test_streamable_http_init_returns_session_id() {
         .to_request();
     let resp = test::call_service(&app, req).await;
 
-    assert!(resp.status().is_success(), "Expected 2xx, got {}", resp.status());
-    let session_id = resp.headers().get("mcp-session-id")
+    assert!(
+        resp.status().is_success(),
+        "Expected 2xx, got {}",
+        resp.status()
+    );
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
         .expect("Expected mcp-session-id header");

--- a/crates/rust-mcp-actix/tests/integration_tests.rs
+++ b/crates/rust-mcp-actix/tests/integration_tests.rs
@@ -3,7 +3,9 @@ use rust_mcp_actix::{mcp_scope, ActixMountOptions};
 use rust_mcp_sdk::id_generator::{FastIdGenerator, UuidGenerator};
 use rust_mcp_sdk::mcp_http::{McpAppState, McpHttpHandler};
 use rust_mcp_sdk::mcp_server::ServerHandler;
-use rust_mcp_sdk::schema::{Implementation, InitializeResult, ProtocolVersion, ServerCapabilities};
+use rust_mcp_sdk::schema::{
+    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
+};
 use rust_mcp_sdk::session_store::InMemorySessionStore;
 use rust_mcp_sdk::ToMcpServerHandler;
 use std::sync::Arc;
@@ -48,6 +50,15 @@ fn make_state() -> (Arc<McpAppState>, Arc<McpHttpHandler>) {
     (state, handler)
 }
 
+fn make_state_json_mode() -> (Arc<McpAppState>, Arc<McpHttpHandler>) {
+    let (state, handler) = make_state();
+    let state = McpAppState {
+        enable_json_response: true,
+        ..Arc::unwrap_or_clone(state)
+    };
+    (Arc::new(state), handler)
+}
+
 fn default_mount() -> ActixMountOptions {
     ActixMountOptions {
         streamable_http_endpoint: "/mcp".into(),
@@ -58,7 +69,7 @@ fn default_mount() -> ActixMountOptions {
 }
 
 // =====================================================================
-// Integration tests (actix runtime required)
+// Basic route tests
 // =====================================================================
 
 #[actix_web::test]
@@ -70,12 +81,7 @@ async fn test_mcp_scope_routes_health() {
 
     let req = test::TestRequest::get().uri("/health").to_request();
     let resp = test::call_service(&app, req).await;
-    // Health endpoint should be registered when health_endpoint is Some
-    assert!(
-        resp.status().is_success() || resp.status() != 404,
-        "Health route should not 404, got {}",
-        resp.status()
-    );
+    assert!(resp.status().is_success() || resp.status() != 404);
 }
 
 #[actix_web::test]
@@ -117,13 +123,14 @@ async fn test_unknown_path_returns_404() {
     let scope = mcp_scope(state, handler, &opts);
     let app = test::init_service(App::new().service(scope)).await;
 
-    let req = test::TestRequest::get()
-        .uri("/non-existent-path")
-        .to_request();
+    let req = test::TestRequest::get().uri("/non-existent-path").to_request();
     let resp = test::call_service(&app, req).await;
-
     assert_eq!(resp.status(), 404);
 }
+
+// =====================================================================
+// Streamable HTTP route tests
+// =====================================================================
 
 #[actix_web::test]
 async fn test_streamable_http_get_returns_error_without_session() {
@@ -148,6 +155,7 @@ async fn test_streamable_http_post_invalid_body() {
         .uri("/mcp")
         .set_payload("not-valid-json")
         .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Accept", "application/json, text/event-stream"))
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert!(!resp.status().is_success());
@@ -165,15 +173,59 @@ async fn test_streamable_http_delete_returns_error_without_session() {
     assert!(!resp.status().is_success());
 }
 
+// =====================================================================
+// SSE streaming endpoint
+// =====================================================================
+
 #[actix_web::test]
-async fn test_sse_endpoint_registered() {
-    // Verify that mcp_scope can be constructed and app initialized without panicking.
-    // SSE connections are long-lived streams not suited for the synchronous test client.
+async fn test_sse_endpoint_returns_event_stream() {
     let (state, handler) = make_state();
     let opts = default_mount();
     let scope = mcp_scope(state, handler, &opts);
-    let _app = test::init_service(App::new().service(scope)).await;
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/sse")
+        .insert_header(("Accept", "text/event-stream"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), 200);
+    let content_type = resp.headers().get("content-type")
+        .and_then(|v| v.to_str().ok()).unwrap_or("");
+    assert!(content_type.starts_with("text/event-stream"),
+        "Expected text/event-stream, got: {}", content_type);
 }
+
+#[actix_web::test]
+async fn test_streamable_http_init_returns_session_id() {
+    let (state, handler) = make_state_json_mode();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/mcp")
+        .set_payload(serde_json::json!({
+            "jsonrpc":"2.0","id":1,"method":"initialize",
+            "params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1"}}
+        }).to_string())
+        .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Accept", "application/json, text/event-stream"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert!(resp.status().is_success(), "Expected 2xx, got {}", resp.status());
+    let session_id = resp.headers().get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .expect("Expected mcp-session-id header");
+    assert!(!session_id.is_empty());
+}
+
+// =====================================================================
+// Messages endpoint
+// =====================================================================
 
 #[actix_web::test]
 async fn test_messages_endpoint_rejects_invalid_session() {
@@ -186,13 +238,18 @@ async fn test_messages_endpoint_rejects_invalid_session() {
         .uri("/messages")
         .set_payload("{}")
         .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Accept", "application/json, text/event-stream"))
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert!(!resp.status().is_success());
 }
 
+// =====================================================================
+// Error status code mapping
+// =====================================================================
+
 #[actix_web::test]
-async fn test_error_bridge_session_id_missing() {
+async fn test_error_mapping_session_missing_returns_400() {
     let (state, handler) = make_state();
     let opts = default_mount();
     let scope = mcp_scope(state, handler, &opts);
@@ -202,8 +259,25 @@ async fn test_error_bridge_session_id_missing() {
         .uri("/messages")
         .set_payload("{}")
         .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Accept", "application/json, text/event-stream"))
         .to_request();
     let resp = test::call_service(&app, req).await;
-
     assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
+async fn test_error_mapping_invalid_session_returns_404() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/messages?sessionId=nonexistent")
+        .set_payload("{}")
+        .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Accept", "application/json, text/event-stream"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 404);
 }

--- a/crates/rust-mcp-actix/tests/unit.rs
+++ b/crates/rust-mcp-actix/tests/unit.rs
@@ -22,3 +22,63 @@ fn test_actix_mount_options_custom() {
     assert_eq!(mount.sse_messages_endpoint, "/api/messages");
     assert_eq!(mount.health_endpoint, Some("/api/health".into()));
 }
+
+#[test]
+fn test_create_actix_server_returns_server() {
+    use rust_mcp_sdk::mcp_server::ServerHandler;
+    use rust_mcp_sdk::schema::{
+        Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
+    };
+    use rust_mcp_sdk::ToMcpServerHandler;
+
+    #[derive(Default)]
+    struct DummyHandler;
+    impl ServerHandler for DummyHandler {}
+
+    let details = InitializeResult {
+        server_info: Implementation {
+            name: "test".into(),
+            version: "0.1.0".into(),
+            title: None,
+            description: None,
+            icons: vec![],
+            website_url: None,
+        },
+        capabilities: ServerCapabilities::default(),
+        meta: None,
+        instructions: None,
+        protocol_version: ProtocolVersion::V2025_11_25.into(),
+    };
+
+    let handler = DummyHandler::default().to_mcp_server_handler();
+    let options = rust_mcp_actix::ActixServerOptions::default();
+
+    let server = rust_mcp_actix::create_actix_server(details, handler, options);
+    assert!(server.server_info(None).is_ok());
+}
+
+#[test]
+fn test_actix_server_options_default_valid() {
+    let options = rust_mcp_actix::ActixServerOptions::default();
+    assert!(options.validate().is_ok());
+}
+
+#[test]
+fn test_actix_server_options_resolve_address() {
+    let options = rust_mcp_actix::ActixServerOptions::default();
+    let addr = options.resolve_server_address();
+    assert!(addr.is_ok());
+}
+
+#[test]
+fn test_actix_server_options_custom_endpoints() {
+    let options = rust_mcp_actix::ActixServerOptions {
+        custom_streamable_http_endpoint: Some("/v2/mcp".into()),
+        custom_sse_endpoint: Some("/v2/sse".into()),
+        custom_messages_endpoint: Some("/v2/msg".into()),
+        ..Default::default()
+    };
+    assert_eq!(options.streamable_http_endpoint(), "/v2/mcp");
+    assert_eq!(options.sse_endpoint(), "/v2/sse");
+    assert_eq!(options.sse_messages_endpoint(), "/v2/msg");
+}

--- a/crates/rust-mcp-actix/tests/unit.rs
+++ b/crates/rust-mcp-actix/tests/unit.rs
@@ -1,0 +1,24 @@
+use rust_mcp_actix::ActixMountOptions;
+
+#[test]
+fn test_actix_mount_options_default() {
+    let mount = ActixMountOptions::default();
+    assert_eq!(mount.streamable_http_endpoint, "/mcp");
+    assert_eq!(mount.sse_endpoint, "/sse");
+    assert_eq!(mount.sse_messages_endpoint, "/messages");
+    assert!(mount.health_endpoint.is_none());
+}
+
+#[test]
+fn test_actix_mount_options_custom() {
+    let mount = ActixMountOptions {
+        streamable_http_endpoint: "/api/mcp".into(),
+        sse_endpoint: "/api/sse".into(),
+        sse_messages_endpoint: "/api/messages".into(),
+        health_endpoint: Some("/api/health".into()),
+    };
+    assert_eq!(mount.streamable_http_endpoint, "/api/mcp");
+    assert_eq!(mount.sse_endpoint, "/api/sse");
+    assert_eq!(mount.sse_messages_endpoint, "/api/messages");
+    assert_eq!(mount.health_endpoint, Some("/api/health".into()));
+}

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 [dependencies]
 rust-mcp-sdk = { workspace = true, features = ["server", "streamable-http", "sse", "auth"] }
 thiserror = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 axum-server = { workspace = true, features = [] }
 tokio = { workspace = true }

--- a/crates/rust-mcp-axum/src/runtime.rs
+++ b/crates/rust-mcp-axum/src/runtime.rs
@@ -2,6 +2,7 @@ use crate::error::{TransportServerError, TransportServerResult};
 use crate::AxumServer;
 use axum_server::Handle;
 use futures::StreamExt;
+use rust_mcp_sdk::McpHttpServer;
 use rust_mcp_sdk::{
     error::SdkResult,
     mcp_server::ServerRuntime,
@@ -500,5 +501,24 @@ impl AxumRuntime {
 
     pub fn client_task_store(&self) -> Option<Arc<ClientTaskStore>> {
         self.state.client_task_store.clone()
+    }
+}
+
+use async_trait::async_trait;
+
+#[async_trait]
+impl McpHttpServer for AxumRuntime {
+    async fn graceful_shutdown(&self) {
+        self.graceful_shutdown(None);
+    }
+
+    async fn sessions(&self) -> Vec<SessionId> {
+        AxumRuntime::sessions(self).await
+    }
+
+    async fn runtime_by_session(&self, id: &SessionId) -> SdkResult<Arc<ServerRuntime>> {
+        AxumRuntime::runtime_by_session(self, id)
+            .await
+            .map_err(Into::into)
     }
 }

--- a/crates/rust-mcp-sdk/src/mcp_traits.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits.rs
@@ -3,6 +3,8 @@ pub(super) mod id_generator;
 mod mcp_client;
 mod mcp_handler;
 #[cfg(feature = "server")]
+mod mcp_http_server;
+#[cfg(feature = "server")]
 mod mcp_server;
 mod request_id_gen;
 
@@ -13,6 +15,8 @@ pub use id_generator::*;
 #[cfg(feature = "client")]
 pub use mcp_client::*;
 pub use mcp_handler::*;
+#[cfg(feature = "server")]
+pub use mcp_http_server::*;
 #[cfg(feature = "server")]
 pub use mcp_server::*;
 pub use request_id_gen::*;

--- a/crates/rust-mcp-sdk/src/mcp_traits/mcp_http_server.rs
+++ b/crates/rust-mcp-sdk/src/mcp_traits/mcp_http_server.rs
@@ -1,0 +1,30 @@
+use crate::error::SdkResult;
+use crate::mcp_runtimes::server_runtime::ServerRuntime;
+use async_trait::async_trait;
+use rust_mcp_transport::SessionId;
+use std::sync::Arc;
+
+/// Common interface for running MCP servers over HTTP transports.
+///
+/// Implemented by framework-specific runtimes (e.g. `AxumRuntime` in `rust-mcp-axum`,
+/// `ActixRuntime` in `rust-mcp-actix`) to provide a uniform API for:
+///
+/// - Graceful shutdown
+/// - Session enumeration
+/// - Per-session runtime access
+///
+/// Users coding against `dyn McpHttpServer` can swap HTTP frameworks without
+/// changing their runtime interaction code.
+#[async_trait]
+pub trait McpHttpServer: Send + Sync {
+    /// Gracefully shuts down the server, waiting for in-flight requests to complete.
+    async fn graceful_shutdown(&self);
+
+    /// Returns all active session IDs on this server.
+    async fn sessions(&self) -> Vec<SessionId>;
+
+    /// Returns the runtime for a given session ID.
+    ///
+    /// Returns an error if the session does not exist or has been closed.
+    async fn runtime_by_session(&self, id: &SessionId) -> SdkResult<Arc<ServerRuntime>>;
+}


### PR DESCRIPTION
### 📌 Summary

Adds the `McpHttpServer` framework-agnostic trait and `rust-mcp-actix` crate with full Actix-web support. 



### 🔍 Related Issues

- #103 
- These changes support progress toward #124 

### ✨ Changes Made

- Introduced `McpHttpServer` trait  (`crates/rust-mcp-sdk/src/mcp_traits/`)
  - Framework-agnostic interface: `graceful_shutdown()`, `sessions()`, `runtime_by_session()`
  - `impl McpHttpServer for AxumRuntime` in `rust-mcp-axum`

- New`rust-mcp-actix` crate
  - Full bridge: `from_actix_request()` / `to_actix_response()` (SSE streaming + standard)
  - Turnkey: `create_actix_server()` + `ActixServer` + `ActixRuntime`
  - Bring your own server: `mcp_scope()` + `ActixMountOptions`
  - Config: `ActixServerOptions` mirrors `AxumServerOptions`
  - TLS: `ssl` feature via `actix-web/rustls-0_23` + `rustls` + `rustls-pemfile`
  - `impl McpHttpServer for ActixRuntime`

- Updated release pipeline
  - `.release-config.json` - added `crates/rust-mcp-axum` + `crates/rust-mcp-actix` packages
  - `.release-manifest.json` - added both crates at `0.1.0`
  - `.github/workflows/release-pr.yml` 



### 🛠️ Testing Steps

```bash
cargo test -p rust-mcp-actix    
cargo test -p rust-mcp-axum   
cargo build --workspace --examples
cargo build -p rust-mcp-actix --features ssl
```

### 💡 Additional Notes
Full parity with rust-mcp-axum. Migration is one import change:

```diff
- use mcp_axum::{create_axum_server, AxumServerOptions};
+ use rust_mcp_actix::{create_actix_server, ActixServerOptions};
```
