### PR TITLE
fix(tls): install rustls crypto provider before serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "rust-mcp-macros",
  "rust-mcp-schema",
  "rust-mcp-transport",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
@@ -1930,6 +1931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -32,7 +32,7 @@ tracing.workspace = true
 base64.workspace = true
 bytes.workspace = true
 
-# rustls = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
 hyper = { version = "1.6.0", optional = true }
 http = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
@@ -82,7 +82,7 @@ auth=["url","jsonwebtoken/aws_lc_rs","reqwest"]
 server = []                                                               # Server feature
 client = []                                                               # Client feature
 hyper-server = ["axum", "axum-server", "hyper", "server", "streamable-http", "tokio-stream","http","http-body","http-body-util"]
-ssl = ["axum-server/tls-rustls"]
+ssl = ["axum-server/tls-rustls", "dep:rustls"]
 tls-no-provider = ["axum-server/tls-rustls-no-provider"]
 macros = ["rust-mcp-macros/sdk"]
 

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -464,6 +464,14 @@ impl HyperServer {
     /// * `TransportServerResult<()>` - Ok if the server starts successfully, Err otherwise
     #[cfg(feature = "ssl")]
     pub(crate) async fn start_ssl(self, addr: SocketAddr) -> TransportServerResult<()> {
+        // Install a process-wide rustls crypto provider before the first TLS
+        // handshake. With both `aws-lc-rs` (via jsonwebtoken) and `ring`
+        // potentially in the dependency graph, rustls otherwise has no
+        // unambiguous default and the first handshake panics. `install_default`
+        // returns an error if a provider is already installed, which we
+        // intentionally ignore so embedders may install their own first.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let config = RustlsConfig::from_pem_file(
             self.options.ssl_cert_path.as_deref().unwrap_or_default(),
             self.options.ssl_key_path.as_deref().unwrap_or_default(),


### PR DESCRIPTION
### 📌 Summary

No rustls `CryptoProvider` was installed explicitly. With both `aws-lc-rs` (pulled by `jsonwebtoken`) and `ring` potentially in the dependency graph, rustls has no unambiguous default and the first TLS handshake can panic. The `ssl` path now installs the `aws-lc-rs` provider before serving.

### 🔍 Related Issues

- Related to #141

### ✨ Changes Made

- Add `rustls` as an optional dependency under the `ssl` feature.
- Install `aws_lc_rs` `CryptoProvider` at the start of `start_ssl` (ignoring the already-installed case so embedders can install their own).