### PR TITLE
perf(auth): reuse a shared reqwest::Client

### DIFF
--- a/crates/rust-mcp-extra/src/token_verifier/generic_token_verifier.rs
+++ b/crates/rust-mcp-extra/src/token_verifier/generic_token_verifier.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use reqwest::{header::AUTHORIZATION, StatusCode};
 use rust_mcp_sdk::{
     auth::{
-        decode_token_header, Audience, AuthInfo, AuthenticationError, IntrospectionResponse,
-        JsonWebKeySet, OauthTokenVerifier,
+        decode_token_header, shared_http_client, Audience, AuthInfo, AuthenticationError,
+        IntrospectionResponse, JsonWebKeySet, OauthTokenVerifier,
     },
     mcp_http::error_message_from_response,
 };
@@ -212,7 +212,7 @@ impl GenericOauthTokenVerifier {
             }
         };
 
-        let client = reqwest::Client::new();
+        let client = shared_http_client();
 
         let response = client
             .get(user_info_endpoint.to_owned())
@@ -255,7 +255,7 @@ impl GenericOauthTokenVerifier {
         token: &str,
         introspection_endpoint: &Url,
     ) -> Result<AuthInfo, AuthenticationError> {
-        let client = reqwest::Client::new();
+        let client = shared_http_client();
 
         // Form data body
         let mut form = HashMap::new();
@@ -343,7 +343,9 @@ impl GenericOauthTokenVerifier {
     }
 
     async fn populate_jwks(&self, jwks_uri: &Url) -> Result<(), AuthenticationError> {
-        let response = reqwest::get(jwks_uri.to_owned())
+        let response = shared_http_client()
+            .get(jwks_uri.to_owned())
+            .send()
             .await
             .map_err(|err| AuthenticationError::Jwks(err.to_string()))?;
         let jwks: JsonWebKeySet = response

--- a/crates/rust-mcp-sdk/src/auth.rs
+++ b/crates/rust-mcp-sdk/src/auth.rs
@@ -22,3 +22,22 @@ pub use spec::Audience;
 pub use spec::*;
 #[cfg(feature = "auth")]
 pub use token_verifier::*;
+
+#[cfg(feature = "auth")]
+use std::sync::LazyLock;
+
+/// Process-wide shared `reqwest::Client` used for OAuth discovery, metadata, and
+/// JWKS fetches.
+///
+/// Constructing a new `Client` per call creates a fresh connection pool and TLS
+/// configuration on every request. Cloning this shared client (cheap; it is
+/// `Arc`-backed) reuses the same pool, which matters during key-rotation events
+/// where many verifications fetch JWKS concurrently.
+#[cfg(feature = "auth")]
+static SHARED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+
+/// Returns a clone of the process-wide shared [`reqwest::Client`].
+#[cfg(feature = "auth")]
+pub fn shared_http_client() -> reqwest::Client {
+    SHARED_HTTP_CLIENT.clone()
+}

--- a/crates/rust-mcp-sdk/src/auth/auth_provider/remote_auth_provider.rs
+++ b/crates/rust-mcp-sdk/src/auth/auth_provider/remote_auth_provider.rs
@@ -13,7 +13,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::{header::CONTENT_TYPE, StatusCode};
 use http_body_util::{BodyExt, Full};
-use reqwest::Client;
 use std::{collections::HashMap, sync::Arc};
 
 /// Represents a **Remote OAuth authentication provider** integrated with the MCP server.
@@ -68,7 +67,7 @@ impl RemoteAuthProvider {
         token_verifier: Box<dyn OauthTokenVerifier>,
         required_scopes: Option<Vec<String>>,
     ) -> Result<Self, reqwest::Error> {
-        let client = Client::new();
+        let client = crate::auth::shared_http_client();
 
         let auth_server_meta = client
             .get(authorization_server_metadata_url)

--- a/crates/rust-mcp-sdk/src/auth/metadata.rs
+++ b/crates/rust-mcp-sdk/src/auth/metadata.rs
@@ -5,7 +5,6 @@ use crate::{
     error::McpSdkError,
     utils::join_url,
 };
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -139,7 +138,7 @@ impl<'a> AuthMetadataBuilder<'a> {
     where
         S: Into<Cow<'a, str>>,
     {
-        let client = Client::new();
+        let client = crate::auth::shared_http_client();
         let json: Value = client
             .get(discovery_url)
             .send()

--- a/crates/rust-mcp-sdk/src/auth/spec/discovery.rs
+++ b/crates/rust-mcp-sdk/src/auth/spec/discovery.rs
@@ -3,7 +3,6 @@ use crate::{
     error::McpSdkError,
     mcp_http::url_base,
 };
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
@@ -151,7 +150,7 @@ impl AuthorizationServerMetadata {
     /// to RFC 8414 (OAuth 2.0 Authorization Server Metadata) or OpenID Connect Discovery 1.0.
     ///
     pub async fn from_discovery_url(discovery_url: &str) -> Result<Self, McpSdkError> {
-        let client = Client::new();
+        let client = crate::auth::shared_http_client();
         let metadata = client
             .get(discovery_url)
             .send()


### PR DESCRIPTION
### 📌 Summary

OAuth discovery, metadata, and JWKS/introspection/userinfo fetches each constructed a new `reqwest::Client` per call, creating a fresh connection pool and TLS configuration every time. They now share one process-wide client, so requests reuse the connection pool — which matters during key-rotation events with many concurrent verifications.

### 🔍 Related Issues

- Related to #141

### ✨ Changes Made

- Add `auth::shared_http_client()` backed by a `LazyLock<reqwest::Client>`.
- Use it in discovery, metadata, and the remote auth provider.
- Use it for JWKS, introspection, and userinfo fetches in `GenericOauthTokenVerifier` (replacing per-call `Client::new()` / `reqwest::get`).

> Touches `generic_token_verifier.rs`; may need a trivial rebase if #148 lands first.