### PR TITLE
perf(http): extract POST body as Bytes

### DIFF
--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/streamable_http_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/streamable_http_routes.rs
@@ -1,5 +1,6 @@
 use crate::hyper_servers::error::TransportServerResult;
 use crate::mcp_http::{McpAppState, McpHttpHandler};
+use axum::body::Bytes;
 use axum::routing::get;
 use axum::Extension;
 use axum::{
@@ -8,7 +9,7 @@ use axum::{
     routing::{delete, post},
     Router,
 };
-use http::{HeaderMap, Method, Uri};
+use http::{HeaderMap, Method, StatusCode, Uri};
 use std::{collections::HashMap, sync::Arc};
 
 pub fn routes(streamable_http_endpoint: &str) -> Router<Arc<McpAppState>> {
@@ -40,10 +41,22 @@ pub async fn handle_streamable_http_post(
     State(state): State<Arc<McpAppState>>,
     Extension(http_handler): Extension<Arc<McpHttpHandler>>,
     Query(_params): Query<HashMap<String, String>>,
-    payload: String,
+    payload: Bytes,
 ) -> TransportServerResult<impl IntoResponse> {
-    let request =
-        McpHttpHandler::create_request(Method::POST, uri, headers, Some(payload.as_str()));
+    // Borrow the raw body as UTF-8 instead of extracting an owned `String`,
+    // avoiding an allocation and copy per request. JSON-RPC payloads are UTF-8;
+    // anything else is rejected up front.
+    let payload = match std::str::from_utf8(&payload) {
+        Ok(payload) => payload,
+        Err(_) => {
+            return Ok(axum::response::Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(axum::body::Body::from("Request body must be valid UTF-8"))
+                .expect("static 400 response is always valid"));
+        }
+    };
+
+    let request = McpHttpHandler::create_request(Method::POST, uri, headers, Some(payload));
     let generic_res = http_handler.handle_streamable_http(request, state).await?;
     let (parts, body) = generic_res.into_parts();
     let resp = axum::response::Response::from_parts(parts, axum::body::Body::new(body));


### PR DESCRIPTION
### 📌 Summary

The streamable-HTTP POST handler extracted the body as an owned `String`, allocating and copying on every request. It now extracts `Bytes` and borrows the body as UTF-8, avoiding the per-request allocation; non-UTF-8 bodies are rejected with `400`.

### 🔍 Related Issues

- Related to #141

### ✨ Changes Made

- Replace the `String` extractor with `Bytes` in `handle_streamable_http_post`.
- Borrow the bytes as `&str` (zero-copy) and reject invalid UTF-8 with `400`.