### PR TITLE
fix: update getting started document

### DIFF
--- a/crates/rust-mcp-extra/src/token_verifier/generic_token_verifier.rs
+++ b/crates/rust-mcp-extra/src/token_verifier/generic_token_verifier.rs
@@ -915,9 +915,7 @@ mod tests {
     async fn test_with_allowed_algorithms_rejects_restricted_allowlist() {
         let server = OAuthTestServer::start().await;
         let client = server
-            .register_client(
-                json!({ "scope": "openid", "redirect_uris": ["http://localhost"] }),
-            )
+            .register_client(json!({ "scope": "openid", "redirect_uris": ["http://localhost"] }))
             .await;
 
         let verifier = token_verifier(
@@ -930,8 +928,7 @@ mod tests {
         .await
         .with_allowed_algorithms(vec![Algorithm::ES256]);
 
-        let token = server
-            .generate_jwt(&client, server.jwt_options().user_id("hal").build());
+        let token = server.generate_jwt(&client, server.jwt_options().user_id("hal").build());
 
         let err = verifier.verify_token(token).await.unwrap_err();
         assert!(matches!(

--- a/doc/getting-started-mcp-server.md
+++ b/doc/getting-started-mcp-server.md
@@ -268,6 +268,7 @@ async fn main() -> SdkResult<()> {
         handler: handler.to_mcp_server_handler(),
         task_store: None,
         client_task_store: None,
+        message_observer: None,        
     });
 
     // Start the server


### PR DESCRIPTION
### 📌 Summary

Adds the missing `message_observer: None` field to the server builder example in the getting-started guide.

### 🔍 Related Issues

- Fixes #161

### ✨ Changes Made

- Added `message_observer: None` to the server setup example in `doc/getting-started-mcp-server.md`

### 🛠️ Testing Steps

1. Review the diff at `doc/getting-started-mcp-server.md`

### 💡 Additional Notes

N/A