### PR TITLE
fix(http): auto-derive DNS rebinding allowed_hosts from bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ server.start().await?;
 
 When using Streamable HTTP transport, following security best practices are recommended:
 
-- Enable DNS rebinding protection and provide proper `allowed_hosts` and `allowed_origins` to prevent DNS rebinding attacks.
+- DNS rebinding protection is enabled by default. If `allowed_hosts` is not set, it auto-derives from `host:port` (e.g. `127.0.0.1:8080`). For wildcard binds (`0.0.0.0`, `::`), explicitly configure `allowed_hosts`.
 - When running locally, bind only to localhost (127.0.0.1 / localhost) rather than all network interfaces (0.0.0.0)
 - Use TLS/HTTPS for production deployments
 

--- a/crates/rust-mcp-actix/src/options.rs
+++ b/crates/rust-mcp-actix/src/options.rs
@@ -1,6 +1,7 @@
 use rust_mcp_sdk::auth::AuthProvider;
 use rust_mcp_sdk::event_store::EventStore;
 use rust_mcp_sdk::id_generator::IdGenerator;
+use rust_mcp_sdk::mcp_http::DnsRebindingOptions;
 use rust_mcp_sdk::mcp_http::HealthHandler;
 use rust_mcp_sdk::mcp_http::McpMountOptions;
 use rust_mcp_sdk::mcp_http::{
@@ -59,6 +60,12 @@ pub struct ActixServerOptions {
     pub message_observer: Option<Arc<dyn McpObserver<ClientMessage, ServerMessage>>>,
     /// Maximum request body size in bytes. Defaults to 4 MiB when None.
     pub max_request_body_size: Option<usize>,
+    /// DNS rebinding protection configuration (enabled by default).
+    ///
+    /// When `dns_rebinding_protection` is `true` and no `allowed_hosts` or
+    /// `allowed_origins` are configured, `allowed_hosts` is auto-derived from
+    /// `host:port` unless the bind address is a wildcard.
+    pub dns_rebinding: DnsRebindingOptions,
     /// Enable TLS/SSL (requires `ssl` feature, default: false)
     pub enable_ssl: bool,
     /// Path to TLS certificate PEM file
@@ -180,6 +187,7 @@ impl Default for ActixServerOptions {
             health_handler: None,
             message_observer: None,
             max_request_body_size: None,
+            dns_rebinding: DnsRebindingOptions::default(),
             enable_ssl: false,
             ssl_cert_path: None,
             ssl_key_path: None,

--- a/crates/rust-mcp-actix/src/server.rs
+++ b/crates/rust-mcp-actix/src/server.rs
@@ -1,7 +1,7 @@
 use crate::options::ActixServerOptions;
 use crate::ActixRuntime;
 use rust_mcp_sdk::mcp_http::middleware::AuthMiddleware;
-use rust_mcp_sdk::mcp_http::Middleware;
+use rust_mcp_sdk::mcp_http::{resolve_dns_middleware, Middleware};
 use rust_mcp_sdk::{
     error::SdkResult,
     id_generator::{FastIdGenerator, UuidGenerator},
@@ -49,6 +49,15 @@ impl ActixServer {
         });
 
         let mut middlewares: Vec<Arc<dyn Middleware>> = vec![];
+
+        if let Some(dns) = resolve_dns_middleware(
+            &mut server_options.dns_rebinding,
+            &server_options.host,
+            server_options.port,
+        ) {
+            middlewares.push(Arc::new(dns));
+        }
+
         if let Some(auth_provider) = server_options.auth.take() {
             middlewares.push(Arc::new(AuthMiddleware::new(auth_provider)));
         }

--- a/crates/rust-mcp-axum/src/server.rs
+++ b/crates/rust-mcp-axum/src/server.rs
@@ -136,16 +136,18 @@ pub struct AxumServerOptions {
     pub ssl_key_path: Option<String>,
 
     /// List of allowed host header values for DNS rebinding protection.
-    /// If not specified, host validation is disabled.
+    /// If not specified and `dns_rebinding_protection` is true, auto-derives
+    /// from `host:port` unless the host is a wildcard (`0.0.0.0`, `::`).
     pub allowed_hosts: Option<Vec<String>>,
 
     /// List of allowed origin header values for DNS rebinding protection.
     /// If not specified, origin validation is disabled.
     pub allowed_origins: Option<Vec<String>>,
 
-    /// Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
-    /// Default is `true`; a startup warning is logged if neither `allowed_hosts`
-    /// nor `allowed_origins` is set. Set to `false` to opt out.
+    /// Enable DNS rebinding protection. Default is `true`.
+    /// When neither `allowed_hosts` nor `allowed_origins` is configured,
+    /// `allowed_hosts` is auto-derived from `host:port` unless the bind
+    /// address is a wildcard (`0.0.0.0`, `::`). Set to `false` to opt out.
     pub dns_rebinding_protection: bool,
 
     /// If set to true, the SSE transport will also be supported for backward compatibility (default: true)
@@ -288,9 +290,36 @@ impl AxumServerOptions {
             .unwrap_or(rust_mcp_sdk::mcp_http::DEFAULT_MAX_REQUEST_BODY_SIZE)
     }
 
-    pub fn needs_dns_protection(&self) -> bool {
-        self.dns_rebinding_protection
-            && (self.allowed_hosts.is_some() || self.allowed_origins.is_some())
+    /// Resolves `allowed_hosts`, auto-deriving from `host:port` when unset.
+    ///
+    /// When `dns_rebinding_protection` is enabled and `allowed_hosts` is `None`:
+    /// - If the host is a wildcard (`0.0.0.0`, `::`, or empty), a warning is
+    ///   logged and `None` is returned (no enforcement).
+    /// - Otherwise, the host is auto-derived as `"host:port"` and logged at
+    ///   `debug` level.
+    fn resolve_allowed_hosts(&mut self) -> Option<Vec<String>> {
+        if !self.dns_rebinding_protection {
+            return None;
+        }
+        if let Some(hosts) = self.allowed_hosts.take() {
+            return Some(hosts);
+        }
+        let is_wildcard = self.host.is_empty() || self.host == "0.0.0.0" || self.host == "::";
+        if is_wildcard {
+            tracing::warn!(
+                "DNS-rebinding protection is enabled but host is a wildcard ({}) \
+                 and neither `allowed_hosts` nor `allowed_origins` is configured. \
+                 Set `allowed_hosts` explicitly, or set `dns_rebinding_protection = false`.",
+                self.host
+            );
+            return None;
+        }
+        let host = format!("{}:{}", self.host, self.port);
+        tracing::debug!(
+            "DNS-rebinding protection: auto-derived allowed_hosts=[\"{host}\"] \
+             from host config"
+        );
+        Some(vec![host])
     }
 
     /// Resolves the mount options from this server configuration.
@@ -388,23 +417,17 @@ impl AxumServer {
 
         // populate middlewares
         let mut middlewares: Vec<Arc<dyn Middleware>> = vec![];
-        if server_options.dns_rebinding_protection
-            && server_options.allowed_hosts.is_none()
-            && server_options.allowed_origins.is_none()
-        {
-            tracing::warn!(
-                "DNS-rebinding protection is enabled but neither `allowed_hosts` nor \
-                 `allowed_origins` is configured, so Host/Origin validation is not enforced. \
-                 Set `allowed_hosts`/`allowed_origins`, or set `dns_rebinding_protection = false` \
-                 to silence this warning."
-            );
-        }
-        if server_options.needs_dns_protection() {
-            //dns pritection middleware
-            middlewares.push(Arc::new(DnsRebindProtector::new(
-                server_options.allowed_hosts.take(),
-                server_options.allowed_origins.take(),
-            )));
+
+        if server_options.dns_rebinding_protection {
+            let allowed_hosts = server_options.resolve_allowed_hosts();
+            let allowed_origins = server_options.allowed_origins.take();
+
+            if allowed_hosts.is_some() || allowed_origins.is_some() {
+                middlewares.push(Arc::new(DnsRebindProtector::new(
+                    allowed_hosts,
+                    allowed_origins,
+                )));
+            }
         }
 
         let http_handler = {
@@ -685,34 +708,116 @@ mod tests {
     }
 
     #[test]
-    fn test_server_options_needs_dns_protection() {
-        let options = AxumServerOptions::default();
+    fn test_resolve_allowed_hosts_explicit() {
+        let mut options = AxumServerOptions {
+            allowed_hosts: Some(vec!["example.com".into()]),
+            ..Default::default()
+        };
+        assert_eq!(
+            options.resolve_allowed_hosts(),
+            Some(vec!["example.com".into()])
+        );
+    }
 
-        // should be false by default
-        assert!(!options.needs_dns_protection());
-
-        // should still be false unless allowed_hosts or allowed_origins are also provided
-        let options = AxumServerOptions {
+    #[test]
+    fn test_resolve_allowed_hosts_auto_derive() {
+        let mut options = AxumServerOptions {
+            host: "api.example.com".into(),
+            port: 443,
             dns_rebinding_protection: true,
             ..Default::default()
         };
-        assert!(!options.needs_dns_protection());
+        assert_eq!(
+            options.resolve_allowed_hosts(),
+            Some(vec!["api.example.com:443".into()])
+        );
+    }
 
-        // should be true when dns_rebinding_protection is true and allowed_hosts is provided
-        let options = AxumServerOptions {
+    #[test]
+    fn test_resolve_allowed_hosts_localhost_auto_derive() {
+        let mut options = AxumServerOptions::default();
+        assert_eq!(
+            options.resolve_allowed_hosts(),
+            Some(vec!["127.0.0.1:8080".into()])
+        );
+    }
+
+    #[test]
+    fn test_resolve_allowed_hosts_wildcard_v4_returns_none() {
+        let mut options = AxumServerOptions {
+            host: "0.0.0.0".into(),
             dns_rebinding_protection: true,
-            allowed_hosts: Some(vec![String::from("127.0.0.1")]),
             ..Default::default()
         };
-        assert!(options.needs_dns_protection());
+        assert_eq!(options.resolve_allowed_hosts(), None);
+    }
 
-        // should be true when dns_rebinding_protection is true and allowed_origins is provided
-        let options = AxumServerOptions {
+    #[test]
+    fn test_resolve_allowed_hosts_wildcard_v6_returns_none() {
+        let mut options = AxumServerOptions {
+            host: "::".into(),
+            port: 8080,
             dns_rebinding_protection: true,
-            allowed_origins: Some(vec![String::from("http://127.0.0.1:8080")]),
             ..Default::default()
         };
-        assert!(options.needs_dns_protection());
+        assert_eq!(options.resolve_allowed_hosts(), None);
+    }
+
+    #[test]
+    fn test_resolve_allowed_hosts_empty_host_returns_none() {
+        let mut options = AxumServerOptions {
+            host: String::new(),
+            dns_rebinding_protection: true,
+            ..Default::default()
+        };
+        assert_eq!(options.resolve_allowed_hosts(), None);
+    }
+
+    #[test]
+    fn test_resolve_allowed_hosts_ipv6_loopback_auto_derives() {
+        let mut options = AxumServerOptions {
+            host: "::1".into(),
+            port: 3000,
+            dns_rebinding_protection: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            options.resolve_allowed_hosts(),
+            Some(vec!["::1:3000".into()])
+        );
+    }
+
+    #[test]
+    fn test_resolve_allowed_hosts_auto_derive_respects_custom_port() {
+        let mut options = AxumServerOptions {
+            host: "127.0.0.1".into(),
+            port: 9090,
+            dns_rebinding_protection: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            options.resolve_allowed_hosts(),
+            Some(vec!["127.0.0.1:9090".into()])
+        );
+    }
+
+    #[test]
+    fn test_resolve_allowed_hosts_disabled_ignores_explicit_lists() {
+        let mut options = AxumServerOptions {
+            allowed_hosts: Some(vec!["example.com".into()]),
+            dns_rebinding_protection: false,
+            ..Default::default()
+        };
+        assert_eq!(options.resolve_allowed_hosts(), None);
+    }
+
+    #[test]
+    fn test_resolve_allowed_hosts_disabled_returns_none() {
+        let mut options = AxumServerOptions {
+            dns_rebinding_protection: false,
+            ..Default::default()
+        };
+        assert_eq!(options.resolve_allowed_hosts(), None);
     }
 
     #[test]

--- a/crates/rust-mcp-axum/src/server.rs
+++ b/crates/rust-mcp-axum/src/server.rs
@@ -13,7 +13,9 @@ use rust_mcp_sdk::schema::schema_utils::{ClientMessage, ServerMessage};
 use rust_mcp_sdk::{
     error::SdkResult,
     id_generator::{FastIdGenerator, UuidGenerator},
-    mcp_http::{middleware::DnsRebindProtector, HealthHandler, McpAppState, McpHttpHandler},
+    mcp_http::{
+        resolve_dns_middleware, DnsRebindingOptions, HealthHandler, McpAppState, McpHttpHandler,
+    },
     session_store::InMemorySessionStore,
     task_store::{ClientTaskStore, ServerTaskStore},
     IdGenerator, McpObserver, McpServerHandler,
@@ -135,20 +137,12 @@ pub struct AxumServerOptions {
     /// Required if `enable_ssl` is `true`.
     pub ssl_key_path: Option<String>,
 
-    /// List of allowed host header values for DNS rebinding protection.
-    /// If not specified and `dns_rebinding_protection` is true, auto-derives
-    /// from `host:port` unless the host is a wildcard (`0.0.0.0`, `::`).
-    pub allowed_hosts: Option<Vec<String>>,
-
-    /// List of allowed origin header values for DNS rebinding protection.
-    /// If not specified, origin validation is disabled.
-    pub allowed_origins: Option<Vec<String>>,
-
-    /// Enable DNS rebinding protection. Default is `true`.
-    /// When neither `allowed_hosts` nor `allowed_origins` is configured,
-    /// `allowed_hosts` is auto-derived from `host:port` unless the bind
-    /// address is a wildcard (`0.0.0.0`, `::`). Set to `false` to opt out.
-    pub dns_rebinding_protection: bool,
+    /// DNS rebinding protection configuration (enabled by default).
+    ///
+    /// When `dns_rebinding_protection` is `true` and no `allowed_hosts` or
+    /// `allowed_origins` are configured, `allowed_hosts` is auto-derived from
+    /// `host:port` unless the bind address is a wildcard.
+    pub dns_rebinding: DnsRebindingOptions,
 
     /// If set to true, the SSE transport will also be supported for backward compatibility (default: true)
     pub sse_support: bool,
@@ -290,38 +284,6 @@ impl AxumServerOptions {
             .unwrap_or(rust_mcp_sdk::mcp_http::DEFAULT_MAX_REQUEST_BODY_SIZE)
     }
 
-    /// Resolves `allowed_hosts`, auto-deriving from `host:port` when unset.
-    ///
-    /// When `dns_rebinding_protection` is enabled and `allowed_hosts` is `None`:
-    /// - If the host is a wildcard (`0.0.0.0`, `::`, or empty), a warning is
-    ///   logged and `None` is returned (no enforcement).
-    /// - Otherwise, the host is auto-derived as `"host:port"` and logged at
-    ///   `debug` level.
-    fn resolve_allowed_hosts(&mut self) -> Option<Vec<String>> {
-        if !self.dns_rebinding_protection {
-            return None;
-        }
-        if let Some(hosts) = self.allowed_hosts.take() {
-            return Some(hosts);
-        }
-        let is_wildcard = self.host.is_empty() || self.host == "0.0.0.0" || self.host == "::";
-        if is_wildcard {
-            tracing::warn!(
-                "DNS-rebinding protection is enabled but host is a wildcard ({}) \
-                 and neither `allowed_hosts` nor `allowed_origins` is configured. \
-                 Set `allowed_hosts` explicitly, or set `dns_rebinding_protection = false`.",
-                self.host
-            );
-            return None;
-        }
-        let host = format!("{}:{}", self.host, self.port);
-        tracing::debug!(
-            "DNS-rebinding protection: auto-derived allowed_hosts=[\"{host}\"] \
-             from host config"
-        );
-        Some(vec![host])
-    }
-
     /// Resolves the mount options from this server configuration.
     ///
     /// Prepares [`McpMountOptions`] by resolving custom endpoints to their
@@ -358,9 +320,7 @@ impl Default for AxumServerOptions {
             session_id_generator: None,
             enable_json_response: None,
             sse_support: true,
-            allowed_hosts: None,
-            allowed_origins: None,
-            dns_rebinding_protection: true,
+            dns_rebinding: DnsRebindingOptions::default(),
             event_store: None,
             auth: None,
             task_store: None,
@@ -418,16 +378,12 @@ impl AxumServer {
         // populate middlewares
         let mut middlewares: Vec<Arc<dyn Middleware>> = vec![];
 
-        if server_options.dns_rebinding_protection {
-            let allowed_hosts = server_options.resolve_allowed_hosts();
-            let allowed_origins = server_options.allowed_origins.take();
-
-            if allowed_hosts.is_some() || allowed_origins.is_some() {
-                middlewares.push(Arc::new(DnsRebindProtector::new(
-                    allowed_hosts,
-                    allowed_origins,
-                )));
-            }
+        if let Some(dns) = resolve_dns_middleware(
+            &mut server_options.dns_rebinding,
+            &server_options.host,
+            server_options.port,
+        ) {
+            middlewares.push(Arc::new(dns));
         }
 
         let http_handler = {
@@ -705,119 +661,6 @@ mod tests {
             "http://127.0.0.1:8080/abcd/messages"
         );
         assert_eq!(options.sse_messages_endpoint(), "/abcd/messages");
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_explicit() {
-        let mut options = AxumServerOptions {
-            allowed_hosts: Some(vec!["example.com".into()]),
-            ..Default::default()
-        };
-        assert_eq!(
-            options.resolve_allowed_hosts(),
-            Some(vec!["example.com".into()])
-        );
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_auto_derive() {
-        let mut options = AxumServerOptions {
-            host: "api.example.com".into(),
-            port: 443,
-            dns_rebinding_protection: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            options.resolve_allowed_hosts(),
-            Some(vec!["api.example.com:443".into()])
-        );
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_localhost_auto_derive() {
-        let mut options = AxumServerOptions::default();
-        assert_eq!(
-            options.resolve_allowed_hosts(),
-            Some(vec!["127.0.0.1:8080".into()])
-        );
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_wildcard_v4_returns_none() {
-        let mut options = AxumServerOptions {
-            host: "0.0.0.0".into(),
-            dns_rebinding_protection: true,
-            ..Default::default()
-        };
-        assert_eq!(options.resolve_allowed_hosts(), None);
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_wildcard_v6_returns_none() {
-        let mut options = AxumServerOptions {
-            host: "::".into(),
-            port: 8080,
-            dns_rebinding_protection: true,
-            ..Default::default()
-        };
-        assert_eq!(options.resolve_allowed_hosts(), None);
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_empty_host_returns_none() {
-        let mut options = AxumServerOptions {
-            host: String::new(),
-            dns_rebinding_protection: true,
-            ..Default::default()
-        };
-        assert_eq!(options.resolve_allowed_hosts(), None);
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_ipv6_loopback_auto_derives() {
-        let mut options = AxumServerOptions {
-            host: "::1".into(),
-            port: 3000,
-            dns_rebinding_protection: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            options.resolve_allowed_hosts(),
-            Some(vec!["::1:3000".into()])
-        );
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_auto_derive_respects_custom_port() {
-        let mut options = AxumServerOptions {
-            host: "127.0.0.1".into(),
-            port: 9090,
-            dns_rebinding_protection: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            options.resolve_allowed_hosts(),
-            Some(vec!["127.0.0.1:9090".into()])
-        );
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_disabled_ignores_explicit_lists() {
-        let mut options = AxumServerOptions {
-            allowed_hosts: Some(vec!["example.com".into()]),
-            dns_rebinding_protection: false,
-            ..Default::default()
-        };
-        assert_eq!(options.resolve_allowed_hosts(), None);
-    }
-
-    #[test]
-    fn test_resolve_allowed_hosts_disabled_returns_none() {
-        let mut options = AxumServerOptions {
-            dns_rebinding_protection: false,
-            ..Default::default()
-        };
-        assert_eq!(options.resolve_allowed_hosts(), None);
     }
 
     #[test]

--- a/crates/rust-mcp-axum/tests/integration_tests.rs
+++ b/crates/rust-mcp-axum/tests/integration_tests.rs
@@ -446,41 +446,6 @@ fn test_axum_server_options_base_url_ssl() {
 }
 
 #[test]
-fn test_axum_server_options_needs_dns_protection_disabled_by_default() {
-    let options = AxumServerOptions::default();
-    assert!(!options.needs_dns_protection());
-}
-
-#[test]
-fn test_axum_server_options_needs_dns_protection_enabled_with_hosts() {
-    let options = AxumServerOptions {
-        dns_rebinding_protection: true,
-        allowed_hosts: Some(vec!["127.0.0.1".into()]),
-        ..AxumServerOptions::default()
-    };
-    assert!(options.needs_dns_protection());
-}
-
-#[test]
-fn test_axum_server_options_needs_dns_protection_enabled_with_origins() {
-    let options = AxumServerOptions {
-        dns_rebinding_protection: true,
-        allowed_origins: Some(vec!["http://localhost".into()]),
-        ..AxumServerOptions::default()
-    };
-    assert!(options.needs_dns_protection());
-}
-
-#[test]
-fn test_axum_server_options_dns_protection_requires_hosts_or_origins() {
-    let options = AxumServerOptions {
-        dns_rebinding_protection: true,
-        ..AxumServerOptions::default()
-    };
-    assert!(!options.needs_dns_protection());
-}
-
-#[test]
 fn test_axum_server_options_sse_url_methods() {
     let options = AxumServerOptions {
         host: "127.0.0.1".into(),

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -476,7 +476,7 @@ server.start().await?;
 
 When using Streamable HTTP transport, following security best practices are recommended:
 
-- Enable DNS rebinding protection and provide proper `allowed_hosts` and `allowed_origins` to prevent DNS rebinding attacks.
+- DNS rebinding protection is enabled by default. If `allowed_hosts` is not set, it auto-derives from `host:port` (e.g. `127.0.0.1:8080`). For wildcard binds (`0.0.0.0`, `::`), explicitly configure `allowed_hosts`.
 - When running locally, bind only to localhost (127.0.0.1 / localhost) rather than all network interfaces (0.0.0.0)
 - Use TLS/HTTPS for production deployments
 

--- a/crates/rust-mcp-sdk/src/hyper_servers/server.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/server.rs
@@ -117,7 +117,8 @@ pub struct HyperServerOptions {
     pub allowed_origins: Option<Vec<String>>,
 
     /// Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
-    /// Default is false for backwards compatibility.
+    /// Default is `true`; a startup warning is logged if neither `allowed_hosts`
+    /// nor `allowed_origins` is set. Set to `false` to opt out.
     pub dns_rebinding_protection: bool,
 
     /// If set to true, the SSE transport will also be supported for backward compatibility (default: true)
@@ -282,7 +283,7 @@ impl Default for HyperServerOptions {
             sse_support: true,
             allowed_hosts: None,
             allowed_origins: None,
-            dns_rebinding_protection: false,
+            dns_rebinding_protection: true,
             event_store: None,
             #[cfg(feature = "auth")]
             auth: None,
@@ -340,6 +341,17 @@ impl HyperServer {
 
         // populate middlewares
         let mut middlewares: Vec<Arc<dyn Middleware>> = vec![];
+        if server_options.dns_rebinding_protection
+            && server_options.allowed_hosts.is_none()
+            && server_options.allowed_origins.is_none()
+        {
+            tracing::warn!(
+                "DNS-rebinding protection is enabled but neither `allowed_hosts` nor \
+                 `allowed_origins` is configured, so Host/Origin validation is not enforced. \
+                 Set `allowed_hosts`/`allowed_origins`, or set `dns_rebinding_protection = false` \
+                 to silence this warning."
+            );
+        }
         if server_options.needs_dns_protection() {
             //dns pritection middleware
             middlewares.push(Arc::new(DnsRebindProtector::new(

--- a/crates/rust-mcp-sdk/src/mcp_http.rs
+++ b/crates/rust-mcp-sdk/src/mcp_http.rs
@@ -8,6 +8,8 @@ pub mod mount;
 pub mod middleware;
 mod types;
 
+mod dns_rebinding;
+
 pub use app_state::*;
 pub use error::*;
 pub use http_utils::*;
@@ -16,6 +18,7 @@ pub use mount::*;
 
 pub use types::*;
 
+pub use dns_rebinding::*;
 pub use health_handler::*;
 pub use http;
 pub use middleware::Middleware;

--- a/crates/rust-mcp-sdk/src/mcp_http/dns_rebinding.rs
+++ b/crates/rust-mcp-sdk/src/mcp_http/dns_rebinding.rs
@@ -1,0 +1,186 @@
+use super::middleware::DnsRebindProtector;
+
+/// Shared DNS rebinding protection configuration for all HTTP framework
+/// integrations.
+///
+/// Include this in every framework's server options struct. At startup,
+/// call [`resolve_dns_middleware`] to optionally install the protection
+/// middleware.
+///
+/// # Per-framework adoption
+///
+/// ```ignore
+/// // 1. Add to options struct
+/// pub dns_rebinding: DnsRebindingOptions,
+///
+/// // 2. Default it
+/// dns_rebinding: DnsRebindingOptions::default(),
+///
+/// // 3. Install middleware in your server's new()
+/// if let Some(dns) = resolve_dns_middleware(
+///     &mut opts.dns_rebinding, &opts.host, opts.port,
+/// ) {
+///     middlewares.push(Arc::new(dns));
+/// }
+/// ```
+///
+/// # Default behavior
+///
+/// When `dns_rebinding_protection` is `true` and `allowed_hosts` is `None`,
+/// the host is auto-derived from `host:port` unless the bind address is a
+/// wildcard (`0.0.0.0`, `::`, or empty). Auto-derived hosts are logged at
+/// `debug` level.
+pub struct DnsRebindingOptions {
+    /// Enable DNS rebinding protection. Default is `true`.
+    pub dns_rebinding_protection: bool,
+    /// List of allowed host header values for DNS rebinding protection.
+    /// If not specified and `dns_rebinding_protection` is true, auto-derives
+    /// from `host:port` unless the host is a wildcard.
+    pub allowed_hosts: Option<Vec<String>>,
+    /// List of allowed origin header values for DNS rebinding protection.
+    /// If not specified, origin validation is disabled.
+    pub allowed_origins: Option<Vec<String>>,
+}
+
+impl Default for DnsRebindingOptions {
+    fn default() -> Self {
+        Self {
+            dns_rebinding_protection: true,
+            allowed_hosts: None,
+            allowed_origins: None,
+        }
+    }
+}
+
+fn is_wildcard(host: &str) -> bool {
+    host.is_empty() || host == "0.0.0.0" || host == "::"
+}
+
+/// Resolves DNS rebinding middleware from the given options.
+///
+/// Returns `Some(DnsRebindProtector)` if protection should be active, or
+/// `None` if protection is disabled or cannot be configured (wildcard host
+/// with no explicit lists). When `allowed_hosts` is `None` and protection
+/// is enabled, it auto-derives from `host:port` unless the host is a
+/// wildcard.
+pub fn resolve_dns_middleware(
+    opts: &mut DnsRebindingOptions,
+    host: &str,
+    port: u16,
+) -> Option<DnsRebindProtector> {
+    if !opts.dns_rebinding_protection {
+        return None;
+    }
+    let allowed_hosts = if let Some(hosts) = opts.allowed_hosts.take() {
+        Some(hosts)
+    } else if is_wildcard(host) {
+        tracing::warn!(
+            "DNS-rebinding protection is enabled but host is a wildcard ({host}) \
+             and neither `allowed_hosts` nor `allowed_origins` is configured. \
+             Set `allowed_hosts` explicitly, or set `dns_rebinding_protection = false`."
+        );
+        None
+    } else {
+        let host_port = format!("{host}:{port}");
+        tracing::debug!(
+            "DNS-rebinding protection: auto-derived allowed_hosts=[\"{host_port}\"] \
+             from host config"
+        );
+        Some(vec![host_port])
+    };
+    let allowed_origins = opts.allowed_origins.take();
+    if allowed_hosts.is_some() || allowed_origins.is_some() {
+        Some(DnsRebindProtector::new(allowed_hosts, allowed_origins))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_explicit_allowed_hosts() {
+        let mut opts = DnsRebindingOptions {
+            allowed_hosts: Some(vec!["example.com".into()]),
+            ..Default::default()
+        };
+        let middleware = resolve_dns_middleware(&mut opts, "127.0.0.1", 8080).unwrap();
+        assert_eq!(middleware.allowed_hosts, Some(vec!["example.com".into()]));
+    }
+
+    #[test]
+    fn test_auto_derive_from_domain() {
+        let mut opts = DnsRebindingOptions::default();
+        let middleware = resolve_dns_middleware(&mut opts, "api.example.com", 443).unwrap();
+        assert_eq!(
+            middleware.allowed_hosts,
+            Some(vec!["api.example.com:443".into()])
+        );
+    }
+
+    #[test]
+    fn test_auto_derive_from_localhost_default() {
+        let mut opts = DnsRebindingOptions::default();
+        let middleware = resolve_dns_middleware(&mut opts, "127.0.0.1", 8080).unwrap();
+        assert_eq!(
+            middleware.allowed_hosts,
+            Some(vec!["127.0.0.1:8080".into()])
+        );
+    }
+
+    #[test]
+    fn test_wildcard_v4_returns_none() {
+        let mut opts = DnsRebindingOptions::default();
+        assert!(resolve_dns_middleware(&mut opts, "0.0.0.0", 8080).is_none());
+    }
+
+    #[test]
+    fn test_wildcard_v6_returns_none() {
+        let mut opts = DnsRebindingOptions::default();
+        assert!(resolve_dns_middleware(&mut opts, "::", 8080).is_none());
+    }
+
+    #[test]
+    fn test_empty_host_returns_none() {
+        let mut opts = DnsRebindingOptions::default();
+        assert!(resolve_dns_middleware(&mut opts, "", 8080).is_none());
+    }
+
+    #[test]
+    fn test_ipv6_loopback_auto_derives() {
+        let mut opts = DnsRebindingOptions::default();
+        let middleware = resolve_dns_middleware(&mut opts, "::1", 3000).unwrap();
+        assert_eq!(middleware.allowed_hosts, Some(vec!["::1:3000".into()]));
+    }
+
+    #[test]
+    fn test_auto_derive_respects_custom_port() {
+        let mut opts = DnsRebindingOptions::default();
+        let middleware = resolve_dns_middleware(&mut opts, "127.0.0.1", 9090).unwrap();
+        assert_eq!(
+            middleware.allowed_hosts,
+            Some(vec!["127.0.0.1:9090".into()])
+        );
+    }
+
+    #[test]
+    fn test_disabled_returns_none() {
+        let mut opts = DnsRebindingOptions {
+            dns_rebinding_protection: false,
+            ..Default::default()
+        };
+        assert!(resolve_dns_middleware(&mut opts, "127.0.0.1", 8080).is_none());
+    }
+
+    #[test]
+    fn test_disabled_ignores_explicit_lists() {
+        let mut opts = DnsRebindingOptions {
+            allowed_hosts: Some(vec!["example.com".into()]),
+            dns_rebinding_protection: false,
+            ..Default::default()
+        };
+        assert!(resolve_dns_middleware(&mut opts, "127.0.0.1", 8080).is_none());
+    }
+}

--- a/crates/rust-mcp-sdk/src/mcp_http/middleware/dns_rebind_protector.rs
+++ b/crates/rust-mcp-sdk/src/mcp_http/middleware/dns_rebind_protector.rs
@@ -43,7 +43,9 @@ use std::sync::Arc;
 /// # Security Considerations
 /// - Always pin exact hostnames (e.g., `app.example.com:8443`)
 /// - Avoid wildcards or overly broad patterns
-/// - For local development, include `localhost:PORT` explicitly
+/// - For local development, the host is auto-derived from the bind address
+///   by default. When binding to a wildcard (`0.0.0.0`), configure
+///   `allowed_hosts` explicitly.
 /// - Never allow raw IP addresses in production allowlists
 pub struct DnsRebindProtector {
     /// List of allowed host header values for DNS rebinding protection.

--- a/crates/rust-mcp-sdk/tests/test_streamable_http_server.rs
+++ b/crates/rust-mcp-sdk/tests/test_streamable_http_server.rs
@@ -20,6 +20,7 @@ use rust_mcp_schema::{
     CallToolRequestParams, ElicitResult, ElicitResultContent, ListRootsResult, LoggingLevel,
     LoggingMessageNotificationParams, RequestId, ServerRequest,
 };
+use rust_mcp_sdk::mcp_http::DnsRebindingOptions;
 use rust_mcp_sdk::{
     auth::{AuthInfo, AuthMetadataBuilder, AuthProvider, RemoteAuthProvider},
     event_store::InMemoryEventStore,
@@ -1228,8 +1229,10 @@ async fn should_accept_requests_with_allowed_host_headers() {
         session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
             "AAA-BBB-CCC".to_string()
         ]))),
-        allowed_hosts: Some(vec!["127.0.0.1:9090".to_string()]),
-        dns_rebinding_protection: true,
+        dns_rebinding: DnsRebindingOptions {
+            allowed_hosts: Some(vec!["127.0.0.1:9090".to_string()]),
+            ..Default::default()
+        },
         ..Default::default()
     };
 
@@ -1267,8 +1270,10 @@ async fn should_reject_requests_with_disallowed_host_headers() {
         session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
             "AAA-BBB-CCC".to_string()
         ]))),
-        allowed_hosts: Some(vec!["example.com:3001".to_string()]),
-        dns_rebinding_protection: true,
+        dns_rebinding: DnsRebindingOptions {
+            allowed_hosts: Some(vec!["example.com:3001".to_string()]),
+            ..Default::default()
+        },
         ..Default::default()
     };
 
@@ -1300,8 +1305,10 @@ async fn should_reject_get_requests_with_disallowed_host_headers() {
         session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
             "AAA-BBB-CCC".to_string()
         ]))),
-        allowed_hosts: Some(vec!["example.com:3001".to_string()]),
-        dns_rebinding_protection: true,
+        dns_rebinding: DnsRebindingOptions {
+            allowed_hosts: Some(vec!["example.com:3001".to_string()]),
+            ..Default::default()
+        },
         ..Default::default()
     };
 
@@ -1336,11 +1343,13 @@ async fn should_accept_requests_with_allowed_origin_headers() {
         session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
             "AAA-BBB-CCC".to_string()
         ]))),
-        allowed_origins: Some(vec![
-            "http://localhost:3000".to_string(),
-            "https://example.com".to_string(),
-        ]),
-        dns_rebinding_protection: true,
+        dns_rebinding: DnsRebindingOptions {
+            allowed_origins: Some(vec![
+                "http://localhost:3000".to_string(),
+                "https://example.com".to_string(),
+            ]),
+            ..Default::default()
+        },
         ..Default::default()
     };
 
@@ -1386,8 +1395,10 @@ async fn should_reject_requests_with_disallowed_origin_headers() {
         session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
             "AAA-BBB-CCC".to_string()
         ]))),
-        allowed_origins: Some(vec!["http://localhost:3000".to_string()]),
-        dns_rebinding_protection: true,
+        dns_rebinding: DnsRebindingOptions {
+            allowed_origins: Some(vec!["http://localhost:3000".to_string()]),
+            ..Default::default()
+        },
         ..Default::default()
     };
 
@@ -1430,9 +1441,11 @@ async fn should_skip_all_validations_when_false() {
         session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
             "AAA-BBB-CCC".to_string()
         ]))),
-        allowed_hosts: Some(vec!["localhost".to_string()]),
-        allowed_origins: Some(vec!["http://localhost:3030".to_string()]),
-        dns_rebinding_protection: false,
+        dns_rebinding: DnsRebindingOptions {
+            allowed_hosts: Some(vec!["localhost".to_string()]),
+            allowed_origins: Some(vec!["http://localhost:3030".to_string()]),
+            dns_rebinding_protection: false,
+        },
         ..Default::default()
     };
 


### PR DESCRIPTION
### 📌 Summary
DNS-rebinding protection in the original PR #153 defaulted to true but only logged a warning — no actual protection was applied when no allowed lists were configured. This change auto-derives allowed_hosts from host:port when dns_rebinding_protection is enabled and the bind address is not a wildcard. The logic is centralized in a shared DnsRebindingOptions struct + resolve_dns_middleware free function in the core SDK, eliminating duplication across framework crates.

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #141 , #153 


### ✨ Changes Made
- New DnsRebindingOptions shared struct (dns_rebinding_protection, allowed_hosts, allowed_origins) in rust-mcp-sdk/src/mcp_http/dns_rebinding.rs
- New resolve_dns_middleware() free function — auto-derives allowed_hosts from host:port when unset and host is not a wildcard, logs debug! on auto-derive, warn! on wildcard
- Axum — replaced 3 individual fields + resolve_allowed_hosts method with 1 dns_rebinding: DnsRebindingOptions field; middleware block reduced from 12 lines to 4
- Actix — added dns_rebinding: DnsRebindingOptions field to ActixServerOptions; same 4-line middleware install in ActixServer::new()
- 10 unit tests in core SDK covering: explicit lists, auto-derive (domain, localhost, IPv6 loopback, custom port), wildcards (IPv4, IPv6, empty), disabled flag, disabled with explicit lists
- Updated dns_rebind_protector.rs docs to mention auto-derive
- README security sections updated to describe auto-derive behavior

### 🛠️ Testing Steps
<!-- Explain how reviewers can test your changes, if applicable -->
```
cargo test -p rust-mcp-sdk --lib -- dns
cargo test -p rust-mcp-axum --lib
cargo test -p rust-mcp-actix --lib
cargo nextest run -p rust-mcp-sdk -p rust-mcp-axum -p rust-mcp-actix -p rust-mcp-transport
cargo clippy -p rust-mcp-sdk -p rust-mcp-axum -p rust-mcp-actix
```

### 💡 Additional Notes

Per-framework adoption (for future frameworks):

```rs
// 1. Add to options struct
pub dns_rebinding: DnsRebindingOptions,
// 2. Default it
dns_rebinding: DnsRebindingOptions::default(),
// 3. Install middleware
if let Some(dns) = resolve_dns_middleware(
    &mut opts.dns_rebinding, &opts.host, opts.port,
) {
    middlewares.push(Arc::new(dns));
}

```
Opt out: 
```
AxumServerOptions { dns_rebinding: DnsRebindingOptions { dns_rebinding_protection: false, ..Default::default() }, ..Default::default() }

```