### PR TITLE
perf: extract POST body as Bytes

### DIFF
--- a/crates/rust-mcp-actix/src/routes/streamable_http.rs
+++ b/crates/rust-mcp-actix/src/routes/streamable_http.rs
@@ -21,9 +21,15 @@ pub async fn handle_streamable_http_post(
     req: HttpRequest,
     state: web::Data<Arc<McpAppState>>,
     handler: web::Data<McpHttpHandler>,
-    payload: String,
+    payload: web::Bytes,
 ) -> HttpResponse {
-    let request = crate::bridge::from_actix_request(&req, Some(&payload));
+    let payload = match std::str::from_utf8(&payload) {
+        Ok(payload) => payload,
+        Err(_) => {
+            return HttpResponse::BadRequest().body("Request body must be valid UTF-8");
+        }
+    };
+    let request = crate::bridge::from_actix_request(&req, Some(payload));
     match handler
         .handle_streamable_http(request, state.get_ref().clone())
         .await

--- a/crates/rust-mcp-actix/tests/integration_tests.rs
+++ b/crates/rust-mcp-actix/tests/integration_tests.rs
@@ -183,6 +183,24 @@ async fn test_streamable_http_post_invalid_body() {
 }
 
 #[actix_web::test]
+async fn test_streamable_http_post_non_utf8_body_rejected() {
+    let (state, handler) = make_state();
+    let opts = default_mount();
+    let scope = mcp_scope(state, handler, &opts);
+    let app = test::init_service(App::new().service(scope)).await;
+
+    let non_utf8 = vec![0xFFu8, 0xFE, 0xFD];
+    let req = test::TestRequest::post()
+        .uri("/mcp")
+        .set_payload(non_utf8)
+        .insert_header(("Content-Type", "application/json"))
+        .insert_header(("Accept", "application/json, text/event-stream"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[actix_web::test]
 async fn test_streamable_http_delete_returns_error_without_session() {
     let (state, handler) = make_state();
     let opts = default_mount();

--- a/crates/rust-mcp-axum/src/routes/streamable_http_routes.rs
+++ b/crates/rust-mcp-axum/src/routes/streamable_http_routes.rs
@@ -1,5 +1,4 @@
-use crate::hyper_servers::error::TransportServerResult;
-use crate::mcp_http::{McpAppState, McpHttpHandler};
+use crate::error::TransportServerResult;
 use axum::body::Bytes;
 use axum::routing::get;
 use axum::Extension;

--- a/crates/rust-mcp-axum/tests/integration_tests.rs
+++ b/crates/rust-mcp-axum/tests/integration_tests.rs
@@ -225,6 +225,29 @@ async fn test_streamable_http_post_invalid_body() {
 }
 
 #[tokio::test]
+async fn test_streamable_http_post_non_utf8_body_rejected() {
+    let handler = McpHttpHandler::new(None, vec![], None);
+    let mount = default_mount();
+    let app = make_app(handler, &mount);
+
+    // Raw bytes with an invalid UTF-8 sequence (0xFF 0xFE 0xFD)
+    let non_utf8 = vec![0xFF, 0xFE, 0xFD];
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .method(Method::POST)
+                .uri("/mcp")
+                .header("Content-Type", "application/json")
+                .body(Body::from(non_utf8))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn test_streamable_http_delete_without_session_id() {
     let handler = McpHttpHandler::new(None, vec![], None);
     let mount = default_mount();

--- a/crates/rust-mcp-sdk/src/hyper_servers/routes/streamable_http_routes.rs
+++ b/crates/rust-mcp-sdk/src/hyper_servers/routes/streamable_http_routes.rs
@@ -1,5 +1,6 @@
 use crate::hyper_servers::error::TransportServerResult;
 use crate::mcp_http::{McpAppState, McpHttpHandler};
+use axum::body::Bytes;
 use axum::routing::get;
 use axum::Extension;
 use axum::{
@@ -8,7 +9,7 @@ use axum::{
     routing::{delete, post},
     Router,
 };
-use http::{HeaderMap, Method, Uri};
+use http::{HeaderMap, Method, StatusCode, Uri};
 use std::{collections::HashMap, sync::Arc};
 
 pub fn routes(streamable_http_endpoint: &str) -> Router<Arc<McpAppState>> {
@@ -40,10 +41,22 @@ pub async fn handle_streamable_http_post(
     State(state): State<Arc<McpAppState>>,
     Extension(http_handler): Extension<Arc<McpHttpHandler>>,
     Query(_params): Query<HashMap<String, String>>,
-    payload: String,
+    payload: Bytes,
 ) -> TransportServerResult<impl IntoResponse> {
-    let request =
-        McpHttpHandler::create_request(Method::POST, uri, headers, Some(payload.as_str()));
+    // Borrow the raw body as UTF-8 instead of extracting an owned `String`,
+    // avoiding an allocation and copy per request. JSON-RPC payloads are UTF-8;
+    // anything else is rejected up front.
+    let payload = match std::str::from_utf8(&payload) {
+        Ok(payload) => payload,
+        Err(_) => {
+            return Ok(axum::response::Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(axum::body::Body::from("Request body must be valid UTF-8"))
+                .expect("static 400 response is always valid"));
+        }
+    };
+
+    let request = McpHttpHandler::create_request(Method::POST, uri, headers, Some(payload));
     let generic_res = http_handler.handle_streamable_http(request, state).await?;
     let (parts, body) = generic_res.into_parts();
     let resp = axum::response::Response::from_parts(parts, axum::body::Body::new(body));

--- a/crates/rust-mcp-sdk/tests/test_streamable_http_server.rs
+++ b/crates/rust-mcp-sdk/tests/test_streamable_http_server.rs
@@ -712,6 +712,36 @@ async fn should_reject_unsupported_content_type() {
     server.axum_runtime.await_server().await.unwrap()
 }
 
+// should reject non-UTF-8 POST body with 400
+#[tokio::test]
+async fn should_reject_non_utf8_post_body() {
+    let server_options = AxumServerOptions {
+        port: random_port(),
+        session_id_generator: Some(Arc::new(TestIdGenerator::new(vec![
+            "AAA-BBB-CCC".to_string()
+        ]))),
+        ..Default::default()
+    };
+
+    let server = create_start_server(server_options).await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let client = reqwest::Client::new();
+    let non_utf8 = vec![0xFFu8, 0xFE, 0xFD];
+    let response = client
+        .post(&server.streamable_url)
+        .header("Content-Type", "application/json")
+        .body(non_utf8)
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    server.axum_runtime.graceful_shutdown(ONE_MILLISECOND);
+    server.axum_runtime.await_server().await.unwrap()
+}
+
 // should handle JSON-RPC batch notification messages with 202 response
 #[tokio::test]
 async fn should_handle_batch_notification_messages_with_202_response() {


### PR DESCRIPTION
### 📌 Summary
The streamable-HTTP POST handler extracted the body as an owned String, causing an internal copy (Axum converts Bytes → Vec<u8> → String). It now extracts Bytes directly and borrows as &str via std::str::from_utf8, avoiding the copy. Non-UTF-8 bodies are rejected with 400. The same optimization is applied to both the Axum and Actix route handlers.

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #141 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Axum: Replace payload: String with payload: Bytes in handle_streamable_http_post; borrow as &str via from_utf8; reject non-UTF-8 with 400
- Actix: Same optimization — String → web::Bytes in handle_streamable_http_post, match Axum behavior for non-UTF-8
- Tests (3 new):
  - Axum integration test: POST non-UTF-8 bytes → 400 BAD_REQUEST
  - Actix integration test: POST non-UTF-8 bytes → 400 BAD_REQUEST
  - E2E test: POST non-UTF-8 bytes to running server → 400 BAD_REQUEST

### 🛠️ Testing Steps
```
cargo test -p rust-mcp-axum --test integration_tests -- non_utf8
cargo test -p rust-mcp-actix --test integration_tests -- non_utf8
cargo test -p rust-mcp-sdk --test test_streamable_http_server -- should_reject_non_utf8
cargo nextest run -p rust-mcp-sdk -p rust-mcp-axum -p rust-mcp-actix
```

### 💡 Additional Notes
<!-- Any other information or context about the PR -->
The perf win is avoiding the Bytes::to_vec() call inside Axum's String extractor. Both String::as_str() and the new from_utf8(&bytes) borrow are zero-copy , the saved allocation is the intermediate Vec<u8> that Axum converts to String.