### PR TITLE
fix(tls): install rustls crypto provider before TLS serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "rust-mcp-sdk",
+ "rustls",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -2456,6 +2457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/crates/rust-mcp-actix/src/runtime.rs
+++ b/crates/rust-mcp-actix/src/runtime.rs
@@ -64,6 +64,7 @@ impl ActixRuntime {
 
         #[cfg(feature = "ssl")]
         let srv = if server.options().enable_ssl {
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
             let config = load_rustls_config(
                 server
                     .options()
@@ -574,4 +575,13 @@ fn load_rustls_config(cert_path: &str, key_path: &str) -> std::io::Result<rustls
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
 
     Ok(config)
+}
+
+#[cfg(all(test, feature = "ssl"))]
+mod ssl_tests {
+    #[test]
+    fn install_crypto_provider_idempotent() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
 }

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 axum-server = { workspace = true, features = [] }
+rustls = { workspace = true, optional = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
@@ -29,7 +30,7 @@ serde_json = { workspace = true }
 http-body-util = { workspace = true }
 
 [features]
-ssl = ["axum-server/tls-rustls"]
+ssl = ["axum-server/tls-rustls", "dep:rustls"]
 tls-no-provider = ["axum-server/tls-rustls-no-provider"]
 
 [lints]

--- a/crates/rust-mcp-axum/src/server.rs
+++ b/crates/rust-mcp-axum/src/server.rs
@@ -506,6 +506,8 @@ impl AxumServer {
     /// * `TransportServerResult<()>` - Ok if the server starts successfully, Err otherwise
     #[cfg(feature = "ssl")]
     pub(crate) async fn start_ssl(self, addr: SocketAddr) -> TransportServerResult<()> {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let config = RustlsConfig::from_pem_file(
             self.options.ssl_cert_path.as_deref().unwrap_or_default(),
             self.options.ssl_key_path.as_deref().unwrap_or_default(),
@@ -746,5 +748,12 @@ mod tests {
             ..Default::default()
         };
         assert!(options.resolve_server_address().await.is_err());
+    }
+
+    #[cfg(feature = "ssl")]
+    #[test]
+    fn install_crypto_provider_idempotent() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     }
 }


### PR DESCRIPTION
Add optional rustls dependency to axum, call aws_lc_rs provider's install_default() in Actix and Axum SSL startup paths, and add tests to verify idempotent installation. Update Cargo.lock.

### 📌 Summary
No rustls `CryptoProvider` was installed explicitly. With both `aws-lc-rs`
(via `jsonwebtoken`) and `ring` in the dependency graph, rustls 0.23 has no
unambiguous default and the first TLS handshake panics. Both `AxumServer` and
`ActixServer` now install the `aws_lc_rs` provider before serving TLS.

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #141 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->
- Add `rustls` as an optional dependency to `rust-mcp-axum` (`ssl` feature)
- Install `aws_lc_rs` `CryptoProvider` at the start of `AxumServer::start_ssl()`
- Install `aws_lc_rs` `CryptoProvider` in `ActixRuntime::create()` before
  building the TLS config
- Ignore the "already installed" error so embedders may install their own
  provider first
- Two idempotency unit tests: double-call does not panic


### 🛠️ Testing Steps
<!-- Explain how reviewers can test your changes, if applicable -->
```
cargo test -p rust-mcp-axum --lib --features ssl -- crypto
cargo test -p rust-mcp-actix --lib --features ssl -- crypto
cargo test -p rust-mcp-axum --test integration_tests --features ssl
cargo test -p rust-mcp-actix --test integration_tests --features ssl
cargo nextest run -p rust-mcp-sdk -p rust-mcp-axum -p rust-mcp-actix -p rust-mcp-transport
```
### 💡 Additional Notes
<!-- Any other information or context about the PR -->
The fix uses `let _ = rustls::crypto::aws_lc_rs::default_provider().install_default()`,
the standard rustls pattern for process-wide provider installation. If a
provider is already installed (e.g. by an embedder preferring `ring`), the
call returns `Err` and is silently ignored , existing provider takes
precedence.