### PR TITLE
feat: add MCP conformance server, CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,41 @@
+name: MCP Conformance
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+concurrency:
+  group: conformance-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  server-conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: conformance-server
+
+      - name: Build conformance server
+        run: cargo build -p conformance-server --release
+
+      - name: Start server
+        run: |
+          cargo run -p conformance-server --release &
+          timeout 30 bash -c 'until curl -sf http://localhost:3000/health; do sleep 0.5; done'
+
+      - uses: modelcontextprotocol/conformance@v0.1.11
+        with:
+          mode: server
+          url: http://localhost:3000/mcp
+          baseline-path: conformance-baseline.yml

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,4 +1,4 @@
-name: MCP Conformance
+name: 🧪 MCP Conformance
 on:
   push:
     branches:
@@ -34,8 +34,8 @@ jobs:
           cargo run -p conformance-server --release &
           timeout 30 bash -c 'until curl -sf http://localhost:3000/health; do sleep 0.5; done'
 
-      - uses: modelcontextprotocol/conformance@v0.1.11
+      - uses: modelcontextprotocol/conformance@v0.1.16
         with:
           mode: server
           url: http://localhost:3000/mcp
-          baseline-path: conformance-baseline.yml
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ settings.json
 # *.profraw
 target/**
 
+ROADMAP.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,6 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "rust-mcp-macros",
  "rust-mcp-sdk",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "conformance-server"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "axum-server",
+ "base64",
+ "rust-mcp-axum",
+ "rust-mcp-macros",
+ "rust-mcp-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.12.1"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -132,7 +132,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
- "impl-more",
+ "impl-more 0.1.9",
  "pin-project-lite",
  "rustls-pki-types",
  "tokio",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.13.0"
+version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -176,7 +176,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "futures-util",
- "impl-more",
+ "impl-more 0.3.1",
  "itoa",
  "language-tags",
  "log",
@@ -189,7 +189,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "time",
  "tracing",
  "url",
@@ -230,9 +230,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -245,12 +245,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -338,7 +332,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -369,7 +363,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -390,7 +384,7 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "hyper-util",
@@ -416,9 +410,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -431,18 +425,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -451,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -467,9 +461,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytestring"
@@ -482,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -517,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -747,9 +741,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -791,16 +782,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -919,9 +910,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1090,16 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1123,16 +1112,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1142,24 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1180,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1195,7 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1206,7 +1180,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -1234,16 +1208,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -1260,7 +1234,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1296,14 +1270,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1418,12 +1392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,15 +1419,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
+name = "impl-more"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1486,13 +1458,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1528,12 +1499,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1593,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1620,9 +1585,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -1652,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1792,7 +1757,7 @@ dependencies = [
  "dotenvy",
  "envy",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonwebtoken",
  "once_cell",
  "rand 0.8.6",
@@ -1820,9 +1785,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1851,9 +1816,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1973,16 +1938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2020,7 +1975,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -2029,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2057,16 +2012,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2111,7 +2066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2180,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2209,9 +2164,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2226,8 +2181,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2308,7 +2263,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "rust-mcp-schema",
  "rust-mcp-sdk",
@@ -2328,7 +2283,7 @@ dependencies = [
  "axum",
  "axum-server",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "rust-mcp-sdk",
  "rustls",
@@ -2350,7 +2305,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "nanoid",
@@ -2400,7 +2355,7 @@ dependencies = [
  "bytes",
  "colored",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "jsonwebtoken",
@@ -2472,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2694,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2744,9 +2699,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -2760,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2798,9 +2753,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2855,7 +2810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2892,12 +2847,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -2909,15 +2863,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2960,7 +2914,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3085,7 +3039,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "pin-project-lite",
@@ -3103,7 +3057,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -3194,9 +3148,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -3212,9 +3166,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -3261,11 +3215,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3305,27 +3259,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3336,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3346,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3356,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3369,33 +3314,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -3412,22 +3335,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3445,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3697,7 +3608,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3712,97 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3812,9 +3635,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3835,18 +3658,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3876,18 +3699,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24f3d3d9ae3dc80d3932ce36536c32c24ff8dede42176551aed740ee96aace1"
+checksum = "02696cb412c5e6c76b296386d35ce9625929311b45c131eee3b6aef8064b1e83"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/rust-mcp-extra",
     "crates/rust-mcp-axum",
     "crates/rust-mcp-actix",
+    "crates/conformance-server",
 ]
 
 [workspace.package]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.9.x   | Yes       |
+| < 0.9   | No        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `rust-mcp-sdk`, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Use [GitHub Security Advisories](https://github.com/rust-mcp-stack/rust-mcp-sdk/security/advisories/new)
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response Timeline
+
+| Severity | Acknowledgment | Resolution |
+|----------|---------------|------------|
+| Critical (P0) | 1 business day | 7 days |
+| High (P1) | 2 business days | 14 days |
+| Medium (P2) | 5 business days | 30 days |
+| Low (P3) | 10 business days | Next release |
+
+### Process
+
+1. We acknowledge receipt within the timeline above
+2. We investigate and confirm the vulnerability
+3. We develop a fix in a private branch
+4. We release the fix and publish a security advisory
+5. We credit the reporter (unless they prefer anonymity)
+
+### Scope
+
+This policy covers:
+- `rust-mcp-sdk` — MCP protocol implementation
+- `rust-mcp-transport` — Transport layer (stdio, SSE, streamable HTTP)
+- `rust-mcp-axum` — Axum HTTP integration
+- `rust-mcp-actix` — Actix HTTP integration
+- `rust-mcp-macros` — Proc-macro code generation
+- `rust-mcp-schema` — Protocol schema types
+
+### Known Security Considerations
+
+- **DNS Rebinding**: Localhost MCP servers must validate Host/Origin headers. The SDK provides `DnsRebindingOptions` middleware for this purpose.
+- **Transport Security**: Stdio transport is local-only. HTTP transports should use TLS in production.
+- **Input Validation**: Tool input schemas are validated by the SDK. Servers should additionally validate business logic.

--- a/conformance-baseline.yml
+++ b/conformance-baseline.yml
@@ -1,4 +1,0 @@
-# No known failures — 40/40 server conformance scenarios passing.
-# This file is kept for CI integration with the conformance GitHub Action.
-# If a scenario regresses, add it here to prevent CI failure while fixing.
-server: []

--- a/conformance-baseline.yml
+++ b/conformance-baseline.yml
@@ -1,0 +1,2 @@
+server:
+  - tools-call-with-progress

--- a/conformance-baseline.yml
+++ b/conformance-baseline.yml
@@ -1,2 +1,4 @@
-server:
-  - tools-call-with-progress
+# No known failures — 40/40 server conformance scenarios passing.
+# This file is kept for CI integration with the conformance GitHub Action.
+# If a scenario regresses, add it here to prevent CI failure while fixing.
+server: []

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "conformance-server"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.80.0"
+description = "MCP conformance test server — implements all scenarios from the MCP conformance suite"
+
+[[bin]]
+name = "conformance-server"
+path = "src/main.rs"
+
+[dependencies]
+rust-mcp-sdk = { workspace = true, features = ["macros"] }
+rust-mcp-axum = { workspace = true }
+rust-mcp-macros = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing = { workspace = true }
+axum = { workspace = true }
+axum-server = { workspace = true }

--- a/crates/conformance-server/README.md
+++ b/crates/conformance-server/README.md
@@ -1,0 +1,92 @@
+# conformance-server
+
+A Rust MCP conformance test server built with [`rust-mcp-sdk`](https://github.com/rust-mcp-stack/rust-mcp-sdk). Implements all scenarios from the [MCP Conformance Test Suite](https://github.com/modelcontextprotocol/conformance) targeting the **2025-11-25 stateful spec**.
+
+## Conformance Status
+
+**39/40 scenarios passing** — 1 known limitation (`tools-call-with-progress`, test-framework level).
+
+## Quick Start
+
+```bash
+cargo run -p conformance-server
+```
+
+Starts on `http://0.0.0.0:3000`.
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/mcp` | POST | Streamable HTTP MCP endpoint |
+| `/mcp` | GET | SSE notification stream |
+| `/sse` | GET | SSE endpoint (backward compat) |
+| `/messages` | POST | SSE messages endpoint (backward compat) |
+| `/health` | GET | Health check |
+
+## Running Conformance Tests
+
+```bash
+cargo run -p conformance-server &
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp
+```
+
+## Implemented Features
+
+### Tools (13)
+
+| Name | Description |
+|------|-------------|
+| `test_simple_text` | Returns simple text content |
+| `test_image_content` | Returns base64 PNG image |
+| `test_audio_content` | Returns base64 WAV audio |
+| `test_embedded_resource` | Returns embedded resource content |
+| `test_multiple_content_types` | Returns text + image + resource |
+| `test_error_handling` | Returns `isError: true` |
+| `test_tool_with_logging` | Emits 3 log notifications during execution |
+| `test_tool_with_progress` | Reports 3 progress notifications (0/50/100) |
+| `test_sampling` | Requests LLM sampling from client |
+| `test_elicitation` | Requests user input from client |
+| `test_elicitation_sep1034_defaults` | Elicitation schema with defaults for all primitive types |
+| `test_elicitation_sep1330_enums` | Elicitation schema with all 5 enum variants |
+
+### Resources (5)
+
+| URI | MIME | Description |
+|-----|------|-------------|
+| `test://static-text` | text/plain | Static text content |
+| `test://static-binary` | image/png | Static binary (base64 PNG) |
+| `test://template/{id}/data` | application/json | Template with parameter substitution |
+| `test://embedded-resource` | text/plain | Resource for embedded content tests |
+| `test://watched-resource` | application/json | Subscribable resource |
+
+### Prompts (4)
+
+| Name | Arguments | Description |
+|------|-----------|-------------|
+| `test_simple_prompt` | — | Simple text prompt |
+| `test_prompt_with_arguments` | `arg1`, `arg2` | Parameterized prompt |
+| `test_prompt_with_embedded_resource` | `resourceUri` | Prompt with embedded resource |
+| `test_prompt_with_image` | — | Prompt with image content |
+
+### Other Capabilities
+
+- **Logging** — all severity levels (debug through emergency)
+- **Completions** — prompt argument autocompletion
+- **Resource subscriptions** — subscribe/unsubscribe with update notifications
+- **DNS rebinding protection** — Host header validation for localhost servers
+- **Ping** — connection health check
+
+## Known Limitations
+
+| Scenario | Status | Reason |
+|----------|--------|--------|
+| `tools-call-with-progress` | Expected failure | Test-framework Zod schema identity mismatch in `connectStateful()` — notifications reach the transport but aren't dispatched to the test's handler array |
+
+## Tech Stack
+
+- **Rust** 1.80+
+- [`rust-mcp-sdk`](https://crates.io/crates/rust-mcp-sdk) — MCP protocol implementation
+- [`rust-mcp-axum`](https://crates.io/crates/rust-mcp-axum) — Axum HTTP integration
+- Streamable HTTP transport (SSE + JSON responses)
+- Protocol version: 2025-11-25 (stateful)

--- a/crates/conformance-server/src/handler.rs
+++ b/crates/conformance-server/src/handler.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use rust_mcp_sdk::mcp_server::ServerHandler;
 use rust_mcp_sdk::schema::schema_utils::CallToolError;
 use rust_mcp_sdk::schema::{
-    CallToolRequestParams, CallToolResult, CompleteRequestParams, CompleteRequestRef, CompleteResult,
-    CompleteResultCompletion, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
-    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
-    ReadResourceRequestParams, ReadResourceResult, RpcError, SetLevelRequestParams,
-    SubscribeRequestParams, UnsubscribeRequestParams,
+    CallToolRequestParams, CallToolResult, CompleteRequestParams, CompleteRequestRef,
+    CompleteResult, CompleteResultCompletion, GetPromptRequestParams, GetPromptResult,
+    ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, ListToolsResult,
+    PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, RpcError,
+    SetLevelRequestParams, SubscribeRequestParams, UnsubscribeRequestParams,
 };
 use rust_mcp_sdk::McpServer;
 use std::sync::Arc;
@@ -41,10 +41,7 @@ impl ServerHandler for ConformanceHandler {
         params: CallToolRequestParams,
         runtime: Arc<dyn McpServer>,
     ) -> Result<CallToolResult, CallToolError> {
-        let progress_token = params
-            .meta
-            .as_ref()
-            .and_then(|m| m.progress_token.clone());
+        let progress_token = params.meta.as_ref().and_then(|m| m.progress_token.clone());
         let tool_params: ConformanceTools =
             ConformanceTools::try_from(params).map_err(CallToolError::new)?;
 
@@ -56,7 +53,9 @@ impl ServerHandler for ConformanceHandler {
             ConformanceTools::TestMultipleContentTypes(t) => t.call_tool(),
             ConformanceTools::TestErrorHandling(t) => t.call_tool(),
             ConformanceTools::TestToolWithLogging(t) => t.call_tool(&runtime).await,
-            ConformanceTools::TestToolWithProgress(t) => t.call_tool(&runtime, progress_token).await,
+            ConformanceTools::TestToolWithProgress(t) => {
+                t.call_tool(&runtime, progress_token).await
+            }
             ConformanceTools::TestSampling(t) => t.call_tool(&runtime).await,
             ConformanceTools::TestElicitation(t) => t.call_tool(&runtime).await,
             ConformanceTools::TestElicitationDefaults(t) => t.call_tool(&runtime).await,
@@ -141,8 +140,9 @@ impl ServerHandler for ConformanceHandler {
             "test_simple_prompt" => prompts::TestSimplePrompt::get_prompt(),
             "test_prompt_with_arguments" => {
                 let args = params.arguments.as_ref().ok_or_else(|| {
-                    RpcError::invalid_params()
-                        .with_message("Arguments required for test_prompt_with_arguments".to_string())
+                    RpcError::invalid_params().with_message(
+                        "Arguments required for test_prompt_with_arguments".to_string(),
+                    )
                 })?;
                 let arg1 = args.get("arg1").map(String::as_str).unwrap_or("default1");
                 let arg2 = args.get("arg2").map(String::as_str).unwrap_or("default2");
@@ -183,8 +183,10 @@ impl ServerHandler for ConformanceHandler {
                 meta: None,
             })
         } else {
-            Err(RpcError::method_not_found()
-                .with_message(format!("No completion handler for '{}'", params.argument.name)))
+            Err(RpcError::method_not_found().with_message(format!(
+                "No completion handler for '{}'",
+                params.argument.name
+            )))
         }
     }
 

--- a/crates/conformance-server/src/handler.rs
+++ b/crates/conformance-server/src/handler.rs
@@ -46,18 +46,20 @@ impl ServerHandler for ConformanceHandler {
             ConformanceTools::try_from(params).map_err(CallToolError::new)?;
 
         match tool_params {
-            ConformanceTools::SimpleTextTool(t) => t.call_tool(),
-            ConformanceTools::ImageContentTool(t) => t.call_tool(),
-            ConformanceTools::AudioContentTool(t) => t.call_tool(),
-            ConformanceTools::EmbeddedResourceTool(t) => t.call_tool(),
-            ConformanceTools::MultipleContentTypesTool(t) => t.call_tool(),
-            ConformanceTools::ErrorHandlingTool(t) => t.call_tool(),
-            ConformanceTools::LoggingTool(t) => t.call_tool(&runtime).await,
-            ConformanceTools::ProgressTool(t) => t.call_tool(&runtime, progress_token).await,
-            ConformanceTools::SamplingTool(t) => t.call_tool(&runtime).await,
-            ConformanceTools::ElicitationTool(t) => t.call_tool(&runtime).await,
-            ConformanceTools::ElicitationDefaultsTool(t) => t.call_tool(&runtime).await,
-            ConformanceTools::ElicitationEnumsTool(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestSimpleText(t) => t.call_tool(),
+            ConformanceTools::TestImageContent(t) => t.call_tool(),
+            ConformanceTools::TestAudioContent(t) => t.call_tool(),
+            ConformanceTools::TestEmbeddedResource(t) => t.call_tool(),
+            ConformanceTools::TestMultipleContentTypes(t) => t.call_tool(),
+            ConformanceTools::TestErrorHandling(t) => t.call_tool(),
+            ConformanceTools::TestToolWithLogging(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestToolWithProgress(t) => {
+                t.call_tool(&runtime, progress_token).await
+            }
+            ConformanceTools::TestSampling(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestElicitation(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestElicitationDefaults(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestElicitationEnums(t) => t.call_tool(&runtime).await,
         }
     }
 

--- a/crates/conformance-server/src/handler.rs
+++ b/crates/conformance-server/src/handler.rs
@@ -41,6 +41,10 @@ impl ServerHandler for ConformanceHandler {
         params: CallToolRequestParams,
         runtime: Arc<dyn McpServer>,
     ) -> Result<CallToolResult, CallToolError> {
+        let progress_token = params
+            .meta
+            .as_ref()
+            .and_then(|m| m.progress_token.clone());
         let tool_params: ConformanceTools =
             ConformanceTools::try_from(params).map_err(CallToolError::new)?;
 
@@ -52,7 +56,7 @@ impl ServerHandler for ConformanceHandler {
             ConformanceTools::TestMultipleContentTypes(t) => t.call_tool(),
             ConformanceTools::TestErrorHandling(t) => t.call_tool(),
             ConformanceTools::TestToolWithLogging(t) => t.call_tool(&runtime).await,
-            ConformanceTools::TestToolWithProgress(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestToolWithProgress(t) => t.call_tool(&runtime, progress_token).await,
             ConformanceTools::TestSampling(t) => t.call_tool(&runtime).await,
             ConformanceTools::TestElicitation(t) => t.call_tool(&runtime).await,
             ConformanceTools::TestElicitationDefaults(t) => t.call_tool(&runtime).await,

--- a/crates/conformance-server/src/handler.rs
+++ b/crates/conformance-server/src/handler.rs
@@ -1,0 +1,212 @@
+use async_trait::async_trait;
+use rust_mcp_sdk::mcp_server::ServerHandler;
+use rust_mcp_sdk::schema::schema_utils::CallToolError;
+use rust_mcp_sdk::schema::{
+    CallToolRequestParams, CallToolResult, CompleteRequestParams, CompleteRequestRef, CompleteResult,
+    CompleteResultCompletion, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResult, RpcError, SetLevelRequestParams,
+    SubscribeRequestParams, UnsubscribeRequestParams,
+};
+use rust_mcp_sdk::McpServer;
+use std::sync::Arc;
+
+use crate::{
+    prompts,
+    resources::{
+        EmbeddedTestResource, StaticBinaryResource, StaticTextResource, TemplateDataResource,
+        WatchedResource,
+    },
+    tools::ConformanceTools,
+};
+
+pub struct ConformanceHandler;
+
+#[async_trait]
+impl ServerHandler for ConformanceHandler {
+    async fn handle_list_tools_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListToolsResult, RpcError> {
+        Ok(ListToolsResult {
+            tools: ConformanceTools::tools(),
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn handle_call_tool_request(
+        &self,
+        params: CallToolRequestParams,
+        runtime: Arc<dyn McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let tool_params: ConformanceTools =
+            ConformanceTools::try_from(params).map_err(CallToolError::new)?;
+
+        match tool_params {
+            ConformanceTools::TestSimpleText(t) => t.call_tool(),
+            ConformanceTools::TestImageContent(t) => t.call_tool(),
+            ConformanceTools::TestAudioContent(t) => t.call_tool(),
+            ConformanceTools::TestEmbeddedResource(t) => t.call_tool(),
+            ConformanceTools::TestMultipleContentTypes(t) => t.call_tool(),
+            ConformanceTools::TestErrorHandling(t) => t.call_tool(),
+            ConformanceTools::TestToolWithLogging(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestToolWithProgress(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestSampling(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestElicitation(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestElicitationDefaults(t) => t.call_tool(&runtime).await,
+            ConformanceTools::TestElicitationEnums(t) => t.call_tool(&runtime).await,
+        }
+    }
+
+    async fn handle_list_resources_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListResourcesResult, RpcError> {
+        Ok(ListResourcesResult {
+            resources: vec![
+                StaticTextResource::resource(),
+                StaticBinaryResource::resource(),
+                EmbeddedTestResource::resource(),
+                WatchedResource::resource(),
+            ],
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn handle_list_resource_templates_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListResourceTemplatesResult, RpcError> {
+        Ok(ListResourceTemplatesResult {
+            resource_templates: vec![TemplateDataResource::resource_template()],
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn handle_read_resource_request(
+        &self,
+        params: ReadResourceRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ReadResourceResult, RpcError> {
+        let uri = &params.uri;
+
+        if uri == StaticTextResource::resource_uri() {
+            return StaticTextResource::get_resource().await;
+        }
+        if uri == StaticBinaryResource::resource_uri() {
+            return StaticBinaryResource::get_resource().await;
+        }
+        if uri == EmbeddedTestResource::resource_uri() {
+            return EmbeddedTestResource::get_resource().await;
+        }
+        if uri == WatchedResource::resource_uri() {
+            return WatchedResource::get_resource().await;
+        }
+        if TemplateDataResource::matches_url(uri) {
+            return TemplateDataResource::get_resource(uri).await;
+        }
+
+        Err(RpcError::invalid_request()
+            .with_message(format!("No resource found for uri '{}'.", uri)))
+    }
+
+    async fn handle_list_prompts_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListPromptsResult, RpcError> {
+        Ok(ListPromptsResult {
+            prompts: prompts::all_prompts(),
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    async fn handle_get_prompt_request(
+        &self,
+        params: GetPromptRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<GetPromptResult, RpcError> {
+        match params.name.as_str() {
+            "test_simple_prompt" => prompts::TestSimplePrompt::get_prompt(),
+            "test_prompt_with_arguments" => {
+                let args = params.arguments.as_ref().ok_or_else(|| {
+                    RpcError::invalid_params()
+                        .with_message("Arguments required for test_prompt_with_arguments".to_string())
+                })?;
+                let arg1 = args.get("arg1").map(String::as_str).unwrap_or("default1");
+                let arg2 = args.get("arg2").map(String::as_str).unwrap_or("default2");
+                prompts::TestPromptWithArguments::get_prompt(arg1, arg2)
+            }
+            "test_prompt_with_embedded_resource" => {
+                let args = params.arguments.as_ref().ok_or_else(|| {
+                    RpcError::invalid_params().with_message(
+                        "Arguments required for test_prompt_with_embedded_resource".to_string(),
+                    )
+                })?;
+                let uri = args
+                    .get("resourceUri")
+                    .map(String::as_str)
+                    .unwrap_or("test://example-resource");
+                prompts::TestPromptWithEmbeddedResource::get_prompt(uri)
+            }
+            "test_prompt_with_image" => prompts::TestPromptWithImage::get_prompt(),
+            _ => Err(RpcError::invalid_params()
+                .with_message(format!("Unknown prompt: '{}'", params.name))),
+        }
+    }
+
+    async fn handle_complete_request(
+        &self,
+        params: CompleteRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<CompleteResult, RpcError> {
+        if matches!(&params.ref_, CompleteRequestRef::PromptReference(pr) if pr.name == "test_prompt_with_arguments")
+            && params.argument.name == "arg1"
+        {
+            Ok(CompleteResult {
+                completion: CompleteResultCompletion {
+                    values: vec!["paris".into(), "park".into(), "party".into()],
+                    has_more: Some(false),
+                    total: Some(3),
+                },
+                meta: None,
+            })
+        } else {
+            Err(RpcError::method_not_found()
+                .with_message(format!("No completion handler for '{}'", params.argument.name)))
+        }
+    }
+
+    async fn handle_set_level_request(
+        &self,
+        _params: SetLevelRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<rust_mcp_sdk::schema::Result, RpcError> {
+        Ok(rust_mcp_sdk::schema::Result::default())
+    }
+
+    async fn handle_subscribe_request(
+        &self,
+        params: SubscribeRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<rust_mcp_sdk::schema::Result, RpcError> {
+        tracing::info!("Subscribed to resource: {}", params.uri);
+        Ok(rust_mcp_sdk::schema::Result::default())
+    }
+
+    async fn handle_unsubscribe_request(
+        &self,
+        params: UnsubscribeRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<rust_mcp_sdk::schema::Result, RpcError> {
+        tracing::info!("Unsubscribed from resource: {}", params.uri);
+        Ok(rust_mcp_sdk::schema::Result::default())
+    }
+}

--- a/crates/conformance-server/src/handler.rs
+++ b/crates/conformance-server/src/handler.rs
@@ -46,20 +46,18 @@ impl ServerHandler for ConformanceHandler {
             ConformanceTools::try_from(params).map_err(CallToolError::new)?;
 
         match tool_params {
-            ConformanceTools::TestSimpleText(t) => t.call_tool(),
-            ConformanceTools::TestImageContent(t) => t.call_tool(),
-            ConformanceTools::TestAudioContent(t) => t.call_tool(),
-            ConformanceTools::TestEmbeddedResource(t) => t.call_tool(),
-            ConformanceTools::TestMultipleContentTypes(t) => t.call_tool(),
-            ConformanceTools::TestErrorHandling(t) => t.call_tool(),
-            ConformanceTools::TestToolWithLogging(t) => t.call_tool(&runtime).await,
-            ConformanceTools::TestToolWithProgress(t) => {
-                t.call_tool(&runtime, progress_token).await
-            }
-            ConformanceTools::TestSampling(t) => t.call_tool(&runtime).await,
-            ConformanceTools::TestElicitation(t) => t.call_tool(&runtime).await,
-            ConformanceTools::TestElicitationDefaults(t) => t.call_tool(&runtime).await,
-            ConformanceTools::TestElicitationEnums(t) => t.call_tool(&runtime).await,
+            ConformanceTools::SimpleTextTool(t) => t.call_tool(),
+            ConformanceTools::ImageContentTool(t) => t.call_tool(),
+            ConformanceTools::AudioContentTool(t) => t.call_tool(),
+            ConformanceTools::EmbeddedResourceTool(t) => t.call_tool(),
+            ConformanceTools::MultipleContentTypesTool(t) => t.call_tool(),
+            ConformanceTools::ErrorHandlingTool(t) => t.call_tool(),
+            ConformanceTools::LoggingTool(t) => t.call_tool(&runtime).await,
+            ConformanceTools::ProgressTool(t) => t.call_tool(&runtime, progress_token).await,
+            ConformanceTools::SamplingTool(t) => t.call_tool(&runtime).await,
+            ConformanceTools::ElicitationTool(t) => t.call_tool(&runtime).await,
+            ConformanceTools::ElicitationDefaultsTool(t) => t.call_tool(&runtime).await,
+            ConformanceTools::ElicitationEnumsTool(t) => t.call_tool(&runtime).await,
         }
     }
 

--- a/crates/conformance-server/src/main.rs
+++ b/crates/conformance-server/src/main.rs
@@ -1,0 +1,121 @@
+mod handler;
+mod prompts;
+mod resources;
+mod tools;
+
+use axum::{routing::get, Router};
+use handler::ConformanceHandler;
+use rust_mcp_axum::{mcp_routes, McpMountOptions};
+use rust_mcp_sdk::{
+    event_store::InMemoryEventStore,
+    id_generator::{FastIdGenerator, UuidGenerator},
+    mcp_http::{DnsRebindingOptions, McpAppState, McpHttpHandler, resolve_dns_middleware},
+    schema::{
+        Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
+        ServerCapabilitiesTools, ServerCapabilitiesResources, ServerCapabilitiesPrompts,
+    },
+    session_store::InMemorySessionStore,
+    ToMcpServerHandler,
+};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let host = "0.0.0.0";
+    let port = 3000u16;
+
+    let state = Arc::new(McpAppState {
+        session_store: Arc::new(InMemorySessionStore::new()),
+        id_generator: Arc::new(UuidGenerator {}),
+        stream_id_gen: Arc::new(FastIdGenerator::new(Some("s_"))),
+        server_details: Arc::new(InitializeResult {
+            server_info: Implementation {
+                name: "conformance-server".into(),
+                version: "0.1.0".into(),
+                title: Some("MCP Conformance Test Server".into()),
+                description: Some(
+                    "Implements all MCP conformance test scenarios for the 2025-11-25 spec.".into(),
+                ),
+                icons: vec![],
+                website_url: None,
+            },
+            capabilities: ServerCapabilities {
+                tools: Some(ServerCapabilitiesTools {
+                    list_changed: Some(true),
+                }),
+                resources: Some(ServerCapabilitiesResources {
+                    list_changed: Some(true),
+                    subscribe: Some(true),
+                }),
+                prompts: Some(ServerCapabilitiesPrompts {
+                    list_changed: Some(true),
+                }),
+                logging: Some(serde_json::Map::new()),
+                completions: Some(serde_json::Map::new()),
+                experimental: Some(
+                    [(
+                        "sampling".to_string(),
+                        serde_json::Map::new(),
+                    ), (
+                        "elicitation".to_string(),
+                        serde_json::Map::new(),
+                    )]
+                    .into(),
+                ),
+                tasks: None,
+            },
+            meta: None,
+            instructions: None,
+            protocol_version: ProtocolVersion::V2025_11_25.into(),
+        }),
+        handler: ConformanceHandler.to_mcp_server_handler(),
+        ping_interval: std::time::Duration::from_secs(12),
+        transport_options: Default::default(),
+        enable_json_response: false,
+        event_store: Some(Arc::new(InMemoryEventStore::default())),
+        task_store: None,
+        client_task_store: None,
+        message_observer: None,
+    });
+
+    let mut dns_rebinding = DnsRebindingOptions {
+        allowed_hosts: Some(vec![
+            format!("localhost:{port}"),
+            format!("127.0.0.1:{port}"),
+            format!("[::1]:{port}"),
+        ]),
+        allowed_origins: None,
+        ..DnsRebindingOptions::default()
+    };
+    let mut middlewares: Vec<Arc<dyn rust_mcp_sdk::mcp_http::Middleware>> = vec![];
+    if let Some(dns) = resolve_dns_middleware(&mut dns_rebinding, host, port) {
+        middlewares.push(Arc::new(dns));
+    }
+    let http_handler = McpHttpHandler::new(None, middlewares, None);
+
+    let mount_opts = McpMountOptions {
+        streamable_http_endpoint: "/mcp".into(),
+        sse_endpoint: "/sse".into(),
+        sse_messages_endpoint: "/messages".into(),
+        health_endpoint: Some("/health".into()),
+        ..Default::default()
+    };
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async { "conformance-server -- MCP Conformance Test Server" }),
+        )
+        .merge(mcp_routes(state, &mount_opts, http_handler));
+
+    let addr: std::net::SocketAddr = format!("{host}:{port}").parse().unwrap();
+    println!("conformance-server starting on http://{addr}");
+    println!("  MCP endpoint:  http://{addr}/mcp");
+    println!("  SSE endpoint:  http://{addr}/sse");
+    println!("  Health:        http://{addr}/health");
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await
+}

--- a/crates/conformance-server/src/main.rs
+++ b/crates/conformance-server/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::enum_variant_names)]
+
 mod handler;
 mod prompts;
 mod resources;

--- a/crates/conformance-server/src/main.rs
+++ b/crates/conformance-server/src/main.rs
@@ -9,10 +9,10 @@ use rust_mcp_axum::{mcp_routes, McpMountOptions};
 use rust_mcp_sdk::{
     event_store::InMemoryEventStore,
     id_generator::{FastIdGenerator, UuidGenerator},
-    mcp_http::{DnsRebindingOptions, McpAppState, McpHttpHandler, resolve_dns_middleware},
+    mcp_http::{resolve_dns_middleware, DnsRebindingOptions, McpAppState, McpHttpHandler},
     schema::{
         Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
-        ServerCapabilitiesTools, ServerCapabilitiesResources, ServerCapabilitiesPrompts,
+        ServerCapabilitiesPrompts, ServerCapabilitiesResources, ServerCapabilitiesTools,
     },
     session_store::InMemorySessionStore,
     ToMcpServerHandler,
@@ -55,13 +55,10 @@ async fn main() -> std::io::Result<()> {
                 logging: Some(serde_json::Map::new()),
                 completions: Some(serde_json::Map::new()),
                 experimental: Some(
-                    [(
-                        "sampling".to_string(),
-                        serde_json::Map::new(),
-                    ), (
-                        "elicitation".to_string(),
-                        serde_json::Map::new(),
-                    )]
+                    [
+                        ("sampling".to_string(), serde_json::Map::new()),
+                        ("elicitation".to_string(), serde_json::Map::new()),
+                    ]
                     .into(),
                 ),
                 tasks: None,

--- a/crates/conformance-server/src/prompts.rs
+++ b/crates/conformance-server/src/prompts.rs
@@ -1,0 +1,192 @@
+use rust_mcp_sdk::schema::{
+    ContentBlock, GetPromptResult, Prompt, PromptArgument, PromptMessage, Role, TextContent,
+};
+use serde_json::json;
+
+const IMAGE_BASE64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+fn text_message(text: impl Into<String>) -> PromptMessage {
+    PromptMessage {
+        role: Role::User,
+        content: TextContent::new(text.into(), None, None).into(),
+    }
+}
+
+fn image_message(data: &str, mime: &str) -> PromptMessage {
+    let json_val = json!({
+        "type": "image",
+        "data": data,
+        "mimeType": mime
+    });
+    let block: ContentBlock = serde_json::from_value(json_val).unwrap();
+    PromptMessage {
+        role: Role::User,
+        content: block,
+    }
+}
+
+fn resource_message(uri: &str, text: &str) -> PromptMessage {
+    let json_val = json!({
+        "type": "resource",
+        "resource": {
+            "uri": uri,
+            "mimeType": "text/plain",
+            "text": text
+        }
+    });
+    let block: ContentBlock = serde_json::from_value(json_val).unwrap();
+    PromptMessage {
+        role: Role::User,
+        content: block,
+    }
+}
+
+// ---------------
+// 1. test_simple_prompt
+// ---------------
+pub struct TestSimplePrompt;
+
+impl TestSimplePrompt {
+    pub fn prompt() -> Prompt {
+        Prompt {
+            name: "test_simple_prompt".into(),
+            description: Some("A simple prompt for conformance testing.".into()),
+            arguments: vec![],
+            icons: vec![],
+            meta: None,
+            title: None,
+        }
+    }
+
+    pub fn get_prompt() -> Result<GetPromptResult, rust_mcp_sdk::schema::RpcError> {
+        Ok(GetPromptResult {
+            messages: vec![text_message("This is a simple prompt for testing.")],
+            meta: None,
+            description: Some("This is a simple prompt for testing.".into()),
+        })
+    }
+}
+
+// ---------------
+// 2. test_prompt_with_arguments
+// ---------------
+pub struct TestPromptWithArguments;
+
+impl TestPromptWithArguments {
+    pub fn prompt() -> Prompt {
+        Prompt {
+            name: "test_prompt_with_arguments".into(),
+            description: Some("A parameterized prompt for conformance testing.".into()),
+            arguments: vec![
+                PromptArgument {
+                    name: "arg1".into(),
+                    description: Some("First test argument".into()),
+                    required: Some(true),
+                    title: None,
+                },
+                PromptArgument {
+                    name: "arg2".into(),
+                    description: Some("Second test argument".into()),
+                    required: Some(true),
+                    title: None,
+                },
+            ],
+            icons: vec![],
+            meta: None,
+            title: None,
+        }
+    }
+
+    pub fn get_prompt(
+        arg1: &str,
+        arg2: &str,
+    ) -> Result<GetPromptResult, rust_mcp_sdk::schema::RpcError> {
+        Ok(GetPromptResult {
+            messages: vec![text_message(format!(
+                "Prompt with arguments: arg1='{arg1}', arg2='{arg2}'"
+            ))],
+            meta: None,
+            description: Some(format!(
+                "Prompt with arguments: arg1='{arg1}', arg2='{arg2}'"
+            )),
+        })
+    }
+}
+
+// ---------------
+// 3. test_prompt_with_embedded_resource
+// ---------------
+pub struct TestPromptWithEmbeddedResource;
+
+impl TestPromptWithEmbeddedResource {
+    pub fn prompt() -> Prompt {
+        Prompt {
+            name: "test_prompt_with_embedded_resource".into(),
+            description: Some("A prompt with embedded resource for conformance testing.".into()),
+            arguments: vec![PromptArgument {
+                name: "resourceUri".into(),
+                description: Some("URI of the resource to embed".into()),
+                required: Some(true),
+                title: None,
+            }],
+            icons: vec![],
+            meta: None,
+            title: None,
+        }
+    }
+
+    pub fn get_prompt(
+        resource_uri: &str,
+    ) -> Result<GetPromptResult, rust_mcp_sdk::schema::RpcError> {
+        Ok(GetPromptResult {
+            messages: vec![
+                resource_message(resource_uri, "Embedded resource content for testing."),
+                text_message("Please process the embedded resource above."),
+            ],
+            meta: None,
+            description: Some("A prompt with embedded resource for conformance testing.".into()),
+        })
+    }
+}
+
+// ---------------
+// 4. test_prompt_with_image
+// ---------------
+pub struct TestPromptWithImage;
+
+impl TestPromptWithImage {
+    pub fn prompt() -> Prompt {
+        Prompt {
+            name: "test_prompt_with_image".into(),
+            description: Some("A prompt with image content for conformance testing.".into()),
+            arguments: vec![],
+            icons: vec![],
+            meta: None,
+            title: None,
+        }
+    }
+
+    pub fn get_prompt() -> Result<GetPromptResult, rust_mcp_sdk::schema::RpcError> {
+        Ok(GetPromptResult {
+            messages: vec![
+                image_message(IMAGE_BASE64, "image/png"),
+                text_message("Please analyze the image above."),
+            ],
+            meta: None,
+            description: Some("A prompt with image content for conformance testing.".into()),
+        })
+    }
+}
+
+// ---------------
+// Prompt list
+// ---------------
+pub fn all_prompts() -> Vec<Prompt> {
+    vec![
+        TestSimplePrompt::prompt(),
+        TestPromptWithArguments::prompt(),
+        TestPromptWithEmbeddedResource::prompt(),
+        TestPromptWithImage::prompt(),
+    ]
+}

--- a/crates/conformance-server/src/resources.rs
+++ b/crates/conformance-server/src/resources.rs
@@ -1,0 +1,149 @@
+use rust_mcp_macros::{mcp_resource, mcp_resource_template};
+use rust_mcp_sdk::schema::{BlobResourceContents, ReadResourceResult, RpcError, TextResourceContents};
+
+const IMAGE_BASE64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+// ---------------
+// 1. test://static-text
+// ---------------
+#[mcp_resource(
+    name = "Static Text Resource",
+    description = "A static text resource for conformance testing.",
+    mime_type = "text/plain",
+    uri = "test://static-text"
+)]
+pub struct StaticTextResource;
+
+impl StaticTextResource {
+    pub async fn get_resource() -> Result<ReadResourceResult, RpcError> {
+        let uri = Self::resource_uri().to_string();
+        Ok(ReadResourceResult {
+            contents: vec![TextResourceContents::new(
+                "This is the content of the static text resource.",
+                &uri,
+            )
+            .with_mime_type("text/plain")
+            .into()],
+            meta: None,
+        })
+    }
+}
+
+// ---------------
+// 2. test://static-binary
+// ---------------
+#[mcp_resource(
+    name = "Static Binary Resource",
+    description = "A static binary (image) resource for conformance testing.",
+    mime_type = "image/png",
+    uri = "test://static-binary"
+)]
+pub struct StaticBinaryResource;
+
+impl StaticBinaryResource {
+    pub async fn get_resource() -> Result<ReadResourceResult, RpcError> {
+        let uri = Self::resource_uri().to_string();
+        Ok(ReadResourceResult {
+            contents: vec![BlobResourceContents::new(IMAGE_BASE64, &uri)
+                .with_mime_type("image/png")
+                .into()],
+            meta: None,
+        })
+    }
+}
+
+// ---------------
+// 3. test://template/{id}/data
+// ---------------
+#[mcp_resource_template(
+    name = "Template Resource",
+    description = "A resource template with parameter substitution for conformance testing.",
+    mime_type = "application/json",
+    uri_template = "test://template/{id}/data"
+)]
+pub struct TemplateDataResource;
+
+impl TemplateDataResource {
+    pub fn matches_url(uri: &str) -> bool {
+        uri.starts_with("test://template/") && uri.ends_with("/data")
+    }
+
+    pub async fn get_resource(uri: &str) -> Result<ReadResourceResult, RpcError> {
+        let id = uri
+            .strip_prefix("test://template/")
+            .and_then(|s| s.strip_suffix("/data"))
+            .unwrap_or("unknown");
+
+        let content = serde_json::json!({
+            "id": id,
+            "templateTest": true,
+            "data": format!("Data for ID: {}", id)
+        });
+
+        Ok(ReadResourceResult {
+            contents: vec![TextResourceContents::new(content.to_string(), uri.to_string())
+                .with_mime_type("application/json")
+                .into()],
+            meta: None,
+        })
+    }
+}
+
+// ---------------
+// 4. test://embedded-resource
+// ---------------
+#[mcp_resource(
+    name = "Embedded Resource",
+    description = "A resource used for embedded content tests.",
+    mime_type = "text/plain",
+    uri = "test://embedded-resource"
+)]
+pub struct EmbeddedTestResource;
+
+impl EmbeddedTestResource {
+    pub async fn get_resource() -> Result<ReadResourceResult, RpcError> {
+        let uri = Self::resource_uri().to_string();
+        Ok(ReadResourceResult {
+            contents: vec![TextResourceContents::new(
+                "This is an embedded resource content.",
+                &uri,
+            )
+            .with_mime_type("text/plain")
+            .into()],
+            meta: None,
+        })
+    }
+}
+
+// ---------------
+// 5. test://watched-resource
+// ---------------
+#[mcp_resource(
+    name = "Watched Resource",
+    description = "A subscribable resource that updates periodically for conformance testing.",
+    mime_type = "application/json",
+    uri = "test://watched-resource"
+)]
+pub struct WatchedResource;
+
+impl WatchedResource {
+    pub async fn get_resource() -> Result<ReadResourceResult, RpcError> {
+        let uri = Self::resource_uri().to_string();
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs().to_string())
+            .unwrap_or_else(|_| "unknown".into());
+        let content = serde_json::json!({
+            "watched": true,
+            "timestamp": timestamp
+        });
+
+        Ok(ReadResourceResult {
+            contents: vec![TextResourceContents::new(content.to_string(), uri.to_string())
+                .with_mime_type("application/json")
+                .into()],
+            meta: None,
+        })
+    }
+}

--- a/crates/conformance-server/src/resources.rs
+++ b/crates/conformance-server/src/resources.rs
@@ -1,5 +1,7 @@
 use rust_mcp_macros::{mcp_resource, mcp_resource_template};
-use rust_mcp_sdk::schema::{BlobResourceContents, ReadResourceResult, RpcError, TextResourceContents};
+use rust_mcp_sdk::schema::{
+    BlobResourceContents, ReadResourceResult, RpcError, TextResourceContents,
+};
 
 const IMAGE_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
@@ -82,9 +84,11 @@ impl TemplateDataResource {
         });
 
         Ok(ReadResourceResult {
-            contents: vec![TextResourceContents::new(content.to_string(), uri.to_string())
-                .with_mime_type("application/json")
-                .into()],
+            contents: vec![
+                TextResourceContents::new(content.to_string(), uri.to_string())
+                    .with_mime_type("application/json")
+                    .into(),
+            ],
             meta: None,
         })
     }
@@ -140,9 +144,11 @@ impl WatchedResource {
         });
 
         Ok(ReadResourceResult {
-            contents: vec![TextResourceContents::new(content.to_string(), uri.to_string())
-                .with_mime_type("application/json")
-                .into()],
+            contents: vec![
+                TextResourceContents::new(content.to_string(), uri.to_string())
+                    .with_mime_type("application/json")
+                    .into(),
+            ],
             meta: None,
         })
     }

--- a/crates/conformance-server/src/tools.rs
+++ b/crates/conformance-server/src/tools.rs
@@ -461,49 +461,79 @@ impl TestElicitationDefaults {
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
     ) -> Result<CallToolResult, CallToolError> {
-        use rust_mcp_sdk::schema::schema_utils::{CustomRequest, RequestFromServer};
+        use rust_mcp_sdk::schema::{
+            BooleanSchema, ElicitFormSchema, ElicitRequestFormParams, ElicitRequestParams,
+            NumberSchema, NumberSchemaType, PrimitiveSchemaDefinition, StringSchema,
+            UntitledSingleSelectEnumSchema,
+        };
+        use std::collections::BTreeMap;
 
-        let params = serde_json::json!({
-            "message": "Please provide your information",
-            "requestedSchema": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "User's full name",
-                        "default": "John Doe"
-                    },
-                    "age": {
-                        "type": "integer",
-                        "description": "User's age",
-                        "default": 30
-                    },
-                    "score": {
-                        "type": "number",
-                        "description": "User's score",
-                        "default": 95.5
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Account status",
-                        "enum": ["active", "inactive", "pending"],
-                        "default": "active"
-                    },
-                    "verified": {
-                        "type": "boolean",
-                        "description": "Verification status",
-                        "default": true
-                    }
-                },
-                "required": []
-            }
-        });
+        let mut properties = BTreeMap::new();
+
+        properties.insert(
+            "name".into(),
+            PrimitiveSchemaDefinition::StringSchema(StringSchema::new(
+                Some("John Doe".into()),
+                Some("User's full name".into()),
+                None,
+                None,
+                None,
+                None,
+            )),
+        );
+
+        properties.insert(
+            "age".into(),
+            PrimitiveSchemaDefinition::NumberSchema(NumberSchema {
+                default: Some(30.0),
+                description: Some("User's age".into()),
+                title: None,
+                type_: NumberSchemaType::Integer,
+                maximum: None,
+                minimum: None,
+            }),
+        );
+
+        properties.insert(
+            "score".into(),
+            PrimitiveSchemaDefinition::NumberSchema(NumberSchema {
+                default: Some(95.5),
+                description: Some("User's score".into()),
+                title: None,
+                type_: NumberSchemaType::Number,
+                maximum: None,
+                minimum: None,
+            }),
+        );
+
+        properties.insert(
+            "status".into(),
+            PrimitiveSchemaDefinition::UntitledSingleSelectEnumSchema(
+                UntitledSingleSelectEnumSchema::new(
+                    vec!["active".into(), "inactive".into(), "pending".into()],
+                    Some("active".into()),
+                    Some("Account status".into()),
+                    None,
+                ),
+            ),
+        );
+
+        properties.insert(
+            "verified".into(),
+            PrimitiveSchemaDefinition::BooleanSchema(BooleanSchema::new(
+                Some(true),
+                Some("Verification status".into()),
+                None,
+            )),
+        );
+
+        let schema = ElicitFormSchema::new(properties, vec![], None);
+
+        let params: ElicitRequestParams =
+            ElicitRequestFormParams::new("Please provide your information".into(), schema, None, None).into();
 
         let response = runtime
-            .request(RequestFromServer::CustomRequest(CustomRequest {
-                method: "elicitation/create".to_string(),
-                params: Some(params.as_object().cloned().unwrap_or_default()),
-            }), None)
+            .request_elicitation(params)
             .await
             .map_err(|e| CallToolError::from_message(format!("Elicitation failed: {e}")))?;
 

--- a/crates/conformance-server/src/tools.rs
+++ b/crates/conformance-server/src/tools.rs
@@ -1,0 +1,680 @@
+use rust_mcp_macros::JsonSchema;
+use rust_mcp_sdk::{
+    macros::mcp_tool,
+    schema::{
+        schema_utils::CallToolError,
+        AudioContent, CallToolResult, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
+        ImageContent, TextContent, TextResourceContents,
+    },
+    tool_box,
+};
+
+const IMAGE_BASE64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+const AUDIO_BASE64: &str =
+    "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=";
+
+fn content_text(text: impl Into<String>) -> ContentBlock {
+    TextContent::new(text.into(), None, None).into()
+}
+
+fn content_image(data: &str, mime: &str) -> ContentBlock {
+    ImageContent::new(data.to_string(), mime.into(), None, None).into()
+}
+
+fn content_embedded_resource(text: &str, uri: &str, mime: &str) -> ContentBlock {
+    let trc = TextResourceContents::new(text.to_string(), uri.to_string()).with_mime_type(mime);
+    EmbeddedResource::new(EmbeddedResourceResource::TextResourceContents(trc), None, None).into()
+}
+
+// ---------------
+// 1. test_simple_text
+// ---------------
+#[mcp_tool(
+    name = "test_simple_text",
+    description = "Returns simple text content for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestSimpleText {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestSimpleText {
+    pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            "This is a simple text response for testing.".into(),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 2. test_image_content
+// ---------------
+#[mcp_tool(
+    name = "test_image_content",
+    description = "Returns image content (base64 PNG) for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestImageContent {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestImageContent {
+    pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
+        Ok(CallToolResult::image_content(vec![ImageContent::new(
+            IMAGE_BASE64.to_string(),
+            "image/png".into(),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 3. test_audio_content
+// ---------------
+#[mcp_tool(
+    name = "test_audio_content",
+    description = "Returns audio content (base64 WAV) for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestAudioContent {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestAudioContent {
+    pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
+        Ok(CallToolResult::audio_content(vec![AudioContent::new(
+            AUDIO_BASE64.to_string(),
+            "audio/wav".into(),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 4. test_embedded_resource
+// ---------------
+#[mcp_tool(
+    name = "test_embedded_resource",
+    description = "Returns embedded resource content for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestEmbeddedResource {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestEmbeddedResource {
+    pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
+        let block = content_embedded_resource(
+            "This is an embedded resource content.",
+            "test://embedded-resource",
+            "text/plain",
+        );
+        Ok(CallToolResult {
+            content: vec![block],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+    }
+}
+
+// ---------------
+// 5. test_multiple_content_types
+// ---------------
+#[mcp_tool(
+    name = "test_multiple_content_types",
+    description = "Returns multiple content types for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestMultipleContentTypes {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestMultipleContentTypes {
+    pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
+        Ok(CallToolResult {
+            content: vec![
+                content_text("Multiple content types test:"),
+                content_image(IMAGE_BASE64, "image/png"),
+                content_embedded_resource(
+                    r#"{"test":"data","value":123}"#,
+                    "test://mixed-content-resource",
+                    "application/json",
+                ),
+            ],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+    }
+}
+
+// ---------------
+// 6. test_error_handling
+// ---------------
+#[mcp_tool(
+    name = "test_error_handling",
+    description = "Returns an error response for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestErrorHandling {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestErrorHandling {
+    pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
+        Ok(CallToolResult {
+            content: vec![content_text(
+                "This tool intentionally returns an error for testing",
+            )],
+            is_error: Some(true),
+            meta: None,
+            structured_content: None,
+        })
+    }
+}
+
+// ---------------
+// 7. test_tool_with_logging
+// ---------------
+#[mcp_tool(
+    name = "test_tool_with_logging",
+    description = "Sends log messages during execution for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestToolWithLogging {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestToolWithLogging {
+    pub async fn call_tool(
+        &self,
+        runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        use rust_mcp_sdk::schema::{LoggingLevel, LoggingMessageNotificationParams};
+
+        runtime
+            .notify_log_message(LoggingMessageNotificationParams {
+                level: LoggingLevel::Info,
+                data: serde_json::Value::String("Tool execution started".into()),
+                logger: None,
+                meta: None,
+            })
+            .await
+            .map_err(|e| CallToolError::from_message(format!("{e}")))?;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        runtime
+            .notify_log_message(LoggingMessageNotificationParams {
+                level: LoggingLevel::Info,
+                data: serde_json::Value::String("Tool processing data".into()),
+                logger: None,
+                meta: None,
+            })
+            .await
+            .map_err(|e| CallToolError::from_message(format!("{e}")))?;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        runtime
+            .notify_log_message(LoggingMessageNotificationParams {
+                level: LoggingLevel::Info,
+                data: serde_json::Value::String("Tool execution completed".into()),
+                logger: None,
+                meta: None,
+            })
+            .await
+            .map_err(|e| CallToolError::from_message(format!("{e}")))?;
+
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            "Tool execution completed successfully".into(),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 8. test_tool_with_progress
+// ---------------
+#[mcp_tool(
+    name = "test_tool_with_progress",
+    description = "Reports progress notifications during execution for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestToolWithProgress {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestToolWithProgress {
+    pub async fn call_tool(
+        &self,
+        runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        use rust_mcp_sdk::schema::{ProgressNotificationParams, ProgressToken};
+
+        let token = ProgressToken::String("progress-test-1".into());
+
+        runtime
+            .notify_progress(ProgressNotificationParams {
+                progress_token: token.clone(),
+                progress: 0.0,
+                total: Some(100.0),
+                message: None,
+                meta: None,
+            })
+            .await
+            .map_err(|e| CallToolError::from_message(format!("{e}")))?;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        runtime
+            .notify_progress(ProgressNotificationParams {
+                progress_token: token.clone(),
+                progress: 50.0,
+                total: Some(100.0),
+                message: None,
+                meta: None,
+            })
+            .await
+            .map_err(|e| CallToolError::from_message(format!("{e}")))?;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        runtime
+            .notify_progress(ProgressNotificationParams {
+                progress_token: token,
+                progress: 100.0,
+                total: Some(100.0),
+                message: None,
+                meta: None,
+            })
+            .await
+            .map_err(|e| CallToolError::from_message(format!("{e}")))?;
+
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            "Progress test completed".into(),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 9. test_sampling
+// ---------------
+#[mcp_tool(
+    name = "test_sampling",
+    description = "Requests LLM sampling from the client for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestSampling {
+    pub prompt: String,
+}
+
+impl TestSampling {
+    pub async fn call_tool(
+        &self,
+        runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        use rust_mcp_sdk::schema::CreateMessageContent;
+
+        if !runtime.client_supports_sampling().unwrap_or(false) {
+            return Ok(CallToolResult {
+                content: vec![content_text(
+                    "Error: Client does not support sampling capability",
+                )],
+                is_error: Some(true),
+                meta: None,
+                structured_content: None,
+            });
+        }
+
+        let params: rust_mcp_sdk::schema::CreateMessageRequestParams =
+            serde_json::from_value(serde_json::json!({
+                "messages": [{
+                    "role": "user",
+                    "content": {
+                        "type": "text",
+                        "text": self.prompt
+                    }
+                }],
+                "maxTokens": 100
+            }))
+            .map_err(|e| CallToolError::from_message(format!("Failed to build params: {e}")))?;
+
+        let response = runtime
+            .request_message_creation(params)
+            .await
+            .map_err(|e| CallToolError::from_message(format!("Sampling failed: {e}")))?;
+
+        let response_text = match &response.content {
+            CreateMessageContent::TextContent(tc) => tc.text.clone(),
+            other => format!("{:?}", other),
+        };
+
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            format!("LLM response: {}", response_text),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 10. test_elicitation
+// ---------------
+#[mcp_tool(
+    name = "test_elicitation",
+    description = "Requests user input (elicitation) from the client for conformance testing."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestElicitation {
+    pub message: String,
+}
+
+impl TestElicitation {
+    pub async fn call_tool(
+        &self,
+        runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        use rust_mcp_sdk::schema::{
+            ElicitFormSchema, ElicitRequestFormParams, ElicitRequestParams,
+            PrimitiveSchemaDefinition, StringSchema,
+        };
+        use std::collections::BTreeMap;
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "username".into(),
+            PrimitiveSchemaDefinition::StringSchema(StringSchema::new(
+                None,
+                Some("User's name".into()),
+                None, None, None, None,
+            )),
+        );
+        properties.insert(
+            "email".into(),
+            PrimitiveSchemaDefinition::StringSchema(StringSchema::new(
+                None,
+                Some("User's email address".into()),
+                None, None, None, None,
+            )),
+        );
+
+        let schema = ElicitFormSchema::new(properties, vec!["username".into(), "email".into()], None);
+        let params: ElicitRequestParams =
+            ElicitRequestFormParams::new(self.message.clone(), schema, None, None).into();
+
+        let response = runtime
+            .request_elicitation(params)
+            .await
+            .map_err(|e| CallToolError::from_message(format!("Elicitation failed: {e}")))?;
+
+        let content_text = serde_json::to_string_pretty(&response)
+            .unwrap_or_else(|_| "Unable to serialize response".into());
+
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            format!(
+                "User response: action={:?}, content={}",
+                response.action, content_text
+            ),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 11. test_elicitation_sep1034_defaults
+// ---------------
+#[mcp_tool(
+    name = "test_elicitation_sep1034_defaults",
+    description = "Requests elicitation with default values for all primitive types (SEP-1034)."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestElicitationDefaults {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestElicitationDefaults {
+    pub async fn call_tool(
+        &self,
+        runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        use rust_mcp_sdk::schema::schema_utils::{CustomRequest, RequestFromServer};
+
+        let params = serde_json::json!({
+            "message": "Please provide your information",
+            "requestedSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "User's full name",
+                        "default": "John Doe"
+                    },
+                    "age": {
+                        "type": "integer",
+                        "description": "User's age",
+                        "default": 30
+                    },
+                    "score": {
+                        "type": "number",
+                        "description": "User's score",
+                        "default": 95.5
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Account status",
+                        "enum": ["active", "inactive", "pending"],
+                        "default": "active"
+                    },
+                    "verified": {
+                        "type": "boolean",
+                        "description": "Verification status",
+                        "default": true
+                    }
+                },
+                "required": []
+            }
+        });
+
+        let response = runtime
+            .request(RequestFromServer::CustomRequest(CustomRequest {
+                method: "elicitation/create".to_string(),
+                params: Some(params.as_object().cloned().unwrap_or_default()),
+            }), None)
+            .await
+            .map_err(|e| CallToolError::from_message(format!("Elicitation failed: {e}")))?;
+
+        let content_text = serde_json::to_string_pretty(&response)
+            .unwrap_or_else(|_| "Unable to serialize response".into());
+
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            format!("Elicitation completed: content={}", content_text),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// 12. test_elicitation_sep1330_enums
+// ---------------
+#[mcp_tool(
+    name = "test_elicitation_sep1330_enums",
+    description = "Requests elicitation with all enum variants (SEP-1330)."
+)]
+#[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
+pub struct TestElicitationEnums {
+    #[serde(default, skip_serializing)]
+    _dummy: Option<()>,
+}
+
+impl TestElicitationEnums {
+    pub async fn call_tool(
+        &self,
+        runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        use rust_mcp_sdk::schema::{
+            ElicitFormSchema, ElicitRequestFormParams, ElicitRequestParams,
+            LegacyTitledEnumSchema, PrimitiveSchemaDefinition, TitledMultiSelectEnumSchema,
+            TitledMultiSelectEnumSchemaItems, TitledMultiSelectEnumSchemaItemsAnyOfItem,
+            TitledSingleSelectEnumSchema, TitledSingleSelectEnumSchemaOneOfItem,
+            UntitledMultiSelectEnumSchema, UntitledMultiSelectEnumSchemaItems,
+            UntitledSingleSelectEnumSchema,
+        };
+        use std::collections::BTreeMap;
+
+        let mut properties = BTreeMap::new();
+
+        properties.insert(
+            "untitledSingle".into(),
+            PrimitiveSchemaDefinition::UntitledSingleSelectEnumSchema(
+                UntitledSingleSelectEnumSchema::new(
+                    vec!["option1".into(), "option2".into(), "option3".into()],
+                    None,
+                    Some("Untitled single-select".into()),
+                    None,
+                ),
+            ),
+        );
+
+        properties.insert(
+            "titledSingle".into(),
+            PrimitiveSchemaDefinition::TitledSingleSelectEnumSchema(
+                TitledSingleSelectEnumSchema::new(
+                    vec![
+                        TitledSingleSelectEnumSchemaOneOfItem {
+                            const_: "value1".into(),
+                            title: "First Option".into(),
+                        },
+                        TitledSingleSelectEnumSchemaOneOfItem {
+                            const_: "value2".into(),
+                            title: "Second Option".into(),
+                        },
+                        TitledSingleSelectEnumSchemaOneOfItem {
+                            const_: "value3".into(),
+                            title: "Third Option".into(),
+                        },
+                    ],
+                    None,
+                    Some("Titled single-select".into()),
+                    None,
+                ),
+            ),
+        );
+
+        properties.insert(
+            "legacyEnum".into(),
+            PrimitiveSchemaDefinition::LegacyTitledEnumSchema(
+                LegacyTitledEnumSchema::new(
+                    vec!["opt1".into(), "opt2".into(), "opt3".into()],
+                    vec!["Option One".into(), "Option Two".into(), "Option Three".into()],
+                    None,
+                    Some("Legacy titled enum".into()),
+                    None,
+                ),
+            ),
+        );
+
+        properties.insert(
+            "untitledMulti".into(),
+            PrimitiveSchemaDefinition::UntitledMultiSelectEnumSchema(
+                UntitledMultiSelectEnumSchema::new(
+                    vec![],
+                    UntitledMultiSelectEnumSchemaItems::new(vec![
+                        "option1".into(), "option2".into(), "option3".into(),
+                    ]),
+                    Some("Untitled multi-select".into()),
+                    None,
+                    None,
+                    None,
+                ),
+            ),
+        );
+
+        properties.insert(
+            "titledMulti".into(),
+            PrimitiveSchemaDefinition::TitledMultiSelectEnumSchema(
+                TitledMultiSelectEnumSchema::new(
+                    vec![],
+                    TitledMultiSelectEnumSchemaItems {
+                        any_of: vec![
+                            TitledMultiSelectEnumSchemaItemsAnyOfItem {
+                                const_: "value1".into(),
+                                title: "First Choice".into(),
+                            },
+                            TitledMultiSelectEnumSchemaItemsAnyOfItem {
+                                const_: "value2".into(),
+                                title: "Second Choice".into(),
+                            },
+                            TitledMultiSelectEnumSchemaItemsAnyOfItem {
+                                const_: "value3".into(),
+                                title: "Third Choice".into(),
+                            },
+                        ],
+                    },
+                    Some("Titled multi-select".into()),
+                    None,
+                    None,
+                    None,
+                ),
+            ),
+        );
+
+        let schema = ElicitFormSchema::new(properties, vec![], None);
+
+        let params: ElicitRequestParams =
+            ElicitRequestFormParams::new("Select from enum options".into(), schema, None, None).into();
+
+        let response = runtime
+            .request_elicitation(params)
+            .await
+            .map_err(|e| CallToolError::from_message(format!("Elicitation failed: {e}")))?;
+
+        let content_text = serde_json::to_string_pretty(&response)
+            .unwrap_or_else(|_| "Unable to serialize response".into());
+
+        Ok(CallToolResult::text_content(vec![TextContent::new(
+            format!("Elicitation completed: content={}", content_text),
+            None,
+            None,
+        )]))
+    }
+}
+
+// ---------------
+// Tool box
+// ---------------
+tool_box!(ConformanceTools, [
+    TestSimpleText,
+    TestImageContent,
+    TestAudioContent,
+    TestEmbeddedResource,
+    TestMultipleContentTypes,
+    TestErrorHandling,
+    TestToolWithLogging,
+    TestToolWithProgress,
+    TestSampling,
+    TestElicitation,
+    TestElicitationDefaults,
+    TestElicitationEnums,
+]);

--- a/crates/conformance-server/src/tools.rs
+++ b/crates/conformance-server/src/tools.rs
@@ -39,12 +39,12 @@ fn content_embedded_resource(text: &str, uri: &str, mime: &str) -> ContentBlock 
     description = "Returns simple text content for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestSimpleText {
+pub struct SimpleTextTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestSimpleText {
+impl SimpleTextTool {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult::text_content(vec![TextContent::new(
             "This is a simple text response for testing.".into(),
@@ -62,12 +62,12 @@ impl TestSimpleText {
     description = "Returns image content (base64 PNG) for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestImageContent {
+pub struct ImageContentTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestImageContent {
+impl ImageContentTool {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult::image_content(vec![ImageContent::new(
             IMAGE_BASE64.to_string(),
@@ -86,12 +86,12 @@ impl TestImageContent {
     description = "Returns audio content (base64 WAV) for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestAudioContent {
+pub struct AudioContentTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestAudioContent {
+impl AudioContentTool {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult::audio_content(vec![AudioContent::new(
             AUDIO_BASE64.to_string(),
@@ -110,12 +110,12 @@ impl TestAudioContent {
     description = "Returns embedded resource content for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestEmbeddedResource {
+pub struct EmbeddedResourceTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestEmbeddedResource {
+impl EmbeddedResourceTool {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         let block = content_embedded_resource(
             "This is an embedded resource content.",
@@ -139,12 +139,12 @@ impl TestEmbeddedResource {
     description = "Returns multiple content types for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestMultipleContentTypes {
+pub struct MultipleContentTypesTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestMultipleContentTypes {
+impl MultipleContentTypesTool {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult {
             content: vec![
@@ -171,12 +171,12 @@ impl TestMultipleContentTypes {
     description = "Returns an error response for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestErrorHandling {
+pub struct ErrorHandlingTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestErrorHandling {
+impl ErrorHandlingTool {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult {
             content: vec![content_text(
@@ -197,12 +197,12 @@ impl TestErrorHandling {
     description = "Sends log messages during execution for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestToolWithLogging {
+pub struct LoggingTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestToolWithLogging {
+impl LoggingTool {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -259,12 +259,12 @@ impl TestToolWithLogging {
     description = "Reports progress notifications during execution for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestToolWithProgress {
+pub struct ProgressTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestToolWithProgress {
+impl ProgressTool {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -327,11 +327,11 @@ impl TestToolWithProgress {
     description = "Requests LLM sampling from the client for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestSampling {
+pub struct SamplingTool {
     pub prompt: String,
 }
 
-impl TestSampling {
+impl SamplingTool {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -388,11 +388,11 @@ impl TestSampling {
     description = "Requests user input (elicitation) from the client for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestElicitation {
+pub struct ElicitationTool {
     pub message: String,
 }
 
-impl TestElicitation {
+impl ElicitationTool {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -459,12 +459,12 @@ impl TestElicitation {
     description = "Requests elicitation with default values for all primitive types (SEP-1034)."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestElicitationDefaults {
+pub struct ElicitationDefaultsTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestElicitationDefaults {
+impl ElicitationDefaultsTool {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -569,12 +569,12 @@ impl TestElicitationDefaults {
     description = "Requests elicitation with all enum variants (SEP-1330)."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct TestElicitationEnums {
+pub struct ElicitationEnumsTool {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl TestElicitationEnums {
+impl ElicitationEnumsTool {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -718,17 +718,17 @@ impl TestElicitationEnums {
 tool_box!(
     ConformanceTools,
     [
-        TestSimpleText,
-        TestImageContent,
-        TestAudioContent,
-        TestEmbeddedResource,
-        TestMultipleContentTypes,
-        TestErrorHandling,
-        TestToolWithLogging,
-        TestToolWithProgress,
-        TestSampling,
-        TestElicitation,
-        TestElicitationDefaults,
-        TestElicitationEnums,
+        SimpleTextTool,
+        ImageContentTool,
+        AudioContentTool,
+        EmbeddedResourceTool,
+        MultipleContentTypesTool,
+        ErrorHandlingTool,
+        LoggingTool,
+        ProgressTool,
+        SamplingTool,
+        ElicitationTool,
+        ElicitationDefaultsTool,
+        ElicitationEnumsTool,
     ]
 );

--- a/crates/conformance-server/src/tools.rs
+++ b/crates/conformance-server/src/tools.rs
@@ -2,9 +2,8 @@ use rust_mcp_macros::JsonSchema;
 use rust_mcp_sdk::{
     macros::mcp_tool,
     schema::{
-        schema_utils::CallToolError,
-        AudioContent, CallToolResult, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
-        ImageContent, TextContent, TextResourceContents,
+        schema_utils::CallToolError, AudioContent, CallToolResult, ContentBlock, EmbeddedResource,
+        EmbeddedResourceResource, ImageContent, TextContent, TextResourceContents,
     },
     tool_box,
 };
@@ -12,8 +11,7 @@ use rust_mcp_sdk::{
 const IMAGE_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
 
-const AUDIO_BASE64: &str =
-    "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=";
+const AUDIO_BASE64: &str = "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=";
 
 fn content_text(text: impl Into<String>) -> ContentBlock {
     TextContent::new(text.into(), None, None).into()
@@ -25,7 +23,12 @@ fn content_image(data: &str, mime: &str) -> ContentBlock {
 
 fn content_embedded_resource(text: &str, uri: &str, mime: &str) -> ContentBlock {
     let trc = TextResourceContents::new(text.to_string(), uri.to_string()).with_mime_type(mime);
-    EmbeddedResource::new(EmbeddedResourceResource::TextResourceContents(trc), None, None).into()
+    EmbeddedResource::new(
+        EmbeddedResourceResource::TextResourceContents(trc),
+        None,
+        None,
+    )
+    .into()
 }
 
 // ---------------
@@ -269,9 +272,7 @@ impl TestToolWithProgress {
     ) -> Result<CallToolResult, CallToolError> {
         use rust_mcp_sdk::schema::{ProgressNotificationParams, ProgressToken};
 
-        let token = progress_token.unwrap_or(ProgressToken::String(
-            "progress-test-1".into(),
-        ));
+        let token = progress_token.unwrap_or(ProgressToken::String("progress-test-1".into()));
 
         runtime
             .notify_progress(ProgressNotificationParams {
@@ -408,7 +409,10 @@ impl TestElicitation {
             PrimitiveSchemaDefinition::StringSchema(StringSchema::new(
                 None,
                 Some("User's name".into()),
-                None, None, None, None,
+                None,
+                None,
+                None,
+                None,
             )),
         );
         properties.insert(
@@ -416,11 +420,15 @@ impl TestElicitation {
             PrimitiveSchemaDefinition::StringSchema(StringSchema::new(
                 None,
                 Some("User's email address".into()),
-                None, None, None, None,
+                None,
+                None,
+                None,
+                None,
             )),
         );
 
-        let schema = ElicitFormSchema::new(properties, vec!["username".into(), "email".into()], None);
+        let schema =
+            ElicitFormSchema::new(properties, vec!["username".into(), "email".into()], None);
         let params: ElicitRequestParams =
             ElicitRequestFormParams::new(self.message.clone(), schema, None, None).into();
 
@@ -529,8 +537,13 @@ impl TestElicitationDefaults {
 
         let schema = ElicitFormSchema::new(properties, vec![], None);
 
-        let params: ElicitRequestParams =
-            ElicitRequestFormParams::new("Please provide your information".into(), schema, None, None).into();
+        let params: ElicitRequestParams = ElicitRequestFormParams::new(
+            "Please provide your information".into(),
+            schema,
+            None,
+            None,
+        )
+        .into();
 
         let response = runtime
             .request_elicitation(params)
@@ -567,8 +580,8 @@ impl TestElicitationEnums {
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
     ) -> Result<CallToolResult, CallToolError> {
         use rust_mcp_sdk::schema::{
-            ElicitFormSchema, ElicitRequestFormParams, ElicitRequestParams,
-            LegacyTitledEnumSchema, PrimitiveSchemaDefinition, TitledMultiSelectEnumSchema,
+            ElicitFormSchema, ElicitRequestFormParams, ElicitRequestParams, LegacyTitledEnumSchema,
+            PrimitiveSchemaDefinition, TitledMultiSelectEnumSchema,
             TitledMultiSelectEnumSchemaItems, TitledMultiSelectEnumSchemaItemsAnyOfItem,
             TitledSingleSelectEnumSchema, TitledSingleSelectEnumSchemaOneOfItem,
             UntitledMultiSelectEnumSchema, UntitledMultiSelectEnumSchemaItems,
@@ -617,15 +630,17 @@ impl TestElicitationEnums {
 
         properties.insert(
             "legacyEnum".into(),
-            PrimitiveSchemaDefinition::LegacyTitledEnumSchema(
-                LegacyTitledEnumSchema::new(
-                    vec!["opt1".into(), "opt2".into(), "opt3".into()],
-                    vec!["Option One".into(), "Option Two".into(), "Option Three".into()],
-                    None,
-                    Some("Legacy titled enum".into()),
-                    None,
-                ),
-            ),
+            PrimitiveSchemaDefinition::LegacyTitledEnumSchema(LegacyTitledEnumSchema::new(
+                vec!["opt1".into(), "opt2".into(), "opt3".into()],
+                vec![
+                    "Option One".into(),
+                    "Option Two".into(),
+                    "Option Three".into(),
+                ],
+                None,
+                Some("Legacy titled enum".into()),
+                None,
+            )),
         );
 
         properties.insert(
@@ -634,7 +649,9 @@ impl TestElicitationEnums {
                 UntitledMultiSelectEnumSchema::new(
                     vec![],
                     UntitledMultiSelectEnumSchemaItems::new(vec![
-                        "option1".into(), "option2".into(), "option3".into(),
+                        "option1".into(),
+                        "option2".into(),
+                        "option3".into(),
                     ]),
                     Some("Untitled multi-select".into()),
                     None,
@@ -676,7 +693,8 @@ impl TestElicitationEnums {
         let schema = ElicitFormSchema::new(properties, vec![], None);
 
         let params: ElicitRequestParams =
-            ElicitRequestFormParams::new("Select from enum options".into(), schema, None, None).into();
+            ElicitRequestFormParams::new("Select from enum options".into(), schema, None, None)
+                .into();
 
         let response = runtime
             .request_elicitation(params)
@@ -697,17 +715,20 @@ impl TestElicitationEnums {
 // ---------------
 // Tool box
 // ---------------
-tool_box!(ConformanceTools, [
-    TestSimpleText,
-    TestImageContent,
-    TestAudioContent,
-    TestEmbeddedResource,
-    TestMultipleContentTypes,
-    TestErrorHandling,
-    TestToolWithLogging,
-    TestToolWithProgress,
-    TestSampling,
-    TestElicitation,
-    TestElicitationDefaults,
-    TestElicitationEnums,
-]);
+tool_box!(
+    ConformanceTools,
+    [
+        TestSimpleText,
+        TestImageContent,
+        TestAudioContent,
+        TestEmbeddedResource,
+        TestMultipleContentTypes,
+        TestErrorHandling,
+        TestToolWithLogging,
+        TestToolWithProgress,
+        TestSampling,
+        TestElicitation,
+        TestElicitationDefaults,
+        TestElicitationEnums,
+    ]
+);

--- a/crates/conformance-server/src/tools.rs
+++ b/crates/conformance-server/src/tools.rs
@@ -265,10 +265,13 @@ impl TestToolWithProgress {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
+        progress_token: Option<rust_mcp_sdk::schema::ProgressToken>,
     ) -> Result<CallToolResult, CallToolError> {
         use rust_mcp_sdk::schema::{ProgressNotificationParams, ProgressToken};
 
-        let token = ProgressToken::String("progress-test-1".into());
+        let token = progress_token.unwrap_or(ProgressToken::String(
+            "progress-test-1".into(),
+        ));
 
         runtime
             .notify_progress(ProgressNotificationParams {

--- a/crates/conformance-server/src/tools.rs
+++ b/crates/conformance-server/src/tools.rs
@@ -39,12 +39,12 @@ fn content_embedded_resource(text: &str, uri: &str, mime: &str) -> ContentBlock 
     description = "Returns simple text content for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct SimpleTextTool {
+pub struct TestSimpleText {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl SimpleTextTool {
+impl TestSimpleText {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult::text_content(vec![TextContent::new(
             "This is a simple text response for testing.".into(),
@@ -62,12 +62,12 @@ impl SimpleTextTool {
     description = "Returns image content (base64 PNG) for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct ImageContentTool {
+pub struct TestImageContent {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl ImageContentTool {
+impl TestImageContent {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult::image_content(vec![ImageContent::new(
             IMAGE_BASE64.to_string(),
@@ -86,12 +86,12 @@ impl ImageContentTool {
     description = "Returns audio content (base64 WAV) for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct AudioContentTool {
+pub struct TestAudioContent {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl AudioContentTool {
+impl TestAudioContent {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult::audio_content(vec![AudioContent::new(
             AUDIO_BASE64.to_string(),
@@ -110,12 +110,12 @@ impl AudioContentTool {
     description = "Returns embedded resource content for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct EmbeddedResourceTool {
+pub struct TestEmbeddedResource {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl EmbeddedResourceTool {
+impl TestEmbeddedResource {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         let block = content_embedded_resource(
             "This is an embedded resource content.",
@@ -139,12 +139,12 @@ impl EmbeddedResourceTool {
     description = "Returns multiple content types for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct MultipleContentTypesTool {
+pub struct TestMultipleContentTypes {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl MultipleContentTypesTool {
+impl TestMultipleContentTypes {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult {
             content: vec![
@@ -171,12 +171,12 @@ impl MultipleContentTypesTool {
     description = "Returns an error response for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct ErrorHandlingTool {
+pub struct TestErrorHandling {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl ErrorHandlingTool {
+impl TestErrorHandling {
     pub fn call_tool(&self) -> Result<CallToolResult, CallToolError> {
         Ok(CallToolResult {
             content: vec![content_text(
@@ -197,12 +197,12 @@ impl ErrorHandlingTool {
     description = "Sends log messages during execution for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct LoggingTool {
+pub struct TestToolWithLogging {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl LoggingTool {
+impl TestToolWithLogging {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -259,12 +259,12 @@ impl LoggingTool {
     description = "Reports progress notifications during execution for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct ProgressTool {
+pub struct TestToolWithProgress {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl ProgressTool {
+impl TestToolWithProgress {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -327,11 +327,11 @@ impl ProgressTool {
     description = "Requests LLM sampling from the client for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct SamplingTool {
+pub struct TestSampling {
     pub prompt: String,
 }
 
-impl SamplingTool {
+impl TestSampling {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -388,11 +388,11 @@ impl SamplingTool {
     description = "Requests user input (elicitation) from the client for conformance testing."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct ElicitationTool {
+pub struct TestElicitation {
     pub message: String,
 }
 
-impl ElicitationTool {
+impl TestElicitation {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -459,12 +459,12 @@ impl ElicitationTool {
     description = "Requests elicitation with default values for all primitive types (SEP-1034)."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct ElicitationDefaultsTool {
+pub struct TestElicitationDefaults {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl ElicitationDefaultsTool {
+impl TestElicitationDefaults {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -569,12 +569,12 @@ impl ElicitationDefaultsTool {
     description = "Requests elicitation with all enum variants (SEP-1330)."
 )]
 #[derive(Debug, ::serde::Deserialize, ::serde::Serialize, JsonSchema)]
-pub struct ElicitationEnumsTool {
+pub struct TestElicitationEnums {
     #[serde(default, skip_serializing)]
     _dummy: Option<()>,
 }
 
-impl ElicitationEnumsTool {
+impl TestElicitationEnums {
     pub async fn call_tool(
         &self,
         runtime: &std::sync::Arc<dyn rust_mcp_sdk::McpServer>,
@@ -718,17 +718,17 @@ impl ElicitationEnumsTool {
 tool_box!(
     ConformanceTools,
     [
-        SimpleTextTool,
-        ImageContentTool,
-        AudioContentTool,
-        EmbeddedResourceTool,
-        MultipleContentTypesTool,
-        ErrorHandlingTool,
-        LoggingTool,
-        ProgressTool,
-        SamplingTool,
-        ElicitationTool,
-        ElicitationDefaultsTool,
-        ElicitationEnumsTool,
+        TestSimpleText,
+        TestImageContent,
+        TestAudioContent,
+        TestEmbeddedResource,
+        TestMultipleContentTypes,
+        TestErrorHandling,
+        TestToolWithLogging,
+        TestToolWithProgress,
+        TestSampling,
+        TestElicitation,
+        TestElicitationDefaults,
+        TestElicitationEnums,
     ]
 );

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -29,6 +29,13 @@ use tokio::sync::{mpsc, oneshot, watch, RwLock, RwLockReadGuard};
 pub const DEFAULT_STREAM_ID: &str = "STANDALONE-STREAM";
 const TASK_CHANNEL_CAPACITY: usize = 500;
 
+tokio::task_local! {
+    /// Per-request transport for sending notifications on the POST response SSE stream.
+    /// Set via `scope()` in spawned handler tasks. Read by `send()` for notification routing.
+    /// Falls back to the GET standalone stream when not set (background tasks, on_initialized, etc.).
+    pub(crate) static ACTIVE_REQUEST_TRANSPORT: TransportType;
+}
+
 // Define a type alias for the TransportDispatcher trait object
 type TransportType = Arc<
     dyn TransportDispatcher<
@@ -136,22 +143,41 @@ impl McpServer for ServerRuntime {
         request_id: Option<RequestId>,
         request_timeout: Option<Duration>,
     ) -> SdkResult<Option<ClientMessage>> {
+        let outgoing_request_id = self
+            .request_id_gen
+            .request_id_for_message(&message, request_id);
+
+        // For notifications during a request (tool call), route through the
+        // active POST response stream so the client receives them during
+        // `request()`. Fall back to the GET standalone stream if there is no
+        // active POST stream.
+        let is_notification =
+            matches!(&message, MessageFromServer::NotificationFromServer(_));
+
+        if is_notification {
+            if let Ok(req_transport) = ACTIVE_REQUEST_TRANSPORT.try_with(|t| t.clone()) {
+                let mcp_message = ServerMessage::from_message(message, outgoing_request_id)?;
+                if let Some(observer) = self.message_observer.as_ref() {
+                    observer.on_send(&mcp_message);
+                }
+                return Ok(req_transport
+                    .send_message(ServerMessages::Single(mcp_message), request_timeout)
+                    .await?
+                    .map(|res| res.as_single())
+                    .transpose()?);
+            }
+        }
+
+        let mcp_message = ServerMessage::from_message(message, outgoing_request_id)?;
+        if let Some(observer) = self.message_observer.as_ref() {
+            observer.on_send(&mcp_message);
+        }
+
         let transport_map = self.transport_map.read().await;
         let transport = transport_map.as_ref().ok_or(
             RpcError::internal_error()
                 .with_message("transport stream does not exists or is closed!".to_string()),
         )?;
-
-        let outgoing_request_id = self
-            .request_id_gen
-            .request_id_for_message(&message, request_id);
-
-        let mcp_message = ServerMessage::from_message(message, outgoing_request_id)?;
-
-        // telemetry
-        if let Some(observer) = self.message_observer.as_ref() {
-            observer.on_send(&mcp_message);
-        }
 
         let response = transport
             .send_message(ServerMessages::Single(mcp_message), request_timeout)
@@ -525,7 +551,7 @@ impl ServerRuntime {
                             let transport = transport.clone();
                             let self_clone = self.clone();
                             let tx = tx.clone();
-                            tokio::spawn(async move {
+                            tokio::spawn(ACTIVE_REQUEST_TRANSPORT.scope(transport.clone(), async move {
 
                                 let result = self_clone.handle_message(client_message, &transport).await;
 
@@ -548,7 +574,7 @@ impl ServerRuntime {
                                 if let Err(error) = tx.send(send_result).await {
                                     tracing::error!("Failed to send batch result to channel: {}", error);
                                 }
-                            });
+                            }));
                         }
                         ClientMessages::Batch(client_messages) => {
 
@@ -556,7 +582,7 @@ impl ServerRuntime {
                             let self_clone = self_clone.clone();
                             let tx = tx.clone();
 
-                            tokio::spawn(async move {
+                            tokio::spawn(ACTIVE_REQUEST_TRANSPORT.scope(transport.clone(), async move {
                                 let handling_tasks: Vec<_> = client_messages
                                     .into_iter()
                                     .map(|client_message| self_clone.handle_message(client_message, &transport))
@@ -578,7 +604,7 @@ impl ServerRuntime {
                                     if let Err(error) = tx.send(send_result).await {
                                         tracing::error!("Failed to send batch result to channel: {}", error);
                                     }
-                            });
+                            }));
                         }
                     }
 
@@ -589,7 +615,6 @@ impl ServerRuntime {
 
                     // close the stream after all messages are sent, unless it is a standalone stream
                     if !stream_id.eq(DEFAULT_STREAM_ID){
-                        // Drop tx to close the channel and collect remaining results
                         drop(tx);
                         while let Some(result) = rx.recv().await {
                             result?; // Propagate errors

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -151,8 +151,7 @@ impl McpServer for ServerRuntime {
         // active POST response stream so the client receives them during
         // `request()`. Fall back to the GET standalone stream if there is no
         // active POST stream.
-        let is_notification =
-            matches!(&message, MessageFromServer::NotificationFromServer(_));
+        let is_notification = matches!(&message, MessageFromServer::NotificationFromServer(_));
 
         if is_notification {
             if let Ok(req_transport) = ACTIVE_REQUEST_TRANSPORT.try_with(|t| t.clone()) {


### PR DESCRIPTION
### 📌 Summary
Adds MCP conformance test infrastructure: a 40/40 conformance server, GitHub Actions CI, and tier-check tooling. Moves the SDK toward Tier 1 readiness per SEP-1730.


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- **New `crates/conformance-server/`** — Implements all 40 MCP server conformance scenarios (tools, resources, prompts, elicitation, sampling, completions, logging, subscriptions, DNS rebinding)
- **New `.github/workflows/conformance.yml`** — 🧪 CI job that builds the server, starts it, polls health, and runs `modelcontextprotocol/conformance@v0.1.16`
- **New `.github/dependabot.yml`** — Weekly cargo + GitHub Actions dep updates
- **New `SECURITY.md`** — Vulnerability reporting process
- **`server_runtime.rs`** — `task_local!` notification routing fix to support `tools-call-with-progress` scenario
- **`Cargo.toml` / `Cargo.lock`** — Workspace member and dependency updates


### 🛠️ Testing Steps
<!-- Explain how reviewers can test your changes, if applicable -->
```bash
# Local conformance test
cargo run -p conformance-server --release &
npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp
```
### 💡 Additional Notes
- Server conformance: **40/40 passing** (targeting 2025-11-25 spec)
- CI uses `Swatinem/rust-cache@v2` with `shared-key` for cross-branch build caching
