### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -2,9 +2,9 @@
   "crates/rust-mcp-sdk": "0.10.0",
   "crates/rust-mcp-macros": "0.9.1",
   "crates/rust-mcp-transport": "0.9.1",
-  "crates/rust-mcp-extra": "0.3.1",
-  "crates/rust-mcp-axum": "0.2.1",
-  "crates/rust-mcp-actix": "0.1.2",
+  "crates/rust-mcp-extra": "0.3.2",
+  "crates/rust-mcp-axum": "0.2.2",
+  "crates/rust-mcp-actix": "0.1.3",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",
@@ -17,5 +17,5 @@
   "examples/simple-mcp-client-streamable-http-core": "0.1.5",
   "examples/auth/server-oauth-remote": "0.1.35",
   "crates/conformance-client": "0.1.1",
-  "crates/conformance-server": "0.1.2"
+  "crates/conformance-server": "0.1.3"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-actix"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-axum"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ rust-mcp-transport = { version = "0.9.1", path = "crates/rust-mcp-transport", de
 rust-mcp-sdk = { version = "0.10.0", path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "0.9.1", path = "crates/rust-mcp-macros", default-features = false }
 rust-mcp-extra = { version="0.1.0", path = "crates/rust-mcp-extra", default-features = false }
-rust-mcp-axum = { version = "0.2.1", path = "crates/rust-mcp-axum" }
-rust-mcp-actix = { version = "0.1.2", path = "crates/rust-mcp-actix" }
+rust-mcp-axum = { version = "0.2.2", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "0.1.3", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version="0.10",  default-features = false }

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test server — implements all scenarios from the MCP conformance suite. Also serves as a reference implementation showing how to build a fully-featured MCP server with rust-mcp-sdk."

--- a/crates/rust-mcp-actix/CHANGELOG.md
+++ b/crates/rust-mcp-actix/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.2...rust-mcp-actix-v0.1.3) (2026-06-24)
+
+
+### 🐛 Bug Fixes
+
+* Initial publish ([0d815bd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0d815bdf7cda2fd8dc6fe7626a317fe6d2a024bf))
+
 ## [0.1.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.1...rust-mcp-actix-v0.1.2) (2026-06-24)
 
 

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-actix"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Ali Hashemi"]
 description = "Actix-web HTTP server integration for rust-mcp-sdk"
 repository = "https://github.com/rust-mcp-stack/rust-mcp-sdk"

--- a/crates/rust-mcp-axum/CHANGELOG.md
+++ b/crates/rust-mcp-axum/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.1...rust-mcp-axum-v0.2.2) (2026-06-24)
+
+
+### 🐛 Bug Fixes
+
+* Initial publish ([0d815bd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0d815bdf7cda2fd8dc6fe7626a317fe6d2a024bf))
+
 ## [0.2.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.0...rust-mcp-axum-v0.2.1) (2026-06-24)
 
 

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-axum"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "Axum HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.3.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.1...rust-mcp-extra-v0.3.2) (2026-06-24)
+
 ## [0.3.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.0...rust-mcp-extra-v0.3.1) (2026-06-24)
 
 ## [0.3.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.2.4...rust-mcp-extra-v0.3.0) (2026-06-24)

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>conformance-server: 0.1.3</summary>

### Dependencies


</details>

<details><summary>rust-mcp-actix: 0.1.3</summary>

## [0.1.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.2...rust-mcp-actix-v0.1.3) (2026-06-24)


### 🐛 Bug Fixes

* Initial publish ([0d815bd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0d815bdf7cda2fd8dc6fe7626a317fe6d2a024bf))
</details>

<details><summary>rust-mcp-axum: 0.2.2</summary>

## [0.2.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.1...rust-mcp-axum-v0.2.2) (2026-06-24)


### 🐛 Bug Fixes

* Initial publish ([0d815bd](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/0d815bdf7cda2fd8dc6fe7626a317fe6d2a024bf))
</details>

<details><summary>rust-mcp-extra: 0.3.2</summary>

## [0.3.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.1...rust-mcp-extra-v0.3.2) (2026-06-24)
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).