### PR TITLE
fix: race condition in the Streamable HTTP transport setup

### DIFF
--- a/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
+++ b/crates/rust-mcp-sdk/src/mcp_handlers/mcp_server_handler.rs
@@ -88,7 +88,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<ListResourcesResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &ListResourcesRequest::method_value(),
+            ListResourcesRequest::method_value(),
         )))
     }
 
@@ -103,7 +103,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<ListResourceTemplatesResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &ListResourceTemplatesRequest::method_value(),
+            ListResourceTemplatesRequest::method_value(),
         )))
     }
 
@@ -118,7 +118,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<ReadResourceResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &ReadResourceRequest::method_value(),
+            ReadResourceRequest::method_value(),
         )))
     }
 
@@ -133,7 +133,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<Result, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &SubscribeRequest::method_value(),
+            SubscribeRequest::method_value(),
         )))
     }
 
@@ -148,7 +148,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<Result, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &UnsubscribeRequest::method_value(),
+            UnsubscribeRequest::method_value(),
         )))
     }
 
@@ -163,7 +163,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<ListPromptsResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &ListPromptsRequest::method_value(),
+            ListPromptsRequest::method_value(),
         )))
     }
 
@@ -178,7 +178,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<GetPromptResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &GetPromptRequest::method_value(),
+            GetPromptRequest::method_value(),
         )))
     }
 
@@ -193,7 +193,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<ListToolsResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &ListToolsRequest::method_value(),
+            ListToolsRequest::method_value(),
         )))
     }
 
@@ -238,7 +238,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<Result, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &SetLevelRequest::method_value(),
+            SetLevelRequest::method_value(),
         )))
     }
 
@@ -253,7 +253,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<CompleteResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &CompleteRequest::method_value(),
+            CompleteRequest::method_value(),
         )))
     }
 
@@ -265,7 +265,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<GetTaskResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &GetTaskRequest::method_value(),
+            GetTaskRequest::method_value(),
         )))
     }
 
@@ -277,7 +277,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<GetTaskPayloadResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &GetTaskPayloadRequest::method_value(),
+            GetTaskPayloadRequest::method_value(),
         )))
     }
 
@@ -289,7 +289,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<CancelTaskResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &CancelTaskRequest::method_value(),
+            CancelTaskRequest::method_value(),
         )))
     }
 
@@ -301,7 +301,7 @@ pub trait ServerHandler: Send + Sync + 'static {
     ) -> std::result::Result<ListTasksResult, RpcError> {
         Err(RpcError::method_not_found().with_message(format!(
             "No handler is implemented for '{}'.",
-            &ListTasksRequest::method_value(),
+            ListTasksRequest::method_value(),
         )))
     }
 

--- a/crates/rust-mcp-sdk/src/mcp_http/http_utils.rs
+++ b/crates/rust-mcp-sdk/src/mcp_http/http_utils.rs
@@ -383,7 +383,9 @@ pub(crate) async fn create_standalone_stream(
     runtime
         .wait_for_transport_ready(state.ping_interval)
         .await
-        .map_err(|err| McpHttpError::HttpError(format!("Failed waiting for transport readiness: {err}")))?;
+        .map_err(|err| {
+            McpHttpError::HttpError(format!("Failed waiting for transport readiness: {err}"))
+        })?;
 
     *response.status_mut() = StatusCode::OK;
     Ok(response)

--- a/crates/rust-mcp-sdk/src/mcp_http/http_utils.rs
+++ b/crates/rust-mcp-sdk/src/mcp_http/http_utils.rs
@@ -374,6 +374,17 @@ pub(crate) async fn create_standalone_stream(
         last_event_id,
     )
     .await?;
+
+    // Wait for the DEFAULT transport to be stored in transport_map before
+    // returning the SSE response to the client. The spawned start_stream task
+    // inside create_sse_stream calls store_transport() asynchronously; we must
+    // block here so the client cannot send tools/call (which needs transport_map
+    // for reverse requests like sampling/createMessage) before it is ready.
+    runtime
+        .wait_for_transport_ready(state.ping_interval)
+        .await
+        .map_err(|err| McpHttpError::HttpError(format!("Failed waiting for transport readiness: {err}")))?;
+
     *response.status_mut() = StatusCode::OK;
     Ok(response)
 }

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -24,7 +24,7 @@ use std::panic;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::{mpsc, oneshot, watch, RwLock, RwLockReadGuard};
+use tokio::sync::{mpsc, oneshot, watch, Notify, RwLock, RwLockReadGuard};
 
 pub const DEFAULT_STREAM_ID: &str = "STANDALONE-STREAM";
 const TASK_CHANNEL_CAPACITY: usize = 500;
@@ -55,6 +55,12 @@ pub struct ServerRuntime {
     server_details: Arc<InitializeResult>,
     session_id: Option<SessionId>,
     transport_map: tokio::sync::RwLock<Option<TransportType>>,
+    /// Notified (via `notify_waiters`) immediately after the DEFAULT standalone
+    /// transport is stored in `transport_map`. Allows `create_standalone_stream`
+    /// to block until the transport is ready before returning the SSE response,
+    /// preventing the race where a subsequent `tools/call` POST arrives before
+    /// the transport is registered.
+    transport_ready: Notify,
     request_id_gen: Box<dyn RequestIdGen>,
     client_details_tx: watch::Sender<Option<InitializeRequestParams>>,
     client_details_rx: watch::Receiver<Option<InitializeRequestParams>>,
@@ -456,9 +462,37 @@ impl ServerRuntime {
         if stream_id != DEFAULT_STREAM_ID {
             return Ok(());
         }
-        let mut transport_map = self.transport_map.write().await;
-        tracing::trace!("save transport for stream id : {}", stream_id);
-        *transport_map = Some(transport);
+        {
+            let mut transport_map = self.transport_map.write().await;
+            tracing::trace!("save transport for stream id : {}", stream_id);
+            *transport_map = Some(transport);
+        } // release write lock before notifying
+        self.transport_ready.notify_waiters();
+        Ok(())
+    }
+
+    /// Waits until the DEFAULT standalone transport has been stored in
+    /// `transport_map`. Returns immediately if it is already present.
+    ///
+    /// Returns `Err` if the timeout elapses, which indicates the
+    /// spawned `start_stream` task failed or hung before calling
+    /// `store_transport`.
+    pub(crate) async fn wait_for_transport_ready(&self, timeout: std::time::Duration) -> SdkResult<()> {
+        // Fast path: transport already stored — no need to wait.
+        if self.transport_map.read().await.is_some() {
+            return Ok(());
+        }
+        tracing::trace!("Waiting for DEFAULT transport to be stored…");
+        tokio::time::timeout(
+            timeout,
+            self.transport_ready.notified(),
+        )
+        .await
+        .map_err(|_| {
+            SdkError::internal_error()
+                .with_message("Timed out waiting for DEFAULT transport storage")
+        })?;
+        tracing::trace!("DEFAULT transport stored, proceeding.");
         Ok(())
     }
 
@@ -654,6 +688,7 @@ impl ServerRuntime {
             handler,
             session_id: Some(session_id),
             transport_map: tokio::sync::RwLock::new(None),
+            transport_ready: Notify::new(),
             client_details_tx,
             client_details_rx,
             request_id_gen: Box::new(RequestIdGenNumeric::new(None)),
@@ -713,6 +748,7 @@ impl ServerRuntime {
             handler: options.handler,
             session_id: None,
             transport_map: tokio::sync::RwLock::new(Some(Arc::new(options.transport))),
+            transport_ready: Notify::new(),
             client_details_tx,
             client_details_rx,
             request_id_gen: Box::new(RequestIdGenNumeric::new(None)),

--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -477,21 +477,21 @@ impl ServerRuntime {
     /// Returns `Err` if the timeout elapses, which indicates the
     /// spawned `start_stream` task failed or hung before calling
     /// `store_transport`.
-    pub(crate) async fn wait_for_transport_ready(&self, timeout: std::time::Duration) -> SdkResult<()> {
+    pub(crate) async fn wait_for_transport_ready(
+        &self,
+        timeout: std::time::Duration,
+    ) -> SdkResult<()> {
         // Fast path: transport already stored — no need to wait.
         if self.transport_map.read().await.is_some() {
             return Ok(());
         }
         tracing::trace!("Waiting for DEFAULT transport to be stored…");
-        tokio::time::timeout(
-            timeout,
-            self.transport_ready.notified(),
-        )
-        .await
-        .map_err(|_| {
-            SdkError::internal_error()
-                .with_message("Timed out waiting for DEFAULT transport storage")
-        })?;
+        tokio::time::timeout(timeout, self.transport_ready.notified())
+            .await
+            .map_err(|_| {
+                SdkError::internal_error()
+                    .with_message("Timed out waiting for DEFAULT transport storage")
+            })?;
         tracing::trace!("DEFAULT transport stored, proceeding.");
         Ok(())
     }


### PR DESCRIPTION
### 📌 Summary
Fix a race condition  in the Streamable HTTP transport setup causing occasional intermittent tools-call-sampling / tools-call-elicitation
conformance failures.

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Add `transport_ready: Notify` to signal `and  await for it when create_standalone_stream and before returning the SSE 200 response to the client.
