### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,10 +1,10 @@
 {
-  "crates/rust-mcp-sdk": "0.10.0",
-  "crates/rust-mcp-macros": "0.9.1",
-  "crates/rust-mcp-transport": "0.9.1",
-  "crates/rust-mcp-extra": "0.3.3",
-  "crates/rust-mcp-axum": "0.2.3",
-  "crates/rust-mcp-actix": "0.1.4",
+  "crates/rust-mcp-sdk": "1.0.0",
+  "crates/rust-mcp-macros": "1.0.0",
+  "crates/rust-mcp-transport": "1.0.0",
+  "crates/rust-mcp-extra": "1.0.0",
+  "crates/rust-mcp-axum": "1.0.0",
+  "crates/rust-mcp-actix": "1.0.0",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",
@@ -16,6 +16,6 @@
   "examples/simple-mcp-client-streamable-http": "0.1.5",
   "examples/simple-mcp-client-streamable-http-core": "0.1.5",
   "examples/auth/server-oauth-remote": "0.1.35",
-  "crates/conformance-client": "0.1.1",
-  "crates/conformance-server": "0.1.4"
+  "crates/conformance-client": "0.1.2",
+  "crates/conformance-server": "0.1.5"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.10.0...rust-mcp-sdk-v1.0.0) (2026-07-25)
+
+
+### 🚀 Features
+
+* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
+
+
+### 🐛 Bug Fixes
+
+* Prevent stdio stderr monitor busy loop ([#216](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/216)) ([fceead9](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/fceead9f571347d456e3550b7506efbe2e44a416))
+* Race condition in the Streamable HTTP transport setup ([#197](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/197)) ([44e50c8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/44e50c8dd51fe7a9feca57c4d854f1e09e81dac1))
+* Race free logic , fixing tools-call-sampling and tools-call-elicitation conformance failures. ([48d8b01](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/48d8b013c0174f3a48a2bb13688eeb812f4cdb73))
+* Resolve infinite test hang and conformance race with liveness-aware ([#202](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/202)) ([e0d8279](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0d827930f7ea6eb1b1b494a4aa5bd4cd2ea5ab6))
+* **server:** Resolve race condition in SSE transport tear-down ([7586a2b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/7586a2bcede97fcffb41c5266364d7b0e4bf4f32))
+
 ## [0.10.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.9.0...rust-mcp-sdk-v0.10.0) (2026-06-24)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-actix"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-axum"
-version = "0.2.3"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.9.1"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.10.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.9.1"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "0.9.1", path = "crates/rust-mcp-transport", default-features = false }
-rust-mcp-sdk = { version = "0.10.0", path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "0.9.1", path = "crates/rust-mcp-macros", default-features = false }
-rust-mcp-extra = { version = "0.3.3", path = "crates/rust-mcp-extra", default-features = false }
-rust-mcp-axum = { version = "0.2.3", path = "crates/rust-mcp-axum" }
-rust-mcp-actix = { version = "0.1.4", path = "crates/rust-mcp-actix" }
+rust-mcp-transport = { version = "1.0.0", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-sdk = { version = "1.0.0", path = "crates/rust-mcp-sdk", default-features = false }
+rust-mcp-macros = { version = "1.0.0", path = "crates/rust-mcp-macros", default-features = false }
+rust-mcp-extra = { version = "1.0.0", path = "crates/rust-mcp-extra", default-features = false }
+rust-mcp-axum = { version = "1.0.0", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "1.0.0", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version="0.10",  default-features = false }

--- a/crates/conformance-client/Cargo.toml
+++ b/crates/conformance-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test client — runs the official MCP client conformance suite against the rust-mcp-sdk client runtime."

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-server"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test server — implements all scenarios from the MCP conformance suite. Also serves as a reference implementation showing how to build a fully-featured MCP server with rust-mcp-sdk."

--- a/crates/rust-mcp-actix/CHANGELOG.md
+++ b/crates/rust-mcp-actix/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.4...rust-mcp-actix-v1.0.0) (2026-07-25)
+
+
+### 🚀 Features
+
+* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
+
+
+### 🚜 Code Refactoring
+
+* Replace rustls-pemfile with rustls-pki-types PemObject API ([449394a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/449394ae7e445a2046365d1d24414f0bb590f7bd))
+
 ## [0.1.4](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.3...rust-mcp-actix-v0.1.4) (2026-06-24)
 
 

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-actix"
-version = "0.1.4"
+version = "1.0.0"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Actix-web HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-axum/CHANGELOG.md
+++ b/crates/rust-mcp-axum/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.3...rust-mcp-axum-v1.0.0) (2026-07-25)
+
+
+### 🚀 Features
+
+* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
+
 ## [0.2.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.2...rust-mcp-axum-v0.2.3) (2026-06-24)
 
 

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-axum"
-version = "0.2.3"
+version = "1.0.0"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Axum HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.3...rust-mcp-extra-v1.0.0) (2026-07-25)
+
+
+### 🚀 Features
+
+* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
+
 ## [0.3.3](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.2...rust-mcp-extra-v0.3.3) (2026-06-24)
 
 ## [0.3.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.1...rust-mcp-extra-v0.3.2) (2026-06-24)

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "0.3.3"
+version = "1.0.0"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "0.10.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
+rust-mcp-sdk = {  version = "1.0.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.5", optional=true}

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.9.1...rust-mcp-macros-v1.0.0) (2026-07-25)
+
+
+### 🐛 Bug Fixes
+
+* **macros:** Emit Option&lt;T&gt; as a JSON Schema type union instead of the OpenAPI nullable keyword ([#200](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/200)) ([4444c6c](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4444c6cd381822b83b7fa0d7f21d77e1d6fdc9a4))
+* **macros:** Emit valid schemas for unrestricted JSON values ([#218](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/218)) ([e4f0af8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e4f0af8f8d1eff458386fc9b63e8fcae5370043a))
+
 ## [0.9.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.9.0...rust-mcp-macros-v0.9.1) (2026-06-24)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "0.9.1"
+version = "1.0.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.10.0...rust-mcp-sdk-v1.0.0) (2026-07-25)
+
+
+### 🚀 Features
+
+* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
+
+
+### 🐛 Bug Fixes
+
+* Prevent stdio stderr monitor busy loop ([#216](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/216)) ([fceead9](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/fceead9f571347d456e3550b7506efbe2e44a416))
+* Race condition in the Streamable HTTP transport setup ([#197](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/197)) ([44e50c8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/44e50c8dd51fe7a9feca57c4d854f1e09e81dac1))
+* Race free logic , fixing tools-call-sampling and tools-call-elicitation conformance failures. ([48d8b01](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/48d8b013c0174f3a48a2bb13688eeb812f4cdb73))
+* Resolve infinite test hang and conformance race with liveness-aware ([#202](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/202)) ([e0d8279](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0d827930f7ea6eb1b1b494a4aa5bd4cd2ea5ab6))
+* **server:** Resolve race condition in SSE transport tear-down ([7586a2b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/7586a2bcede97fcffb41c5266364d7b0e4bf4f32))
+
 ## [0.10.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.9.0...rust-mcp-sdk-v0.10.0) (2026-06-24)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "0.10.0"
+version = "1.0.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.9.1...rust-mcp-transport-v1.0.0) (2026-07-25)
+
+
+### 🚀 Features
+
+* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
+
+
+### 🐛 Bug Fixes
+
+* Preserve partial bytes in SSE parser when putting back incomplete lines ([#217](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/217)) ([83e3114](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/83e31140853acfcabfb62a3653157d306917196b))
+
 ## [0.9.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.9.0...rust-mcp-transport-v0.9.1) (2026-06-24)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "0.9.1"
+version = "1.0.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>conformance-client: 0.1.2</summary>

### Dependencies


</details>

<details><summary>conformance-server: 0.1.5</summary>

### Dependencies


</details>

<details><summary>rust-mcp-actix: 1.0.0</summary>

## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.4...rust-mcp-actix-v1.0.0) (2026-07-25)


### 🚀 Features

* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))


### 🚜 Code Refactoring

* Replace rustls-pemfile with rustls-pki-types PemObject API ([449394a](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/449394ae7e445a2046365d1d24414f0bb590f7bd))
</details>

<details><summary>rust-mcp-axum: 1.0.0</summary>

## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.3...rust-mcp-axum-v1.0.0) (2026-07-25)


### 🚀 Features

* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))
</details>

<details><summary>rust-mcp-extra: 1.0.0</summary>

## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.3...rust-mcp-extra-v1.0.0) (2026-07-25)


### 🚀 Features

* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 0.10.0 to 1.0.0
</details>

<details><summary>rust-mcp-macros: 1.0.0</summary>

## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.9.1...rust-mcp-macros-v1.0.0) (2026-07-25)


### 🐛 Bug Fixes

* **macros:** Emit Option&lt;T&gt; as a JSON Schema type union instead of the OpenAPI nullable keyword ([#200](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/200)) ([4444c6c](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/4444c6cd381822b83b7fa0d7f21d77e1d6fdc9a4))
* **macros:** Emit valid schemas for unrestricted JSON values ([#218](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/218)) ([e4f0af8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e4f0af8f8d1eff458386fc9b63e8fcae5370043a))
</details>

<details><summary>rust-mcp-sdk: 1.0.0</summary>

## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.10.0...rust-mcp-sdk-v1.0.0) (2026-07-25)


### 🚀 Features

* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))


### 🐛 Bug Fixes

* Prevent stdio stderr monitor busy loop ([#216](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/216)) ([fceead9](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/fceead9f571347d456e3550b7506efbe2e44a416))
* Race condition in the Streamable HTTP transport setup ([#197](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/197)) ([44e50c8](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/44e50c8dd51fe7a9feca57c4d854f1e09e81dac1))
* Race free logic , fixing tools-call-sampling and tools-call-elicitation conformance failures. ([48d8b01](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/48d8b013c0174f3a48a2bb13688eeb812f4cdb73))
* Resolve infinite test hang and conformance race with liveness-aware ([#202](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/202)) ([e0d8279](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/e0d827930f7ea6eb1b1b494a4aa5bd4cd2ea5ab6))
* **server:** Resolve race condition in SSE transport tear-down ([7586a2b](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/7586a2bcede97fcffb41c5266364d7b0e4bf4f32))
</details>

<details><summary>rust-mcp-transport: 1.0.0</summary>

## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.9.1...rust-mcp-transport-v1.0.0) (2026-07-25)


### 🚀 Features

* V1.0.0 release preparation and audit ([#219](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/219)) ([b609d94](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b609d9491b8308ed106fb1cf8070b57b1edef9b6))


### 🐛 Bug Fixes

* Preserve partial bytes in SSE parser when putting back incomplete lines ([#217](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/217)) ([83e3114](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/83e31140853acfcabfb62a3653157d306917196b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).