### PR TITLE
fix(macros): emit Option<T> as a JSON Schema type union instead of the OpenAPI nullable keyword

### DIFF
--- a/crates/rust-mcp-macros/src/elicit/generator.rs
+++ b/crates/rust-mcp-macros/src/elicit/generator.rs
@@ -168,28 +168,38 @@ pub fn generate_form_schema(
 ) -> proc_macro2::TokenStream {
     quote! {
         {
-            // Companion to the JSON-Schema-canonical Option<T> emission:
-            // when a field is `Option<T>`, its emitted schema now uses the
-            // JSON-Schema-canonical type union `{"type": ["X", "null"]}`
+            // Companion to the JSON-Schema-canonical `Option<T>` emission: an
+            // optional field's schema uses the type union `{"type": ["X", "null"]}`
             // rather than the OpenAPI 3.0 `nullable` extension keyword.
-            // The downstream `PrimitiveSchemaDefinition::TryFrom` in
-            // rust-mcp-schema 0.10 reads `type` via `.as_str()` and
-            // silently drops fields whose type is an array — which would
-            // surface here as missing form properties. To preserve the
-            // form-elicit shape across crates, collapse `["X", "null"]`
-            // back to the single non-null primitive `"X"` for the
-            // form-schema conversion path. The original (full) JSON schema,
-            // used by sub-agent tool validation, is untouched.
+            //
+            // An elicit form schema is deliberately restricted to primitive
+            // definitions whose `type` is a single scalar, so
+            // `PrimitiveSchemaDefinition::TryFrom` resolves it via `.as_str()`.
+            // That yields `None` for a union, the conversion fails, and the
+            // `filter_map` below drops the property. Project the union back to
+            // its non-null primitive for this conversion only; the full JSON
+            // schema emitted to clients keeps the union.
             fn __mcp_strip_null_from_type(
                 obj: &serde_json::Map<String, serde_json::Value>,
             ) -> serde_json::Map<String, serde_json::Value> {
                 let mut out = obj.clone();
                 if let Some(serde_json::Value::Array(arr)) = out.get("type").cloned() {
-                    let primitive = arr.iter().find_map(|v| {
-                        v.as_str().filter(|s| *s != "null").map(|s| s.to_string())
-                    });
-                    if let Some(p) = primitive {
-                        out.insert("type".to_string(), serde_json::Value::String(p));
+                    // Collapse only the exact `[T, "null"]` union this derive emits for
+                    // `Option<T>`. A `type` union is order-independent and may legitimately
+                    // carry several non-null members; picking one of those would silently
+                    // change the schema's meaning. Anything else is left untouched so the
+                    // conversion below rejects it instead of guessing.
+                    let null_count = arr.iter().filter(|v| v.as_str() == Some("null")).count();
+                    let non_null: Vec<&str> = arr
+                        .iter()
+                        .filter_map(|v| v.as_str())
+                        .filter(|s| *s != "null")
+                        .collect();
+                    if arr.len() == 2 && null_count == 1 && non_null.len() == 1 {
+                        out.insert(
+                            "type".to_string(),
+                            serde_json::Value::String(non_null[0].to_string()),
+                        );
                     }
                 }
                 out

--- a/crates/rust-mcp-macros/src/elicit/generator.rs
+++ b/crates/rust-mcp-macros/src/elicit/generator.rs
@@ -168,12 +168,42 @@ pub fn generate_form_schema(
 ) -> proc_macro2::TokenStream {
     quote! {
         {
+            // Companion to the JSON-Schema-canonical Option<T> emission:
+            // when a field is `Option<T>`, its emitted schema now uses the
+            // JSON-Schema-canonical type union `{"type": ["X", "null"]}`
+            // rather than the OpenAPI 3.0 `nullable` extension keyword.
+            // The downstream `PrimitiveSchemaDefinition::TryFrom` in
+            // rust-mcp-schema 0.10 reads `type` via `.as_str()` and
+            // silently drops fields whose type is an array — which would
+            // surface here as missing form properties. To preserve the
+            // form-elicit shape across crates, collapse `["X", "null"]`
+            // back to the single non-null primitive `"X"` for the
+            // form-schema conversion path. The original (full) JSON schema,
+            // used by sub-agent tool validation, is untouched.
+            fn __mcp_strip_null_from_type(
+                obj: &serde_json::Map<String, serde_json::Value>,
+            ) -> serde_json::Map<String, serde_json::Value> {
+                let mut out = obj.clone();
+                if let Some(serde_json::Value::Array(arr)) = out.get("type").cloned() {
+                    let primitive = arr.iter().find_map(|v| {
+                        v.as_str().filter(|s| *s != "null").map(|s| s.to_string())
+                    });
+                    if let Some(p) = primitive {
+                        out.insert("type".to_string(), serde_json::Value::String(p));
+                    }
+                }
+                out
+            }
+
             let json = #struct_name::json_schema();
             let properties = json.get("properties")
                 .and_then(|v| v.as_object())
                 .into_iter()
                 .flatten()
-                .filter_map(|(k, v)| #base::PrimitiveSchemaDefinition::try_from(v.as_object()?).ok().map(|def| (k.clone(), def)))
+                .filter_map(|(k, v)| {
+                    let normalized = __mcp_strip_null_from_type(v.as_object()?);
+                    #base::PrimitiveSchemaDefinition::try_from(&normalized).ok().map(|def| (k.clone(), def))
+                })
                 .collect();
 
             let required = json.get("required")

--- a/crates/rust-mcp-macros/src/elicit/generator.rs
+++ b/crates/rust-mcp-macros/src/elicit/generator.rs
@@ -176,9 +176,12 @@ pub fn generate_form_schema(
             // definitions whose `type` is a single scalar, so
             // `PrimitiveSchemaDefinition::TryFrom` resolves it via `.as_str()`.
             // That yields `None` for a union, the conversion fails, and the
-            // `filter_map` below drops the property. Project the union back to
-            // its non-null primitive for this conversion only; the full JSON
-            // schema emitted to clients keeps the union.
+            // `filter_map` below drops the property.
+            //
+            // Project the union back to its non-null primitive for this path
+            // only. Note which schema is which: this builds the elicit
+            // `requestedSchema`, so an elicitation client receives the
+            // projected scalar. The tool `inputSchema` keeps the union.
             fn __mcp_strip_null_from_type(
                 obj: &serde_json::Map<String, serde_json::Value>,
             ) -> serde_json::Map<String, serde_json::Value> {

--- a/crates/rust-mcp-macros/src/lib.rs
+++ b/crates/rust-mcp-macros/src/lib.rs
@@ -342,7 +342,12 @@ pub fn mcp_elicit(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Features
 /// - **Basic Types:** Maps `String` to `"string"`, `i32` to `"integer"`, `bool` to `"boolean"`, etc.
-/// - **`Option<T>`:** Adds `"nullable": true` to the schema of the inner type, indicating the field is optional.
+/// - **`Option<T>`:** Encodes nullability the JSON-Schema-canonical way: when the inner schema has
+///   a string `type` (e.g. `"string"`, `"integer"`), it is widened to a type union
+///   `["X", "null"]`. When the inner schema has an array `type`, `"null"` is appended. Otherwise
+///   the inner schema is wrapped in `{"anyOf": [<inner>, {"type": "null"}]}`. The OpenAPI 3.0
+///   extension keyword `"nullable": true` is NOT emitted — strict JSON Schema validators
+///   (notably the Anthropic API tool-call validator) reject extension keywords.
 /// - **`Vec<T>`:** Generates an `"array"` schema with an `"items"` field describing the inner type.
 /// - **Nested Structs:** Recursively includes the schema of nested structs (assumed to derive `JsonSchema`),
 ///   embedding their `"properties"` and `"required"` fields.

--- a/crates/rust-mcp-macros/src/lib.rs
+++ b/crates/rust-mcp-macros/src/lib.rs
@@ -342,12 +342,17 @@ pub fn mcp_elicit(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Features
 /// - **Basic Types:** Maps `String` to `"string"`, `i32` to `"integer"`, `bool` to `"boolean"`, etc.
-/// - **`Option<T>`:** Encodes nullability the JSON-Schema-canonical way: when the inner schema has
-///   a string `type` (e.g. `"string"`, `"integer"`), it is widened to a type union
-///   `["X", "null"]`. When the inner schema has an array `type`, `"null"` is appended. Otherwise
-///   the inner schema is wrapped in `{"anyOf": [<inner>, {"type": "null"}]}`. The OpenAPI 3.0
-///   extension keyword `"nullable": true` is NOT emitted — strict JSON Schema validators
-///   (notably the Anthropic API tool-call validator) reject extension keywords.
+/// - **`Option<T>`:** Encodes nullability the JSON-Schema-canonical way. When the inner schema
+///   has a string `type` — `"string"` and `"integer"`, but equally `"object"` for a nested
+///   struct and `"array"` for a `Vec` — it is widened to a type union `["X", "null"]`.
+///   Type-specific keywords (`properties`, `items`, `minLength`, `format`, …) only assert
+///   against their own type, so `null` remains valid alongside them. When the inner schema
+///   already has an array `type`, `"null"` is appended. When it has no `type` at all — the
+///   shape a derived enum emits, using `oneOf`/`enum` — the inner schema is wrapped in
+///   `{"anyOf": [<inner>, {"type": "null"}]}`, which keeps the inner assertions intact rather
+///   than widening past them. The OpenAPI 3.0 keyword `"nullable": true` is not emitted: it
+///   carries no meaning in JSON Schema, so it never actually permitted `null` in the first
+///   place.
 /// - **`Vec<T>`:** Generates an `"array"` schema with an `"items"` field describing the inner type.
 /// - **Nested Structs:** Recursively includes the schema of nested structs (assumed to derive `JsonSchema`),
 ///   embedding their `"properties"` and `"required"` fields.

--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -290,15 +290,22 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
                                 return quote! {
                                     {
                                         let mut map = #inner_schema;
-                                        // JSON Schema (Draft 7 / 2020-12) does NOT define "nullable" — that
-                                        // is an OpenAPI 3.0 extension keyword. The MCP spec references JSON
-                                        // Schema for the inputSchema field, and strict validators (notably
-                                        // the Anthropic API tool-call validator used by Claude sub-agents)
-                                        // reject the keyword. Encode "this field may be null" the canonical
-                                        // JSON Schema way: union the existing primitive `type` with "null"
-                                        // (`{"type": ["X", "null"]}`), or fall back to a top-level `anyOf`
-                                        // when the inner schema has no string `type` (e.g. nested object
-                                        // or `$ref` schemas).
+                                        // "nullable" is an OpenAPI 3.0 keyword that JSON Schema
+                                        // (Draft 7 / 2020-12, which MCP references for inputSchema)
+                                        // does not define. A conforming validator ignores it rather
+                                        // than rejecting it, which is exactly the problem: it asserts
+                                        // nothing, so the field still rejects the `null` that serde
+                                        // accepts for Option<T>. Encode nullability canonically instead.
+                                        //
+                                        // Widening `type` works whenever the inner schema has one:
+                                        // scalars, a Vec ("array") and a nested struct ("object") all
+                                        // do, and their type-specific keywords assert only against
+                                        // their own type, so `null` stays valid beside them. A derived
+                                        // enum emits `oneOf`/`enum` with no top-level `type`; there,
+                                        // widening is impossible and would be wrong anyway, since
+                                        // keywords in one schema object are conjunctive and a sibling
+                                        // `enum` would keep rejecting `null`. Wrap those in `anyOf` so
+                                        // the inner assertions stay intact.
                                         match map.get("type").cloned() {
                                             Some(serde_json::Value::String(t)) if t != "null" => {
                                                 map.insert(

--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -290,7 +290,47 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
                                 return quote! {
                                     {
                                         let mut map = #inner_schema;
-                                        map.insert("nullable".to_string(), serde_json::Value::Bool(true));
+                                        // JSON Schema (Draft 7 / 2020-12) does NOT define "nullable" — that
+                                        // is an OpenAPI 3.0 extension keyword. The MCP spec references JSON
+                                        // Schema for the inputSchema field, and strict validators (notably
+                                        // the Anthropic API tool-call validator used by Claude sub-agents)
+                                        // reject the keyword. Encode "this field may be null" the canonical
+                                        // JSON Schema way: union the existing primitive `type` with "null"
+                                        // (`{"type": ["X", "null"]}`), or fall back to a top-level `anyOf`
+                                        // when the inner schema has no string `type` (e.g. nested object
+                                        // or `$ref` schemas).
+                                        match map.get("type").cloned() {
+                                            Some(serde_json::Value::String(t)) if t != "null" => {
+                                                map.insert(
+                                                    "type".to_string(),
+                                                    serde_json::Value::Array(vec![
+                                                        serde_json::Value::String(t),
+                                                        serde_json::Value::String("null".to_string()),
+                                                    ]),
+                                                );
+                                            }
+                                            Some(serde_json::Value::Array(mut arr)) => {
+                                                let null_v = serde_json::Value::String("null".to_string());
+                                                if !arr.iter().any(|v| v == &null_v) {
+                                                    arr.push(null_v);
+                                                    map.insert("type".to_string(), serde_json::Value::Array(arr));
+                                                }
+                                            }
+                                            _ => {
+                                                // No primitive `type` to extend — wrap in anyOf so the schema
+                                                // remains JSON-Schema-valid.
+                                                let inner = serde_json::Value::Object(map.into_iter().collect());
+                                                let mut wrapper = serde_json::Map::new();
+                                                wrapper.insert(
+                                                    "anyOf".to_string(),
+                                                    serde_json::Value::Array(vec![
+                                                        inner,
+                                                        serde_json::json!({ "type": "null" }),
+                                                    ]),
+                                                );
+                                                map = wrapper;
+                                            }
+                                        }
                                         #description_quote
                                         #title_quote
                                         #format_quote
@@ -662,11 +702,16 @@ mod tests {
 
     #[test]
     fn test_type_to_json_schema_option() {
+        // Emit JSON-Schema-canonical `["X", "null"]` type union, NOT the
+        // OpenAPI 3.0 `nullable: true` extension keyword.
         let ty: Type = parse_quote!(Option<i32>);
         let attrs: Vec<Attribute> = vec![];
         let tokens = type_to_json_schema(&ty, &attrs);
         let output = tokens.to_string();
-        assert!(output.contains("\"nullable\""));
+        // Must NOT emit the OpenAPI extension.
+        assert!(!output.contains("\"nullable\""));
+        // Must emit a `null` member that the type-union branch will append.
+        assert!(output.contains("\"null\""));
     }
 
     #[test]
@@ -881,12 +926,26 @@ mod tests {
 
     #[test]
     fn test_json_schema_option_of_number() {
+        // Emit JSON-Schema-canonical `["integer", "null"]` type union, NOT
+        // the OpenAPI 3.0 `nullable: true` extension keyword.
         let ty: syn::Type = parse_quote!(Option<u64>);
         let tokens = type_to_json_schema(&ty, &[]);
         let output = render(tokens);
-        assert!(output.contains("\"nullable\".to_string(),serde_json::Value::Bool(true)"));
-        assert!(output
-            .contains("\"type\".to_string(),serde_json::Value::String(\"integer\".to_string())"));
+        // Must NOT emit the OpenAPI extension.
+        assert!(
+            !output.contains("\"nullable\""),
+            "must not emit OpenAPI 3.0 nullable keyword (got: {output})"
+        );
+        // Must produce code that constructs the union — both "integer" and
+        // "null" string literals appear in the emitted token stream.
+        assert!(
+            output.contains("\"integer\""),
+            "expected inner type string literal in emitted tokens (got: {output})"
+        );
+        assert!(
+            output.contains("\"null\""),
+            "expected null string literal in emitted tokens (got: {output})"
+        );
     }
 
     #[test]

--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -326,7 +326,7 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
                                             _ => {
                                                 // No primitive `type` to extend — wrap in anyOf so the schema
                                                 // remains JSON-Schema-valid.
-                                                let inner = serde_json::Value::Object(map.into_iter().collect());
+                                                let inner = serde_json::Value::Object(map);
                                                 let mut wrapper = serde_json::Map::new();
                                                 wrapper.insert(
                                                     "anyOf".to_string(),

--- a/crates/rust-mcp-macros/tests/test_mcp_elicit.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_elicit.rs
@@ -401,3 +401,44 @@ fn readme_example_elicitation_url() {
     assert_eq!(user.tags, vec!["rust", "c++"]);
     assert_eq!(user.email.unwrap(), "alice@Borderland.com");
 }
+
+/// Regression guard for the `Option<T>` type-union encoding.
+///
+/// `Option<T>` fields emit the JSON-Schema-canonical union `{"type": ["X", "null"]}`.
+/// `PrimitiveSchemaDefinition::TryFrom` resolves a schema's type via `.as_str()`, which
+/// yields `None` for an array-valued `type`; the conversion then fails and
+/// `generate_form_schema` silently drops the field. The generator compensates by collapsing
+/// the union back to its non-null primitive for the form path only. Without that step every
+/// optional field disappears from the elicit form, so assert each one still survives.
+///
+/// Only primitive inner types are covered: `Vec<T>` maps to an array schema, which
+/// `PrimitiveSchemaDefinition` accepts solely as a multi-select enum (`items` carrying
+/// `enum`/`anyOf`), so a plain `Option<Vec<String>>` is dropped here for reasons unrelated
+/// to null-union handling.
+#[test]
+fn test_optional_fields_survive_form_schema_conversion() {
+    #[derive(Debug, Clone, JsonSchema)]
+    #[mcp_elicit(message = "Optional fields", mode = form)]
+    pub struct OptionalFields {
+        pub name: String,
+        pub nickname: Option<String>,
+        pub age: Option<i32>,
+        pub visits: Option<i64>,
+        pub subscribed: Option<bool>,
+    }
+
+    match OptionalFields::elicit_request_params() {
+        ElicitRequestParams::FormParams(form) => {
+            let properties = &form.requested_schema.properties;
+            for field in ["name", "nickname", "age", "visits", "subscribed"] {
+                assert!(
+                    properties.contains_key(field),
+                    "`{field}` is missing from the form properties: the Option<T> type union was not collapsed back to its primitive"
+                );
+            }
+            // Optionality stays encoded by `required`, not by the null union.
+            assert_eq!(form.requested_schema.required, vec!["name"]);
+        }
+        _ => panic!("Expected FormParams"),
+    }
+}

--- a/crates/rust-mcp-macros/tests/test_mcp_elicit.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_elicit.rs
@@ -1,7 +1,7 @@
 use rust_mcp_macros::{mcp_elicit, JsonSchema};
 use rust_mcp_schema::{
     ElicitRequestFormParams, ElicitRequestParams, ElicitRequestUrlParams, ElicitResultContent,
-    RpcError,
+    PrimitiveSchemaDefinition, RpcError,
 };
 use std::collections::BTreeMap;
 
@@ -436,6 +436,42 @@ fn test_optional_fields_survive_form_schema_conversion() {
                     "`{field}` is missing from the form properties: the Option<T> type union was not collapsed back to its primitive"
                 );
             }
+
+            // Presence alone would still hold if the union collapsed to the wrong
+            // member, so pin the resolved schema kind of each optional field.
+            assert!(
+                matches!(
+                    properties.get("nickname"),
+                    Some(PrimitiveSchemaDefinition::StringSchema(_))
+                ),
+                "Option<String> should resolve to a string schema, got {:?}",
+                properties.get("nickname")
+            );
+            assert!(
+                matches!(
+                    properties.get("age"),
+                    Some(PrimitiveSchemaDefinition::NumberSchema(_))
+                ),
+                "Option<i32> should resolve to a number schema, got {:?}",
+                properties.get("age")
+            );
+            assert!(
+                matches!(
+                    properties.get("visits"),
+                    Some(PrimitiveSchemaDefinition::NumberSchema(_))
+                ),
+                "Option<i64> should resolve to a number schema, got {:?}",
+                properties.get("visits")
+            );
+            assert!(
+                matches!(
+                    properties.get("subscribed"),
+                    Some(PrimitiveSchemaDefinition::BooleanSchema(_))
+                ),
+                "Option<bool> should resolve to a boolean schema, got {:?}",
+                properties.get("subscribed")
+            );
+
             // Optionality stays encoded by `required`, not by the null union.
             assert_eq!(form.requested_schema.required, vec!["name"]);
         }

--- a/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
@@ -17,11 +17,15 @@ fn test_schema_number() {
 
 /// The `Option<T>` null encoding, asserted on the raw emitted schema.
 ///
-/// The elicit form test covers the *projected* form schema, which deliberately
-/// collapses the union back to a scalar — so it cannot see whether the union was
-/// applied in the first place. These assertions pin the schema clients actually
-/// receive, per inner shape, so that widening one arm while silently leaving
-/// another alone is a test failure rather than a passing build.
+/// This pins the schema a tool's `inputSchema` carries. The elicit form test is
+/// deliberately not a substitute: that path collapses the union back to a scalar
+/// before its assertions, so it cannot see whether the union was applied at all.
+///
+/// The whole schema is compared by equality rather than field by field. Keywords in
+/// one schema object are conjunctive, so a stray sibling assertion — an `enum` beside
+/// a union, or a top-level `oneOf` beside the `anyOf` wrapper — makes `null` invalid
+/// again while every targeted assertion still passes. Only exact equality rules that
+/// out.
 #[test]
 fn test_option_null_encoding_per_inner_shape() {
     #[allow(unused)]
@@ -52,70 +56,48 @@ fn test_option_null_encoding_per_inner_shape() {
     }
 
     let schema = serde_json::Value::Object(AllOptionShapes::json_schema());
-    let props = schema
-        .get("properties")
-        .and_then(|v| v.as_object())
-        .expect("schema should carry properties");
 
-    // Anything with a `type` is widened to a union — including a Vec ("array")
-    // and a nested struct ("object"), whose sibling keywords assert only against
-    // their own type and so leave `null` valid.
-    for (field, expected) in [
-        ("text", "string"),
-        ("number", "integer"),
-        ("big", "integer"),
-        ("ratio", "number"),
-        ("flag", "boolean"),
-        ("list", "array"),
-        ("nested", "object"),
-    ] {
-        assert_eq!(
-            props[field]["type"],
-            serde_json::json!([expected, "null"]),
-            "`{field}` should widen to [\"{expected}\", \"null\"], got {}",
-            props[field]
-        );
-    }
-
-    // The inner schema must survive widening.
-    assert_eq!(props["list"]["items"]["type"], serde_json::json!("string"));
     assert_eq!(
-        props["nested"]["properties"]["a"]["type"],
-        serde_json::json!("string")
-    );
+        schema,
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                // A scalar `type` is widened to a union.
+                "text":   { "type": ["string", "null"] },
+                "number": { "type": ["integer", "null"] },
+                "big":    { "type": ["integer", "null"] },
+                "ratio":  { "type": ["number", "null"] },
+                "flag":   { "type": ["boolean", "null"] },
 
-    // `type` members must stay unique: Option<Option<T>> must not append a second "null".
-    assert_eq!(
-        props["double"]["type"],
-        serde_json::json!(["string", "null"])
-    );
+                // So are `Vec` and a nested struct: `items`, `properties` and `required`
+                // assert only against their own type, so `null` stays valid beside them.
+                "list": {
+                    "type": ["array", "null"],
+                    "items": { "type": "string" }
+                },
+                "nested": {
+                    "type": ["object", "null"],
+                    "properties": { "a": { "type": "string" } },
+                    "required": ["a"]
+                },
 
-    // A derived enum has no top-level `type`, so it is wrapped rather than widened.
-    // Widening would be wrong here: a sibling `enum` is conjunctive and would keep
-    // rejecting `null`.
-    assert!(
-        props["colour"].get("type").is_none(),
-        "a derived enum should not gain a top-level `type`, got {}",
-        props["colour"]
-    );
-    assert_eq!(
-        props["colour"]["anyOf"][1],
-        serde_json::json!({ "type": "null" }),
-        "Option<Enum> should be wrapped in anyOf with a null alternative, got {}",
-        props["colour"]
-    );
-    assert!(
-        props["colour"]["anyOf"][0].get("oneOf").is_some(),
-        "the enum's own schema should be preserved inside the anyOf, got {}",
-        props["colour"]
-    );
+                // A derived enum has no top-level `type` to widen, and widening one in
+                // would not help: the sibling `oneOf` would still reject `null`. It is
+                // wrapped instead, which keeps the inner assertions intact.
+                "colour": {
+                    "anyOf": [
+                        { "oneOf": [ { "enum": ["Red"] }, { "enum": ["Green"] } ] },
+                        { "type": "null" }
+                    ]
+                },
 
-    // The OpenAPI keyword must not reappear anywhere.
-    assert!(
-        !schema.to_string().contains("nullable"),
-        "the OpenAPI `nullable` keyword should not be emitted: {schema}"
+                // `type` members stay unique: Option<Option<T>> gains no second "null".
+                "double": { "type": ["string", "null"] }
+            }
+        }),
+        "raw Option<T> schema drifted"
     );
 
     // Optionality stays encoded by `required`, which no optional field joins.
-    assert!(schema.get("required").is_none() || schema["required"] == serde_json::json!([]));
+    assert!(schema.get("required").is_none());
 }

--- a/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
@@ -14,3 +14,108 @@ fn test_schema_number() {
         r#"{"properties":{"b":{"type":"number"}},"required":["b"],"type":"object"}"#
     )
 }
+
+/// The `Option<T>` null encoding, asserted on the raw emitted schema.
+///
+/// The elicit form test covers the *projected* form schema, which deliberately
+/// collapses the union back to a scalar — so it cannot see whether the union was
+/// applied in the first place. These assertions pin the schema clients actually
+/// receive, per inner shape, so that widening one arm while silently leaving
+/// another alone is a test failure rather than a passing build.
+#[test]
+fn test_option_null_encoding_per_inner_shape() {
+    #[allow(unused)]
+    #[derive(JsonSchema)]
+    enum Colour {
+        Red,
+        Green,
+    }
+
+    #[allow(unused)]
+    #[derive(JsonSchema)]
+    struct Inner {
+        pub a: String,
+    }
+
+    #[allow(unused)]
+    #[derive(JsonSchema)]
+    struct AllOptionShapes {
+        pub text: Option<String>,
+        pub number: Option<i32>,
+        pub big: Option<i64>,
+        pub ratio: Option<f64>,
+        pub flag: Option<bool>,
+        pub list: Option<Vec<String>>,
+        pub nested: Option<Inner>,
+        pub colour: Option<Colour>,
+        pub double: Option<Option<String>>,
+    }
+
+    let schema = serde_json::Value::Object(AllOptionShapes::json_schema());
+    let props = schema
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .expect("schema should carry properties");
+
+    // Anything with a `type` is widened to a union — including a Vec ("array")
+    // and a nested struct ("object"), whose sibling keywords assert only against
+    // their own type and so leave `null` valid.
+    for (field, expected) in [
+        ("text", "string"),
+        ("number", "integer"),
+        ("big", "integer"),
+        ("ratio", "number"),
+        ("flag", "boolean"),
+        ("list", "array"),
+        ("nested", "object"),
+    ] {
+        assert_eq!(
+            props[field]["type"],
+            serde_json::json!([expected, "null"]),
+            "`{field}` should widen to [\"{expected}\", \"null\"], got {}",
+            props[field]
+        );
+    }
+
+    // The inner schema must survive widening.
+    assert_eq!(props["list"]["items"]["type"], serde_json::json!("string"));
+    assert_eq!(
+        props["nested"]["properties"]["a"]["type"],
+        serde_json::json!("string")
+    );
+
+    // `type` members must stay unique: Option<Option<T>> must not append a second "null".
+    assert_eq!(
+        props["double"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+
+    // A derived enum has no top-level `type`, so it is wrapped rather than widened.
+    // Widening would be wrong here: a sibling `enum` is conjunctive and would keep
+    // rejecting `null`.
+    assert!(
+        props["colour"].get("type").is_none(),
+        "a derived enum should not gain a top-level `type`, got {}",
+        props["colour"]
+    );
+    assert_eq!(
+        props["colour"]["anyOf"][1],
+        serde_json::json!({ "type": "null" }),
+        "Option<Enum> should be wrapped in anyOf with a null alternative, got {}",
+        props["colour"]
+    );
+    assert!(
+        props["colour"]["anyOf"][0].get("oneOf").is_some(),
+        "the enum's own schema should be preserved inside the anyOf, got {}",
+        props["colour"]
+    );
+
+    // The OpenAPI keyword must not reappear anywhere.
+    assert!(
+        !schema.to_string().contains("nullable"),
+        "the OpenAPI `nullable` keyword should not be emitted: {schema}"
+    );
+
+    // Optionality stays encoded by `required`, which no optional field joins.
+    assert!(schema.get("required").is_none() || schema["required"] == serde_json::json!([]));
+}

--- a/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
@@ -101,3 +101,50 @@ fn test_option_null_encoding_per_inner_shape() {
     // Optionality stays encoded by `required`, which no optional field joins.
     assert!(schema.get("required").is_none());
 }
+
+/// A type whose hand-written schema already carries an *array* `type`.
+///
+/// The derive recurses into this via `Option<MultiType>` (it calls the inherent
+/// `MultiType::json_schema()`), so the resulting `{"type":["string","integer"]}`
+/// reaches the array-`type` append arm in `type_to_json_schema`. That arm is the
+/// only place a pre-existing type *array* is widened with `"null"`; every derived
+/// inner shape emits either a scalar `type` (widened by the string arm) or an
+/// already-null-bearing `Option<Option<T>>` (the uniqueness path). Without this
+/// fixture the append arm can be neutered to a no-op and the suite still passes.
+struct MultiType;
+
+impl MultiType {
+    pub fn json_schema() -> serde_json::Map<String, serde_json::Value> {
+        match serde_json::json!({ "type": ["string", "integer"] }) {
+            serde_json::Value::Object(map) => map,
+            _ => unreachable!("object literal"),
+        }
+    }
+}
+
+/// Pins the array-`type` union append arm: `Option<T>` where `T`'s schema already
+/// has an array `type` must widen it to include `"null"`, not leave it untouched.
+///
+/// The whole field schema is compared by equality: a mutant that leaves the array
+/// as `["string","integer"]` rejects the `null` serde still deserializes to `None`,
+/// and a stray sibling keyword would make `null` invalid again — exact equality
+/// rules both out.
+#[test]
+fn test_option_widens_array_type_union() {
+    #[allow(unused)]
+    #[derive(JsonSchema)]
+    struct Holder {
+        pub multi: Option<MultiType>,
+    }
+
+    let schema = serde_json::Value::Object(Holder::json_schema());
+    let field = schema
+        .pointer("/properties/multi")
+        .expect("multi field present");
+
+    assert_eq!(
+        field,
+        &serde_json::json!({ "type": ["string", "integer", "null"] }),
+        "array-type union append arm did not widen type to include null"
+    );
+}

--- a/crates/rust-mcp-macros/tests/test_mcp_tool.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_tool.rs
@@ -88,13 +88,14 @@ fn test_attributes() {
                 "minLength": 1,
                 "maxLength": 100
             },
+            // Emit JSON-Schema-canonical `["string", "null"]` type union,
+            // NOT the OpenAPI 3.0 `nullable: true` extension keyword.
             "email": {
-                "type": "string",
+                "type": ["string", "null"],
                 "title": "User Email",
                 "format": "email",
                 "minLength": 5,
-                "maxLength": 255,
-                "nullable": true
+                "maxLength": 255
             },
             "tags": {
                 "type": "array",


### PR DESCRIPTION
## Summary

The `JsonSchema` derive encodes `Option<T>` by adding `"nullable": true` to the inner type's schema (`crates/rust-mcp-macros/src/utils.rs`). `nullable` is an OpenAPI 3.0 keyword with no meaning in JSON Schema Draft 7 or 2020-12, which is what the MCP specification references for a tool's `inputSchema`.

This switches to the JSON Schema canonical encoding, a type union:

```jsonc
// before
"email": { "type": "string", "format": "email", "nullable": true }

// after
"email": { "type": ["string", "null"], "format": "email" }
```

## Why this is a correctness fix, not a style change

To be precise about the problem: an unknown keyword does not make a schema invalid. Draft 7 says unrecognised keywords should be ignored, and 2020-12 treats them as annotations. A conforming validator does not reject `nullable`; it *ignores* it.

That is exactly what makes it a bug. Because `nullable` carries no assertion, `{"type": "string", "nullable": true}` is simply `{"type": "string"}` to a validator — a schema that rejects `null`. Meanwhile serde deserializes an explicit `null` into `None`, so `{"email": null}` is input the server accepts. The schema and the deserializer disagree, and the schema is the one that is wrong.

Field *absence* is already handled correctly and is not what this touches: `src/lib.rs` only pushes a field onto `required` when `!is_option(field_type)`, so `Option<T>` fields are already omitted from `required`. This is about what an optional field accepts when it *is* present.

That also rules out the smaller alternative of deleting the `nullable` insert and stopping there. It would leave `{"type": "string"}`, which still tells a client to reject a `null` the server would have accepted — trading a no-op keyword for a schema that quietly understates the endpoint. The union states what serde actually takes, using only spec-defined keywords.

(Separately, some providers validate tool schemas against a closed dialect that rejects unknown keywords outright. That is a real motivation for dropping `nullable`, but it is provider-specific and not what this PR rests on.)

## Encoding by inner shape

`type_to_json_schema` inspects the inner schema:

- **inner has a string `type`** → widened to `{"type": ["X", "null"]}`. This covers more than scalars: a nested struct emits `"type": "object"` and a `Vec` emits `"type": "array"`, so both take this branch. Their type-specific keywords (`properties`, `required`, `items`, `minLength`, `format`, …) only assert against their own type, so `null` stays valid alongside them.
- **inner already has an array `type`** → `"null"` appended if absent. `type` members must stay unique, so `Option<Option<T>>` collapses rather than gaining a second `"null"`.
- **inner has no `type`** → wrapped as `{"anyOf": [<inner>, {"type": "null"}]}`. This is the shape a derived enum emits (`oneOf` / `enum`, no top-level `type`). Wrapping matters here: widening `type` would not help, because keywords within one schema object are conjunctive, so a sibling `enum` that does not list `null` would keep rejecting `null`. The `anyOf` form keeps the inner assertions intact and adds `null` as a genuine alternative.

I verified the emitted schemas rather than reasoning about them. Every supported shape below accepts `null` under both Draft 7 and 2020-12 (checked against the compiled derive's actual output):

| field | emitted schema | `null` accepted |
|---|---|---|
| `Option<String>` (+`format`/`minLength`/`maxLength`) | `{"type":["string","null"],"format":"email",…}` | Draft 7 ✓, 2020-12 ✓ |
| `Option<u64>` | `{"type":["integer","null"]}` | Draft 7 ✓, 2020-12 ✓ |
| `Option<Vec<String>>` | `{"type":["array","null"],"items":{…}}` | Draft 7 ✓, 2020-12 ✓ |
| `Option<NestedStruct>` | `{"type":["object","null"],"properties":{…},"required":[…]}` | Draft 7 ✓, 2020-12 ✓ |
| `Option<SomeEnum>` | `{"anyOf":[{"oneOf":[…]},{"type":"null"}]}` | Draft 7 ✓, 2020-12 ✓ |
| `Option<Option<String>>` | `{"type":["string","null"]}` | Draft 7 ✓, 2020-12 ✓ |

Scoped to supported, valid shapes: a type the derive cannot map already falls back to `{"type": "unknown"}` on `main`, and `Option<char>` correspondingly becomes `{"type": ["unknown","null"]}`. That is not valid JSON Schema, but it is a pre-existing property of the fallback rather than anything this change introduces.

## Elicit form schemas

An elicit form schema is deliberately restricted to primitive definitions whose `type` is a single scalar, so `PrimitiveSchemaDefinition::try_from` resolves it with `value.get("type").and_then(|v| v.as_str())`. That returns `None` for a union, the conversion returns `Err`, and the surrounding `filter_map(...ok())` drops the property silently. Without compensation, optional fields with a supported primitive inner type would disappear from elicit forms.

`generate_form_schema` therefore projects the union back to its non-null primitive. To be precise about which schema is which: the **tool `inputSchema`** keeps the union; the elicit **`requestedSchema`** receives the projected scalar. Those are different paths and the projection only touches the second. The projection is deliberately narrow — it collapses only an exact `[T, "null"]` pair. A `type` union is order-independent and may legitimately carry several non-null members, so anything else is left untouched and allowed to fail the conversion rather than having a member picked for it.

**This is the part I would most like your opinion on.** The projection covers the type-union shape but not the `anyOf` shape, which is a gap I want to be upfront about even though I could not make it bite. `Option<SomeEnum>` cannot reach the conversion at all today: `mcp_elicit` panics on any field type outside `String` / `bool` / `i32` / `i64` / `Vec<String>`, so such a struct does not compile. And it would be dropped even if it did — but so is `main`'s equivalent shape, so this is not a regression. I checked both against the real converter rather than assuming:

```
main's shape  {"oneOf":[{"enum":["Red"]},{"enum":["Green"]}],"nullable":true}
              -> REJECTED: Failed to parse TitledSingleSelectEnumSchema: missing field `const`
this PR's     {"anyOf":[{"oneOf":[…]},{"type":"null"}]}
              -> REJECTED: 'type' is missing and data type is not supported!
```

`main` enters the `oneOf` branch and then fails anyway, because this derive emits `{"enum":[…]}` alternatives while `TitledSingleSelectEnumSchema` wants `{const, title}`. Both drop the field; only the error differs.

Still, the projection compensating in the macro is the weaker design, and that is the real question for you: `PrimitiveSchemaDefinition::TryFrom` could accept an exact `[supported_type, "null"]` union itself — rejecting ambiguous unions — which would fix every caller of that conversion rather than the one call site this PR patches, and let the helper here disappear. I put it in the macro because it is the smaller, self-contained change, but I think the schema crate is the better home and I am happy to open that PR instead — your call.

## Tests

`cargo test -p rust-mcp-macros`: **101 passing, 1 ignored** (previously 99 passing, 1 ignored).

- `test_type_to_json_schema_option`, `test_json_schema_option_of_number` (`src/utils.rs`) — updated to assert the union and the absence of `nullable`.
- `test_attributes` (`tests/test_mcp_tool.rs`) — expected schema updated to `["string", "null"]`.
- `test_option_null_encoding_per_inner_shape` (`tests/test_mcp_json_schema.rs`) — added. Pins the **raw** emitted schema by whole-object equality: scalar / `Vec` / nested struct widen to a union, `Option<Option<T>>` keeps `type` members unique, and a derived enum is wrapped in `anyOf` without gaining a top-level `type`.
- `test_optional_fields_survive_form_schema_conversion` (`tests/test_mcp_elicit.rs`) — added. Asserts optional fields survive into the form's `requestedSchema`, pins each resolved schema kind, and checks they stay out of `required`.

The two tests cover different paths on purpose. The form test alone cannot detect whether the union was ever applied, because the form path collapses it back to a scalar before the assertion — so a derive that widened `Option<String>` but silently skipped `Option<i32>` would still pass it. The raw-schema test is what closes that.

The raw test asserts the whole schema by equality rather than field by field, and that is deliberate. Keywords in one schema object are conjunctive, so a stray sibling assertion — an `enum` next to a union, or a top-level `oneOf` next to the `anyOf` wrapper — makes `null` invalid again while every targeted assertion still passes. Exact equality is what rules that out.

I checked the guards by mutation rather than trusting them. Each of these fails the suite: bypassing the projection; collapsing every union to `"string"`; widening only `"string"` and leaving numeric/boolean untouched; dropping the uniqueness check so `Option<Option<T>>` gains a duplicate `"null"`; regressing the enum arm to a sibling union instead of the `anyOf` wrapper; and injecting a top-level `oneOf` alongside the wrapper.

`Option<Vec<String>>` is still dropped from form properties, for a pre-existing reason unrelated to this change: `PrimitiveSchemaDefinition` accepts an array schema only as a multi-select enum, requiring `items` to carry `enum` or `anyOf`. A plain `Vec<String>` is dropped on `main` today as well.

## Compatibility

This changes the emitted schema for every `Option<T>` field, so it is visible to clients and worth a release note.

The breaking surface is wider than consumers that look for `"nullable": true`. Anything assuming `type` is always a string is affected — `PrimitiveSchemaDefinition::TryFrom` in `rust-mcp-schema` is itself an example, which is why the elicit path needed the projection above. Schema walkers, form generators and typed deserializers downstream can break the same way even if they never knew about `nullable`.

Schema *validity* is preserved — the union is valid in both drafts, and MCP defaults schemas without `$schema` to 2020-12. Validation *outcomes* change on purpose: an explicit `null` for an optional field becomes valid, which is the point of the fix.

Based on `main` at 544451e.
