### PR TITLE
fix(macros): emit valid schemas for unrestricted JSON values

### DIFF
--- a/crates/rust-mcp-macros/src/lib.rs
+++ b/crates/rust-mcp-macros/src/lib.rs
@@ -357,7 +357,7 @@ pub fn mcp_elicit(args: TokenStream, input: TokenStream) -> TokenStream {
 /// # Limitations
 /// - Supports only structs with named fields (e.g., `struct S { field: Type }`).
 /// - Nested structs must also derive `JsonSchema`, or compilation will fail.
-/// - Unknown types are mapped to `{"type": "unknown"}`.
+/// - Unrecognised types emit an empty schema `{}` (any value accepted).
 /// - Type paths must be in scope (e.g., fully qualified paths like `my_mod::InnerStruct` work if imported).
 ///
 /// # Panics

--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -364,9 +364,8 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
                         }
                     };
                 }
-                // Handle imported serde_json::Value (single-segment, mirroring the 2-segment case above)
-                else if ident == "Value" {
-                    return quote! {
+// Handle imported serde_json::Value (single-segment, mirroring the 2-segment case above)
+                else if ident == "Value" && segment.arguments.is_empty() {
                         {
                             let mut map = serde_json::Map::new();
                             #description_quote

--- a/crates/rust-mcp-macros/src/utils.rs
+++ b/crates/rust-mcp-macros/src/utils.rs
@@ -364,6 +364,18 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
                         }
                     };
                 }
+                // Handle imported serde_json::Value (single-segment, mirroring the 2-segment case above)
+                else if ident == "Value" {
+                    return quote! {
+                        {
+                            let mut map = serde_json::Map::new();
+                            #description_quote
+                            #title_quote
+                            #default_quote
+                            map
+                        }
+                    };
+                }
                 // Handle nested structs
                 else if might_be_struct(ty) {
                     let path = &type_path.path;
@@ -503,12 +515,29 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
                         }
                     };
                 }
+                // Handle serde_json::Value — any JSON value; emit empty schema {}
+                if seg0.ident == "serde_json"
+                    && seg0.arguments.is_empty()
+                    && seg1.ident == "Value"
+                    && seg1.arguments.is_empty()
+                {
+                    return quote! {
+                        {
+                            let mut map = serde_json::Map::new();
+                            #description_quote
+                            #title_quote
+                            #default_quote
+                            map
+                        }
+                    };
+                }
             }
-            // Fallback for unknown types
+            // Fallback for unknown types — emit empty schema {} (any value accepted).
+            // An empty schema is always valid JSON Schema; strict MCP clients reject
+            // non-standard type strings like "unknown".
             quote! {
                 {
                     let mut map = serde_json::Map::new();
-                    map.insert("type".to_string(), serde_json::Value::String("unknown".to_string()));
                     #description_quote
                     #title_quote
                     #default_quote
@@ -519,7 +548,6 @@ pub fn type_to_json_schema(ty: &Type, attrs: &[Attribute]) -> proc_macro2::Token
         _ => quote! {
             {
                 let mut map = serde_json::Map::new();
-                map.insert("type".to_string(), serde_json::Value::String("unknown".to_string()));
                 #description_quote
                 #title_quote
                 #default_quote
@@ -910,10 +938,12 @@ mod tests {
 
     #[test]
     fn test_json_schema_fallback_unknown() {
+        // The fallback for unrecognised types now emits an empty schema {}
+        // (no type key), which is valid JSON Schema meaning "accept any value".
         let ty: syn::Type = parse_quote!((i32, i32));
         let tokens = type_to_json_schema(&ty, &[]);
         let output = render(tokens);
-        assert!(output
-            .contains("\"type\".to_string(),serde_json::Value::String(\"unknown\".to_string())"));
+        // Must NOT emit the invalid "unknown" type string
+        assert!(!output.contains("unknown"));
     }
 }

--- a/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
+++ b/crates/rust-mcp-macros/tests/test_mcp_json_schema.rs
@@ -1,5 +1,5 @@
 use rust_mcp_macros::JsonSchema;
-use serde_json::Number;
+use serde_json::{json, Number, Value};
 
 #[test]
 fn test_schema_number() {
@@ -13,4 +13,20 @@ fn test_schema_number() {
         serde_json::to_string(&TestStruct::json_schema()).unwrap(),
         r#"{"properties":{"b":{"type":"number"}},"required":["b"],"type":"object"}"#
     )
+}
+
+#[test]
+fn test_schema_value_accepts_any_json_value() {
+    #[allow(unused)]
+    #[derive(JsonSchema)]
+    struct TestStruct {
+        imported: Value,
+        qualified: serde_json::Value,
+    }
+
+    let schema = TestStruct::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_eq!(properties["imported"], json!({}));
+    assert_eq!(properties["qualified"], json!({}));
 }


### PR DESCRIPTION
## Summary

- emit the JSON Schema empty object `{}` for imported and fully qualified `serde_json::Value`
- replace the invalid fallback `{"type":"unknown"}` with the canonical unrestricted schema `{}`
- document the fallback behavior and cover both `Value` paths with an integration test

## Why

`serde_json::Value` can contain any JSON value, so its schema must be unrestricted. The previous fallback emitted `"unknown"` as a JSON Schema type, which strict MCP clients reject because it is not a valid primitive type.

## Validation

- `cargo test -p rust-mcp-macros --test test_mcp_json_schema test_schema_value_accepts_any_json_value -- --exact`
- `cargo test -p rust-mcp-macros` (98 tests passed; 2 doc tests passed; 1 doc test ignored)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --examples -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rust-mcp-macros`
- `git diff --check`, gitleaks, and strict `git fsck`

The declared Rust 1.80 MSRV was not run locally because that toolchain was not installed; validation used Rust 1.95.
