### PR TITLE
fix: resolve infinite test hang and conformance race in SSE transport lifecycle

### DIFF
--- a/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
+++ b/crates/rust-mcp-sdk/src/mcp_runtimes/server_runtime.rs
@@ -28,6 +28,10 @@ use tokio::sync::{mpsc, oneshot, watch, Notify, RwLock, RwLockReadGuard};
 
 pub const DEFAULT_STREAM_ID: &str = "STANDALONE-STREAM";
 const TASK_CHANNEL_CAPACITY: usize = 500;
+/// How long `send()` waits for a live DEFAULT standalone transport before
+/// failing a server-initiated request (e.g. elicitation/sampling) when the
+/// GET SSE stream has not been registered yet, or the previous one shut down.
+const DEFAULT_TRANSPORT_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 tokio::task_local! {
     /// Per-request transport for sending notifications on the POST response SSE stream.
@@ -54,12 +58,19 @@ pub struct ServerRuntime {
     // Information about the server
     server_details: Arc<InitializeResult>,
     session_id: Option<SessionId>,
+    /// Holds the latest DEFAULT standalone transport, which may be alive or
+    /// shut down. A shut-down entry is deliberately retained as an event-store
+    /// sink: `write_str` persists outgoing events to the event store before
+    /// attempting the (failing) socket write, so messages sent while the
+    /// client is briefly disconnected can be replayed after it reconnects.
+    /// `None` means no transport was stored yet, or the session was shut down.
+    /// Liveness must be judged via `is_shut_down()`, not by `is_some()`.
     transport_map: tokio::sync::RwLock<Option<TransportType>>,
-    /// Notified (via `notify_waiters`) immediately after the DEFAULT standalone
+    /// Signaled (via `notify_one`) immediately after the DEFAULT standalone
     /// transport is stored in `transport_map`. Allows `create_standalone_stream`
-    /// to block until the transport is ready before returning the SSE response,
-    /// preventing the race where a subsequent `tools/call` POST arrives before
-    /// the transport is registered.
+    /// and `send()` to wait until a live transport is available, preventing the
+    /// race where a request (e.g. `elicitation/create`, `sampling/createMessage`)
+    /// is sent before the transport is registered.
     transport_ready: Notify,
     request_id_gen: Box<dyn RequestIdGen>,
     client_details_tx: watch::Sender<Option<InitializeRequestParams>>,
@@ -178,12 +189,24 @@ impl McpServer for ServerRuntime {
             observer.on_send(&mcp_message);
         }
 
-        let transport_map = self.transport_map.read().await;
-        let transport = transport_map.as_ref().ok_or(
-            RpcError::internal_error()
-                .with_message("transport stream does not exists or is closed!".to_string()),
-        )?;
+        let transport = if is_notification {
+            // use the current DEFAULT transport even if it is shut down. A shut-down standalone
+            // transport still persists the event to the event store so it can be replayed
+            // when the client reconnects.
+            let transport_map = self.transport_map.read().await;
+            transport_map.as_ref().cloned().ok_or(
+                RpcError::internal_error()
+                    .with_message("transport stream does not exists or is closed!".to_string()),
+            )?
+        } else {
+            // wait for the DEFAULT standalone transport to be registered (and alive) instead of failing
+            // instantly when the GET SSE stream has not been processed yet, or a shut-down transport from a previous connection is still in the map.
+            self.wait_for_live_default_transport(DEFAULT_TRANSPORT_WAIT_TIMEOUT)
+                .await?
+        };
 
+        // The read guard is dropped above, before `send_message()` is
+        // awaited, so the lock is never held across a request round-trip.
         let response = transport
             .send_message(ServerMessages::Single(mcp_message), request_timeout)
             .await?
@@ -474,36 +497,65 @@ impl ServerRuntime {
     }
 
     /// Waits until the DEFAULT standalone transport has been stored in
-    /// `transport_map`. Returns immediately if it is already present.
+    /// `transport_map` and is alive (not shut down), then returns a clone of it.
+    ///
+    /// Returns `Err` if the timeout elapses, which indicates the spawned
+    /// `start_stream` task failed or hung before calling `store_transport`,
+    /// or no live standalone stream exists.
+    ///
+    /// # Race-free logic
+    ///  - Fast path: a live transport is already in the map → returned immediately.
+    ///  - `store_transport()` fires `notify_one()`, whose stored permit guarantees
+    ///    no missed wakeup if it ran between the map check and the `await`.
+    ///  - On every wakeup the map is re-checked, so a stale/shut-down entry
+    ///    (e.g. from a previous connection) is never returned.
+    ///  - A cascading `notify_one()` re-arms the permit so other parked waiters
+    ///    also get to re-check the map.
+    async fn wait_for_live_default_transport(
+        &self,
+        timeout: std::time::Duration,
+    ) -> SdkResult<TransportType> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            {
+                let transport_map = self.transport_map.read().await;
+                if let Some(transport) = transport_map.as_ref() {
+                    if !transport.is_shut_down().await {
+                        // Cascade the wakeup so other parked waiters re-check the map.
+                        self.transport_ready.notify_one();
+                        return Ok(transport.clone());
+                    }
+                }
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return Err(SdkError::internal_error()
+                    .with_message("Timed out waiting for DEFAULT transport storage")
+                    .into());
+            }
+            tracing::trace!("Waiting for a live DEFAULT transport to be stored…");
+            tokio::time::timeout(deadline - now, self.transport_ready.notified())
+                .await
+                .map_err(|_| {
+                    SdkError::internal_error()
+                        .with_message("Timed out waiting for DEFAULT transport storage")
+                })?;
+        }
+    }
+
+    /// Waits until the DEFAULT standalone transport has been stored in
+    /// `transport_map` and is alive. Returns immediately if it already is.
     ///
     /// Returns `Err` if the timeout elapses, which indicates the
     /// spawned `start_stream` task failed or hung before calling
     /// `store_transport`.
-    ///
-    /// # Race-free logic
-    ///  - If the transport is already in the map → fast path returns.
-    ///  - If `store_transport` runs concurrently between the read and the
-    ///    `await` → the stored permit is immediately consumed; no hang.
-    ///  - If `store_transport` has not run yet → the task parks until
-    ///    `notify_one` fires.
-    ///
     pub(crate) async fn wait_for_transport_ready(
         &self,
         timeout: std::time::Duration,
     ) -> SdkResult<()> {
-        // transport_map it might contain a stale transport from a previous connection
-        // whose keep_alive task hasn't timed out yet.
-        // so we wait for the explicit signal from the new connection's `store_transport`.
-        // instead of checking is_some()
-        tracing::trace!("Waiting for DEFAULT transport to be stored…");
-        tokio::time::timeout(timeout, self.transport_ready.notified())
+        self.wait_for_live_default_transport(timeout)
             .await
-            .map_err(|_| {
-                SdkError::internal_error()
-                    .with_message("Timed out waiting for DEFAULT transport storage")
-            })?;
-        tracing::trace!("DEFAULT transport stored, proceeding.");
-        Ok(())
+            .map(|_| ())
     }
 
     //TODO: re-visit and simplify unnecessary hashmap
@@ -515,18 +567,19 @@ impl ServerRuntime {
         if stream_id != DEFAULT_STREAM_ID {
             return Ok(());
         }
-        let mut transport_map = self.transport_map.write().await;
-        let should_remove = if let Some(current_transport) = transport_map.as_ref() {
-            Arc::ptr_eq(current_transport, transport_to_remove)
-        } else {
-            false
-        };
-
-        if should_remove {
-            let transport = transport_map.take().unwrap();
-            tracing::trace!("removing transport for stream id : {}", stream_id);
-            drop(transport_map);
-            transport.shut_down().await?;
+        // Shut down the matching transport but deliberately LEAVE it in
+        // `transport_map`: a shut-down standalone transport still persists
+        // outgoing events to the event store (`write_str` stores before
+        // writing), so server-initiated messages sent while the client is
+        // briefly disconnected can be replayed after it reconnects.
+        // The `ptr_eq` guard ensures a stale stream's teardown never shuts
+        // down the transport of a newer connection.
+        let transport_map = self.transport_map.read().await;
+        if let Some(current_transport) = transport_map.as_ref() {
+            if Arc::ptr_eq(current_transport, transport_to_remove) {
+                tracing::trace!("shutting down transport for stream id : {}", stream_id);
+                current_transport.shut_down().await?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Description:
### 📌 Summary

Fixes occasional Intermittent conformance failures (`tools-call-sampling`,
   `tools-call-elicitation`, `elicitation-sep1034-defaults`,
   `elicitation-sep1330-enums`)

Fix: make transport handling **liveness-aware** (`is_shut_down()`, never
`is_some()`) — see `.opencode/plans/conformance-race-fix-v3.md` for full analysis.


### ✨ Changes Made

- `remove_transport`: shuts down the matching transport (keeps the `Arc::ptr_eq`
  guard) but **no longer clears `transport_map`** , the dead transport stays as
  an event-store sink so messages sent during a disconnect window are persisted
  and replayed on reconnect. 
- New `wait_for_live_default_transport()`: liveness-check loop + `notify_one`
  permit + cascading re-notify , race-free in both directions.
  
- `send()`: server-initiated **requests** wait up to 10s for a live transport
  instead of failing instantly on an empty/dead map.


