### PR TITLE
fix: preserve partial bytes in SSE parser when putting back incomplete lines

### DIFF
--- a/crates/rust-mcp-sdk/examples/simple-mcp-client-streamable-http.rs
+++ b/crates/rust-mcp-sdk/examples/simple-mcp-client-streamable-http.rs
@@ -12,7 +12,7 @@ use rust_mcp_sdk::{
 };
 use std::sync::Arc;
 
-const MCP_SERVER_URL: &str = "http://127.0.0.1:3001/mcp";
+const MCP_SERVER_URL: &str = "https://gateway.mcpservers.org/yahoo-finance/mcp";
 
 #[tokio::main]
 async fn main() -> SdkResult<()> {

--- a/crates/rust-mcp-sdk/examples/simple-mcp-client-streamable-http.rs
+++ b/crates/rust-mcp-sdk/examples/simple-mcp-client-streamable-http.rs
@@ -12,7 +12,7 @@ use rust_mcp_sdk::{
 };
 use std::sync::Arc;
 
-const MCP_SERVER_URL: &str = "https://gateway.mcpservers.org/yahoo-finance/mcp";
+const MCP_SERVER_URL: &str = "http://127.0.0.1:3001/mcp";
 
 #[tokio::main]
 async fn main() -> SdkResult<()> {

--- a/crates/rust-mcp-transport/src/mcp_stream.rs
+++ b/crates/rust-mcp-transport/src/mcp_stream.rs
@@ -148,9 +148,10 @@ impl MCPStream {
                                 tx.send(message).await.map_err(GenericSendError::new)?;
                             }
                             Err(e) => {
-                                // Handle error in reading from readable_std
+                                tracing::error!("Error reading from readable stream: {e}");
+                                // Handle error in reading from stream
                                 return Err(TransportError::ProcessError(format!(
-                                    "Error reading from readable_std: {e}"
+                                    "Error reading from readable stream: {e}"
                                 )));
                             }
                         }

--- a/crates/rust-mcp-transport/src/utils/sse_parser.rs
+++ b/crates/rust-mcp-transport/src/utils/sse_parser.rs
@@ -77,12 +77,16 @@ impl SseParser {
             }
         }
 
-        // Put back any incomplete message
+        // Put back any incomplete message, preserving partial bytes
+        // that were after the last \n (self.buffer after the while loop).
+        // this prevents data loss when data is received in multiple chunks (like from Cloudflare workers (Issue: #199))
         if !current_message_lines.is_empty() {
-            self.buffer.clear();
-            for line in current_message_lines {
-                self.buffer.extend_from_slice(&line);
+            let mut new_buf = BytesMut::new();
+            for line in current_message_lines.into_iter() {
+                new_buf.extend_from_slice(&line);
             }
+            new_buf.extend_from_slice(&self.buffer);
+            self.buffer = new_buf;
         }
 
         events
@@ -268,6 +272,70 @@ mod tests {
         assert_eq!(
             events2[0].data.as_deref(),
             Some(Bytes::from("hello world\n").as_ref())
+        );
+    }
+
+    #[test]
+    fn test_data_line_across_chunks_with_preceding_event_line() {
+        let mut parser = SseParser::new();
+
+        let part1 = Bytes::from("event: message\ndata: ");
+        let part2 = Bytes::from("hello\n\n");
+
+        let events1 = parser.process_new_chunk(part1);
+        assert_eq!(events1.len(), 0);
+
+        let events2 = parser.process_new_chunk(part2);
+        assert_eq!(events2.len(), 1);
+        assert_eq!(events2[0].event.as_deref(), Some("message"));
+        assert_eq!(
+            events2[0].data.as_deref(),
+            Some(Bytes::from("hello\n").as_ref())
+        );
+    }
+
+    #[test]
+    fn test_data_line_across_multiple_chunks_with_preceding_event() {
+        let mut parser = SseParser::new();
+
+        let part1 = Bytes::from("event: message\ndata: alpha bra");
+        let part2 = Bytes::from("vo charlie del");
+        let part3 = Bytes::from("ta echo foxtrot\n\n");
+
+        let events1 = parser.process_new_chunk(part1);
+        assert_eq!(events1.len(), 0);
+
+        let events2 = parser.process_new_chunk(part2);
+        assert_eq!(events2.len(), 0);
+
+        let events3 = parser.process_new_chunk(part3);
+        assert_eq!(events3.len(), 1);
+        assert_eq!(events3[0].event.as_deref(), Some("message"));
+        assert_eq!(
+            events3[0].data.as_deref(),
+            Some(Bytes::from("alpha bravo charlie delta echo foxtrot\n").as_ref())
+        );
+    }
+
+    #[test]
+    fn test_multiple_events_split_across_chunks() {
+        let mut parser = SseParser::new();
+
+        let part1 = Bytes::from("data: one\n\ndata: t");
+        let part2 = Bytes::from("wo\n\n");
+
+        let events1 = parser.process_new_chunk(part1);
+        assert_eq!(events1.len(), 1);
+        assert_eq!(
+            events1[0].data.as_deref(),
+            Some(Bytes::from("one\n").as_ref())
+        );
+
+        let events2 = parser.process_new_chunk(part2);
+        assert_eq!(events2.len(), 1);
+        assert_eq!(
+            events2[0].data.as_deref(),
+            Some(Bytes::from("two\n").as_ref())
         );
     }
 


### PR DESCRIPTION
### 📌 Summary

When an SSE response spans multiple TCP chunks (common with
`Transfer-Encoding: chunked` over HTTP/1.1), the `SseParser` was losing
partial bytes that had not yet reached a newline.

(It was observed in the Yahoo Finance MCP at https://gateway.mcpservers.org/yahoo-finance/mcp that the service appears to be behind Cloudflare)


### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #199 

### Root cause

`process_new_chunk` extracted complete lines from the buffer but, during
the "put back" step for event-incomplete lines, called
`self.buffer.clear()` - destroying any partial bytes that remained after
the last `\n`. Only the complete lines were restored, so data between
chunks was lost and the caller then returned `TransportError::Internal("Stream
has ended.")`.



### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Replaced the `clear + extend` with a new `BytesMut` that preserves both the incomplete lines and the partial bytes in the correct order.

- Verified end-to-end against `gateway.mcpservers.org/yahoo-finance/mcp`
   - tool listing and pings now succeed without the "Stream has ended"
  error.
- Added new unit tests and confirmed no regression in the streamable HTTP server integration
  tests.

### 🛠️ Testing Steps
```
cargo make check
```
