### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,10 +1,10 @@
 {
-  "crates/rust-mcp-sdk": "1.0.0",
+  "crates/rust-mcp-sdk": "1.0.1",
   "crates/rust-mcp-macros": "1.0.0",
   "crates/rust-mcp-transport": "1.0.0",
-  "crates/rust-mcp-extra": "1.0.0",
-  "crates/rust-mcp-axum": "1.0.0",
-  "crates/rust-mcp-actix": "1.0.0",
+  "crates/rust-mcp-extra": "1.0.1",
+  "crates/rust-mcp-axum": "1.0.1",
+  "crates/rust-mcp-actix": "1.0.1",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",
@@ -16,6 +16,6 @@
   "examples/simple-mcp-client-streamable-http": "0.1.5",
   "examples/simple-mcp-client-streamable-http-core": "0.1.5",
   "examples/auth/server-oauth-remote": "0.1.35",
-  "crates/conformance-client": "0.1.2",
-  "crates/conformance-server": "0.1.5"
+  "crates/conformance-client": "0.1.3",
+  "crates/conformance-server": "0.1.6"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.0...rust-mcp-sdk-v1.0.1) (2026-07-26)
+
+
+### 🐛 Bug Fixes
+
+* Update stale upgrading sections in READMEs ([36a4139](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/36a4139d81f69bd502df5eb90856e094d9922624))
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.10.0...rust-mcp-sdk-v1.0.0) (2026-07-25)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-server"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-actix"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-axum"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ rust-version = "1.80.0"
 [workspace.dependencies]
 # Workspace member crates
 rust-mcp-transport = { version = "1.0.0", path = "crates/rust-mcp-transport", default-features = false }
-rust-mcp-sdk = { version = "1.0.0", path = "crates/rust-mcp-sdk", default-features = false }
+rust-mcp-sdk = { version = "1.0.1", path = "crates/rust-mcp-sdk", default-features = false }
 rust-mcp-macros = { version = "1.0.0", path = "crates/rust-mcp-macros", default-features = false }
-rust-mcp-extra = { version = "1.0.0", path = "crates/rust-mcp-extra", default-features = false }
-rust-mcp-axum = { version = "1.0.0", path = "crates/rust-mcp-axum" }
-rust-mcp-actix = { version = "1.0.0", path = "crates/rust-mcp-actix" }
+rust-mcp-extra = { version = "1.0.1", path = "crates/rust-mcp-extra", default-features = false }
+rust-mcp-axum = { version = "1.0.1", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "1.0.1", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version="0.10",  default-features = false }

--- a/crates/conformance-client/Cargo.toml
+++ b/crates/conformance-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-client"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test client — runs the official MCP client conformance suite against the rust-mcp-sdk client runtime."

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-server"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test server — implements all scenarios from the MCP conformance suite. Also serves as a reference implementation showing how to build a fully-featured MCP server with rust-mcp-sdk."

--- a/crates/rust-mcp-actix/CHANGELOG.md
+++ b/crates/rust-mcp-actix/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.0...rust-mcp-actix-v1.0.1) (2026-07-26)
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.4...rust-mcp-actix-v1.0.0) (2026-07-25)
 
 

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-actix"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Actix-web HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-actix/README.md
+++ b/crates/rust-mcp-actix/README.md
@@ -206,7 +206,7 @@ server.start().await?;
 <!-- x-release-please-start-version -->
 ```toml
 # With TLS/SSL
-rust-mcp-actix = { version = "1.0.0", features = ["ssl"] }
+rust-mcp-actix = { version = "1.0.1", features = ["ssl"] }
 ```
 <!-- x-release-please-end -->
 

--- a/crates/rust-mcp-axum/CHANGELOG.md
+++ b/crates/rust-mcp-axum/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.0...rust-mcp-axum-v1.0.1) (2026-07-26)
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.3...rust-mcp-axum-v1.0.0) (2026-07-25)
 
 

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-axum"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Axum HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-axum/README.md
+++ b/crates/rust-mcp-axum/README.md
@@ -204,7 +204,7 @@ server.start().await?;
 <!-- x-release-please-start-version -->
 ```toml
 # With TLS/SSL
-rust-mcp-axum = { version = "1.0.0", features = ["ssl"] }
+rust-mcp-axum = { version = "1.0.1", features = ["ssl"] }
 ```
 <!-- x-release-please-end -->
 

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.0...rust-mcp-extra-v1.0.1) (2026-07-26)
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.3...rust-mcp-extra-v1.0.0) (2026-07-25)
 
 

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "1.0.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
+rust-mcp-sdk = {  version = "1.0.1" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.5", optional=true}

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.0...rust-mcp-sdk-v1.0.1) (2026-07-26)
+
+
+### 🐛 Bug Fixes
+
+* Update stale upgrading sections in READMEs ([36a4139](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/36a4139d81f69bd502df5eb90856e094d9922624))
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v0.10.0...rust-mcp-sdk-v1.0.0) (2026-07-25)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -94,7 +94,7 @@ Focus on your application logic , rust-mcp-sdk handles the protocol, transports,
 Add to your Cargo.toml:
 ```toml
 [dependencies]
-rust-mcp-sdk = "1.0.0"  # Check crates.io for the latest version
+rust-mcp-sdk = "1.0.1"  # Check crates.io for the latest version
 ```
 <!-- x-release-please-end -->
 
@@ -561,7 +561,7 @@ When you add rust-mcp-sdk as a dependency without specifying any features, all f
 
 ```toml
 [dependencies]
-rust-mcp-sdk = "1.0.0"
+rust-mcp-sdk = "1.0.1"
 ```
 
 <!-- x-release-please-end -->
@@ -574,7 +574,7 @@ If you only need the MCP Server functionality, you can disable the default featu
 
 ```toml
 [dependencies]
-rust-mcp-sdk = { version = "1.0.0", default-features = false, features = ["server","macros","stdio"] }
+rust-mcp-sdk = { version = "1.0.1", default-features = false, features = ["server","macros","stdio"] }
 ```
 Optionally add [`rust-mcp-axum`](https://crates.io/crates/rust-mcp-axum) and the `streamable-http` feature for **Streamable HTTP** transport, and use `rust-mcp-axum`'s `ssl` feature for TLS/SSL support.
 
@@ -589,7 +589,7 @@ Add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-rust-mcp-sdk = { version = "1.0.0", default-features = false, features = ["client","stdio"] }
+rust-mcp-sdk = { version = "1.0.1", default-features = false, features = ["client","stdio"] }
 ```
 
 <!-- x-release-please-end -->


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>conformance-client: 0.1.3</summary>

### Dependencies


</details>

<details><summary>conformance-server: 0.1.6</summary>

### Dependencies


</details>

<details><summary>rust-mcp-actix: 1.0.1</summary>

## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.0...rust-mcp-actix-v1.0.1) (2026-07-26)
</details>

<details><summary>rust-mcp-axum: 1.0.1</summary>

## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.0...rust-mcp-axum-v1.0.1) (2026-07-26)
</details>

<details><summary>rust-mcp-extra: 1.0.1</summary>

## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.0...rust-mcp-extra-v1.0.1) (2026-07-26)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 1.0.0 to 1.0.1
</details>

<details><summary>rust-mcp-sdk: 1.0.1</summary>

## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.0...rust-mcp-sdk-v1.0.1) (2026-07-26)


### 🐛 Bug Fixes

* Update stale upgrading sections in READMEs ([36a4139](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/36a4139d81f69bd502df5eb90856e094d9922624))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).