### PR TITLE
fix: auth-backcompat-discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Focus on your application logic , rust-mcp-sdk handles the protocol, transports,
 
 **Key Features**
 - ✅ Latest MCP protocol specification supported: 2025-11-25
-- ✅ **100% MCP Conformance** - passes all [official](https://github.com/modelcontextprotocol/conformance) client (254/254) and server (40/40) [conformance tests](https://github.com/rust-mcp-stack/rust-mcp-sdk/actions/workflows/conformance.yml)
+- ✅ **100% MCP Conformance** - passes all [official](https://github.com/modelcontextprotocol/conformance) client  and server  [conformance tests](https://github.com/rust-mcp-stack/rust-mcp-sdk/actions/workflows/conformance.yml)
 - ✅ Transports:Stdio, Streamable HTTP, and backward-compatible SSE support
 - ✅ Framework Agnostic: Seamless **Axum**, **Actix**, and **BYO Server** integrations
 - ✅ Multi-client concurrency

--- a/crates/conformance-client/Cargo.toml
+++ b/crates/conformance-client/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls-tls"] }
+url = { workspace = true }

--- a/crates/conformance-client/src/bin/client/auth/discovery.rs
+++ b/crates/conformance-client/src/bin/client/auth/discovery.rs
@@ -10,7 +10,8 @@
 //!   3. the test-context `scope`, if any (priority 3)
 
 use rust_mcp_sdk::auth::{
-    discover_oauth_server_info, parse_www_authenticate_param, select_scope, OauthServerInfo,
+    discover_oauth_server_info, parse_www_authenticate_param, select_scope,
+    AuthorizationServerMetadata, OauthServerInfo,
 };
 use rust_mcp_sdk::schema::LATEST_PROTOCOL_VERSION;
 
@@ -46,8 +47,9 @@ pub async fn resolve(
     let Some(server_info) =
         discover_oauth_server_info(http, server_url, resource_metadata_url.as_deref()).await
     else {
-        eprintln!("OAuth discovery failed");
-        return None;
+        // 2025-03-26 backcompat: when metadata discovery fails entirely,
+        // fall back to standard OAuth endpoints at the server origin.
+        return fallback_standard_endpoints(server_url);
     };
 
     // SEP-835 scope selection.
@@ -75,6 +77,59 @@ pub async fn resolve(
         server_info,
         selected_scope,
         supports_auth_code,
+    })
+}
+
+/// 2025-03-26 backcompat fallback: construct standard OAuth endpoints
+/// (`/authorize`, `/token`, `/register`) on the server origin when all
+/// metadata discovery paths have been exhausted.
+///
+/// Returns `None` only when the server URL cannot be parsed — this
+/// shouldn't happen for a URL produced by the conformance test harness.
+fn fallback_standard_endpoints(server_url: &str) -> Option<Discovery> {
+    let url = url::Url::parse(server_url).ok()?;
+    let origin = format!("{}://{}", url.scheme(), url.authority());
+
+    let Ok(authz) = url::Url::parse(&format!("{origin}/authorize")) else {
+        return None;
+    };
+    let Ok(token) = url::Url::parse(&format!("{origin}/token")) else {
+        return None;
+    };
+    let reg = url::Url::parse(&format!("{origin}/register")).ok();
+
+    let meta = AuthorizationServerMetadata {
+        issuer: url::Url::parse(&origin).ok()?,
+        authorization_endpoint: authz,
+        token_endpoint: token,
+        jwks_uri: None,
+        registration_endpoint: reg,
+        scopes_supported: None,
+        response_types_supported: vec!["code".to_string()],
+        response_modes_supported: None,
+        grant_types_supported: Some(vec!["authorization_code".to_string()]),
+        token_endpoint_auth_methods_supported: Some(vec!["none".to_string()]),
+        token_endpoint_auth_signing_alg_values_supported: None,
+        service_documentation: None,
+        revocation_endpoint: None,
+        revocation_endpoint_auth_signing_alg_values_supported: None,
+        revocation_endpoint_auth_methods_supported: None,
+        introspection_endpoint: None,
+        introspection_endpoint_auth_methods_supported: None,
+        introspection_endpoint_auth_signing_alg_values_supported: None,
+        code_challenge_methods_supported: Some(vec!["S256".to_string()]),
+        userinfo_endpoint: None,
+        client_id_metadata_document_supported: None,
+    };
+
+    Some(Discovery {
+        server_info: OauthServerInfo {
+            authorization_server_url: origin,
+            authorization_server_metadata: meta,
+            resource_metadata: None,
+        },
+        selected_scope: None,
+        supports_auth_code: true,
     })
 }
 

--- a/crates/conformance-client/src/bin/client/auth/token.rs
+++ b/crates/conformance-client/src/bin/client/auth/token.rs
@@ -28,6 +28,7 @@ pub(super) fn build_auth_client(
     let mut builder = McpAuthConfig::builder()
         .server_url(discovery.auth_server_url())
         .resource(server_url)
+        .metadata(discovery.server_info.authorization_server_metadata.clone())
         .redirect_uri(REDIRECT_URI)
         .client_metadata_url(CIMD_URL);
 

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -25,7 +25,7 @@ Focus on your application logic , rust-mcp-sdk handles the protocol, transports,
 
 **Key Features**
 - ✅ Latest MCP protocol specification supported: 2025-11-25
-- ✅ **100% MCP Conformance** - passes all [official](https://github.com/modelcontextprotocol/conformance) client (254/254) and server (40/40) [conformance tests](https://github.com/rust-mcp-stack/rust-mcp-sdk/actions/workflows/conformance.yml)
+- ✅ **100% MCP Conformance** - passes all [official](https://github.com/modelcontextprotocol/conformance) client  and server  [conformance tests](https://github.com/rust-mcp-stack/rust-mcp-sdk/actions/workflows/conformance.yml)
 - ✅ Transports:Stdio, Streamable HTTP, and backward-compatible SSE support
 - ✅ Framework Agnostic: Seamless **Axum**, **Actix**, and **BYO Server** integrations
 - ✅ Multi-client concurrency

--- a/crates/rust-mcp-sdk/src/auth/client_auth/discovery.rs
+++ b/crates/rust-mcp-sdk/src/auth/client_auth/discovery.rs
@@ -201,10 +201,7 @@ pub fn metadata_url_fallbacks(server_url: &str) -> Vec<String> {
         ));
         // Root well-known paths (auth server may serve metadata at root
         // regardless of the discovery-trigger URL's path component).
-        urls.push(format!(
-            "{}/.well-known/oauth-authorization-server",
-            origin
-        ));
+        urls.push(format!("{}/.well-known/oauth-authorization-server", origin));
         urls.push(format!("{}/.well-known/openid-configuration", origin));
     } else {
         // Root path

--- a/crates/rust-mcp-sdk/src/auth/client_auth/discovery.rs
+++ b/crates/rust-mcp-sdk/src/auth/client_auth/discovery.rs
@@ -199,6 +199,13 @@ pub fn metadata_url_fallbacks(server_url: &str) -> Vec<String> {
             "{}{}/.well-known/openid-configuration",
             origin, path
         ));
+        // Root well-known paths (auth server may serve metadata at root
+        // regardless of the discovery-trigger URL's path component).
+        urls.push(format!(
+            "{}/.well-known/oauth-authorization-server",
+            origin
+        ));
+        urls.push(format!("{}/.well-known/openid-configuration", origin));
     } else {
         // Root path
         urls.push(format!("{}/.well-known/oauth-authorization-server", origin));
@@ -214,7 +221,8 @@ mod tests {
 
     #[test]
     fn fallback_path_based_prepend_style() {
-        // RFC 8414 prepend-style for path-based authorization server URLs
+        // RFC 8414 prepend-style for path-based authorization server URLs.
+        // The root well-known paths are appended after the path-specific ones.
         let urls = metadata_url_fallbacks("https://example.com/tenant1");
         assert_eq!(
             urls[0],
@@ -228,6 +236,15 @@ mod tests {
             urls[2],
             "https://example.com/tenant1/.well-known/openid-configuration"
         );
+        assert_eq!(
+            urls[3],
+            "https://example.com/.well-known/oauth-authorization-server"
+        );
+        assert_eq!(
+            urls[4],
+            "https://example.com/.well-known/openid-configuration"
+        );
+        assert_eq!(urls.len(), 5);
     }
 
     #[test]
@@ -237,6 +254,7 @@ mod tests {
             urls[0],
             "https://example.com/.well-known/oauth-authorization-server/tenant1"
         );
+        assert_eq!(urls.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
### 📌 Summary

Fixes two failing backcompat conformance scenarios (`auth/2025-03-26-oauth-metadata-backcompat`, `auth/2025-03-26-oauth-endpoint-fallback`)


### ✨ Changes Made
- **SDK `metadata_url_fallbacks`**: add root well-known paths (`/.well-known/oauth-authorization-server`, `/.well-known/openid-configuration`) when server URL has a non-root path
- **Conformance client**: add `fallback_standard_endpoints()` — constructs standard OAuth endpoints (`/authorize`, `/token`, `/register`) when all discovery paths are exhausted
- **Conformance client `token.rs`**: pass pre-discovered metadata to `McpAuthConfig` to skip redundant internal discovery
- Add `url` dependency to conformance-client Cargo.toml
