### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,10 +1,10 @@
 {
-  "crates/rust-mcp-sdk": "1.0.1",
-  "crates/rust-mcp-macros": "1.0.0",
-  "crates/rust-mcp-transport": "1.0.0",
-  "crates/rust-mcp-extra": "1.0.1",
-  "crates/rust-mcp-axum": "1.0.1",
-  "crates/rust-mcp-actix": "1.0.1",
+  "crates/rust-mcp-sdk": "1.1.0",
+  "crates/rust-mcp-macros": "1.1.0",
+  "crates/rust-mcp-transport": "1.0.1",
+  "crates/rust-mcp-extra": "1.0.2",
+  "crates/rust-mcp-axum": "1.0.2",
+  "crates/rust-mcp-actix": "1.0.2",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",
@@ -16,6 +16,6 @@
   "examples/simple-mcp-client-streamable-http": "0.1.5",
   "examples/simple-mcp-client-streamable-http-core": "0.1.5",
   "examples/auth/server-oauth-remote": "0.1.35",
-  "crates/conformance-client": "0.1.3",
-  "crates/conformance-server": "0.1.6"
+  "crates/conformance-client": "0.1.4",
+  "crates/conformance-server": "0.1.7"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.1...rust-mcp-sdk-v1.1.0) (2026-08-26)
+
+
+### 🚀 Features
+
+* Add mcp_prompt macro and improve mcp_resource macro ([#232](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/232)) ([10fcf33](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/10fcf334512b3e282955131ac8c3077a929df84f))
+* Rework mcp_prompt macro with typed from_arguments/render API ([#233](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/233)) ([1ec6838](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1ec68383396c992cef3383eb5c0223795383c8f0))
+* **server:** Expose ServerRuntime::shutdown for BYO-server stores ([#234](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/234)) ([292c9ec](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/292c9ec67e4527e6830789d37b2199556aa948ea))
+
+
+### 🐛 Bug Fixes
+
+* Auth url_base utility function ([483af77](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/483af77cc706cb828918d96b5ae21e6830f303e7))
+* Auth-backcompat-discovery ([#221](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/221)) ([6a3999f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6a3999f68a5ba989b54f6581cb9e694e479e7fa8))
+* Generic token verifier introspect ([b05e360](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b05e360c2975b0da8c0e4dc06e4d8f5031ea2a3b))
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.0...rust-mcp-sdk-v1.0.1) (2026-07-26)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-actix"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-axum"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "1.0.0", path = "crates/rust-mcp-transport", default-features = false }
-rust-mcp-sdk = { version = "1.0.1", path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "1.0.0", path = "crates/rust-mcp-macros", default-features = false }
-rust-mcp-extra = { version = "1.0.1", path = "crates/rust-mcp-extra", default-features = false }
-rust-mcp-axum = { version = "1.0.1", path = "crates/rust-mcp-axum" }
-rust-mcp-actix = { version = "1.0.1", path = "crates/rust-mcp-actix" }
+rust-mcp-transport = { version = "1.0.1", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-sdk = { version = "1.1.0", path = "crates/rust-mcp-sdk", default-features = false }
+rust-mcp-macros = { version = "1.1.0", path = "crates/rust-mcp-macros", default-features = false }
+rust-mcp-extra = { version = "1.0.2", path = "crates/rust-mcp-extra", default-features = false }
+rust-mcp-axum = { version = "1.0.2", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "1.0.2", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version="1.0",  default-features = false }

--- a/crates/conformance-client/Cargo.toml
+++ b/crates/conformance-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-client"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test client — runs the official MCP client conformance suite against the rust-mcp-sdk client runtime."

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-server"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test server — implements all scenarios from the MCP conformance suite. Also serves as a reference implementation showing how to build a fully-featured MCP server with rust-mcp-sdk."

--- a/crates/rust-mcp-actix/CHANGELOG.md
+++ b/crates/rust-mcp-actix/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.1...rust-mcp-actix-v1.0.2) (2026-08-26)
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.0...rust-mcp-actix-v1.0.1) (2026-07-26)
 
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v0.1.4...rust-mcp-actix-v1.0.0) (2026-07-25)

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-actix"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Actix-web HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-actix/README.md
+++ b/crates/rust-mcp-actix/README.md
@@ -207,7 +207,7 @@ server.start().await?;
 <!-- x-release-please-start-version -->
 ```toml
 # With TLS/SSL
-rust-mcp-actix = { version = "1.0.1", features = ["ssl"] }
+rust-mcp-actix = { version = "1.0.2", features = ["ssl"] }
 ```
 <!-- x-release-please-end -->
 

--- a/crates/rust-mcp-axum/CHANGELOG.md
+++ b/crates/rust-mcp-axum/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.1...rust-mcp-axum-v1.0.2) (2026-08-26)
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.0...rust-mcp-axum-v1.0.1) (2026-07-26)
 
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v0.2.3...rust-mcp-axum-v1.0.0) (2026-07-25)

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-axum"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Axum HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-axum/README.md
+++ b/crates/rust-mcp-axum/README.md
@@ -205,7 +205,7 @@ server.start().await?;
 <!-- x-release-please-start-version -->
 ```toml
 # With TLS/SSL
-rust-mcp-axum = { version = "1.0.1", features = ["ssl"] }
+rust-mcp-axum = { version = "1.0.2", features = ["ssl"] }
 ```
 <!-- x-release-please-end -->
 

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.1...rust-mcp-extra-v1.0.2) (2026-08-26)
+
+
+### 🐛 Bug Fixes
+
+* Generic token verifier introspect ([b05e360](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b05e360c2975b0da8c0e4dc06e4d8f5031ea2a3b))
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.0...rust-mcp-extra-v1.0.1) (2026-07-26)
 
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v0.3.3...rust-mcp-extra-v1.0.0) (2026-07-25)

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "1.0.1" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
+rust-mcp-sdk = {  version = "1.1.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.5", optional=true}

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v1.0.0...rust-mcp-macros-v1.1.0) (2026-08-26)
+
+
+### 🚀 Features
+
+* Add mcp_prompt macro and improve mcp_resource macro ([#232](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/232)) ([10fcf33](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/10fcf334512b3e282955131ac8c3077a929df84f))
+* Rework mcp_prompt macro with typed from_arguments/render API ([#233](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/233)) ([1ec6838](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1ec68383396c992cef3383eb5c0223795383c8f0))
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v0.9.1...rust-mcp-macros-v1.0.0) (2026-07-25)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.1...rust-mcp-sdk-v1.1.0) (2026-08-26)
+
+
+### 🚀 Features
+
+* Add mcp_prompt macro and improve mcp_resource macro ([#232](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/232)) ([10fcf33](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/10fcf334512b3e282955131ac8c3077a929df84f))
+* Rework mcp_prompt macro with typed from_arguments/render API ([#233](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/233)) ([1ec6838](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1ec68383396c992cef3383eb5c0223795383c8f0))
+* **server:** Expose ServerRuntime::shutdown for BYO-server stores ([#234](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/234)) ([292c9ec](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/292c9ec67e4527e6830789d37b2199556aa948ea))
+
+
+### 🐛 Bug Fixes
+
+* Auth url_base utility function ([483af77](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/483af77cc706cb828918d96b5ae21e6830f303e7))
+* Auth-backcompat-discovery ([#221](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/221)) ([6a3999f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6a3999f68a5ba989b54f6581cb9e694e479e7fa8))
+* Generic token verifier introspect ([b05e360](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b05e360c2975b0da8c0e4dc06e4d8f5031ea2a3b))
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.0...rust-mcp-sdk-v1.0.1) (2026-07-26)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-sdk/README.md
+++ b/crates/rust-mcp-sdk/README.md
@@ -102,7 +102,7 @@ Focus on your application logic , rust-mcp-sdk handles the protocol, transports,
 Add to your Cargo.toml:
 ```toml
 [dependencies]
-rust-mcp-sdk = "1.0.1"  # Check crates.io for the latest version
+rust-mcp-sdk = "1.1.0"  # Check crates.io for the latest version
 ```
 <!-- x-release-please-end -->
 
@@ -574,7 +574,7 @@ When you add rust-mcp-sdk as a dependency without specifying any features, all f
 
 ```toml
 [dependencies]
-rust-mcp-sdk = "1.0.1"
+rust-mcp-sdk = "1.1.0"
 ```
 
 <!-- x-release-please-end -->
@@ -587,7 +587,7 @@ If you only need the MCP Server functionality, you can disable the default featu
 
 ```toml
 [dependencies]
-rust-mcp-sdk = { version = "1.0.1", default-features = false, features = ["server","macros","stdio"] }
+rust-mcp-sdk = { version = "1.1.0", default-features = false, features = ["server","macros","stdio"] }
 ```
 Optionally add [`rust-mcp-axum`](https://crates.io/crates/rust-mcp-axum) and the `streamable-http` feature for **Streamable HTTP** transport, and use `rust-mcp-axum`'s `ssl` feature for TLS/SSL support.
 
@@ -602,7 +602,7 @@ Add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-rust-mcp-sdk = { version = "1.0.1", default-features = false, features = ["client","stdio"] }
+rust-mcp-sdk = { version = "1.1.0", default-features = false, features = ["client","stdio"] }
 ```
 
 <!-- x-release-please-end -->

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v1.0.0...rust-mcp-transport-v1.0.1) (2026-08-26)
+
+
+### 📚 Documentation
+
+* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
+
 ## [1.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v0.9.1...rust-mcp-transport-v1.0.0) (2026-07-25)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>conformance-client: 0.1.4</summary>

### Dependencies


</details>

<details><summary>conformance-server: 0.1.7</summary>

### Dependencies


</details>

<details><summary>rust-mcp-actix: 1.0.2</summary>

## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.1...rust-mcp-actix-v1.0.2) (2026-08-26)


### 📚 Documentation

* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
</details>

<details><summary>rust-mcp-axum: 1.0.2</summary>

## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.1...rust-mcp-axum-v1.0.2) (2026-08-26)


### 📚 Documentation

* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
</details>

<details><summary>rust-mcp-extra: 1.0.2</summary>

## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.1...rust-mcp-extra-v1.0.2) (2026-08-26)


### 🐛 Bug Fixes

* Generic token verifier introspect ([b05e360](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b05e360c2975b0da8c0e4dc06e4d8f5031ea2a3b))


### 📚 Documentation

* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 1.0.1 to 1.1.0
</details>

<details><summary>rust-mcp-macros: 1.1.0</summary>

## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v1.0.0...rust-mcp-macros-v1.1.0) (2026-08-26)


### 🚀 Features

* Add mcp_prompt macro and improve mcp_resource macro ([#232](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/232)) ([10fcf33](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/10fcf334512b3e282955131ac8c3077a929df84f))
* Rework mcp_prompt macro with typed from_arguments/render API ([#233](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/233)) ([1ec6838](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1ec68383396c992cef3383eb5c0223795383c8f0))


### 📚 Documentation

* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
</details>

<details><summary>rust-mcp-sdk: 1.1.0</summary>

## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.1...rust-mcp-sdk-v1.1.0) (2026-08-26)


### 🚀 Features

* Add mcp_prompt macro and improve mcp_resource macro ([#232](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/232)) ([10fcf33](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/10fcf334512b3e282955131ac8c3077a929df84f))
* Rework mcp_prompt macro with typed from_arguments/render API ([#233](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/233)) ([1ec6838](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/1ec68383396c992cef3383eb5c0223795383c8f0))
* **server:** Expose ServerRuntime::shutdown for BYO-server stores ([#234](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/234)) ([292c9ec](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/292c9ec67e4527e6830789d37b2199556aa948ea))


### 🐛 Bug Fixes

* Auth url_base utility function ([483af77](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/483af77cc706cb828918d96b5ae21e6830f303e7))
* Auth-backcompat-discovery ([#221](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/221)) ([6a3999f](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/6a3999f68a5ba989b54f6581cb9e694e479e7fa8))
* Generic token verifier introspect ([b05e360](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/b05e360c2975b0da8c0e4dc06e4d8f5031ea2a3b))


### 📚 Documentation

* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
</details>

<details><summary>rust-mcp-transport: 1.0.1</summary>

## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v1.0.0...rust-mcp-transport-v1.0.1) (2026-08-26)


### 📚 Documentation

* Add versioned Docusaurus site, GitHub Pages deploy & release automation ([#239](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/239)) ([006b7bf](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/006b7bfec21cd41e006ed734505768703343bbb1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).