### PR TITLE
chore: release main

### DIFF
--- a/.release-manifest.json
+++ b/.release-manifest.json
@@ -1,10 +1,10 @@
 {
-  "crates/rust-mcp-sdk": "1.1.0",
-  "crates/rust-mcp-macros": "1.1.0",
-  "crates/rust-mcp-transport": "1.0.1",
-  "crates/rust-mcp-extra": "1.0.2",
-  "crates/rust-mcp-axum": "1.0.2",
-  "crates/rust-mcp-actix": "1.0.2",
+  "crates/rust-mcp-sdk": "2.0.0",
+  "crates/rust-mcp-macros": "2.0.0",
+  "crates/rust-mcp-transport": "2.0.0",
+  "crates/rust-mcp-extra": "2.0.0",
+  "crates/rust-mcp-axum": "2.0.0",
+  "crates/rust-mcp-actix": "2.0.0",
   "examples/hello-world-mcp-server-stdio": "0.1.33",
   "examples/hello-world-mcp-server-stdio-core": "0.1.24",
   "examples/simple-mcp-client-stdio": "0.1.33",
@@ -16,6 +16,6 @@
   "examples/simple-mcp-client-streamable-http": "0.1.5",
   "examples/simple-mcp-client-streamable-http-core": "0.1.5",
   "examples/auth/server-oauth-remote": "0.1.35",
-  "crates/conformance-client": "0.1.4",
-  "crates/conformance-server": "0.1.7"
+  "crates/conformance-client": "0.1.5",
+  "crates/conformance-server": "0.1.8"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.1.0...rust-mcp-sdk-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.1...rust-mcp-sdk-v1.1.0) (2026-08-26)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "conformance-server"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-actix"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-axum"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-extra"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.80.0"
 
 [workspace.dependencies]
 # Workspace member crates
-rust-mcp-transport = { version = "1.0.1", path = "crates/rust-mcp-transport", default-features = false }
-rust-mcp-sdk = { version = "1.1.0", path = "crates/rust-mcp-sdk", default-features = false }
-rust-mcp-macros = { version = "1.1.0", path = "crates/rust-mcp-macros", default-features = false }
-rust-mcp-extra = { version = "1.0.2", path = "crates/rust-mcp-extra", default-features = false }
-rust-mcp-axum = { version = "1.0.2", path = "crates/rust-mcp-axum" }
-rust-mcp-actix = { version = "1.0.2", path = "crates/rust-mcp-actix" }
+rust-mcp-transport = { version = "2.0.0", path = "crates/rust-mcp-transport", default-features = false }
+rust-mcp-sdk = { version = "2.0.0", path = "crates/rust-mcp-sdk", default-features = false }
+rust-mcp-macros = { version = "2.0.0", path = "crates/rust-mcp-macros", default-features = false }
+rust-mcp-extra = { version = "2.0.0", path = "crates/rust-mcp-extra", default-features = false }
+rust-mcp-axum = { version = "2.0.0", path = "crates/rust-mcp-axum" }
+rust-mcp-actix = { version = "2.0.0", path = "crates/rust-mcp-actix" }
 
 # External crates
 rust-mcp-schema = { version = "2.0.0", default-features = false }

--- a/crates/conformance-client/Cargo.toml
+++ b/crates/conformance-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-client"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test client — runs the official MCP client conformance suite against the rust-mcp-sdk client runtime."

--- a/crates/conformance-server/Cargo.toml
+++ b/crates/conformance-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance-server"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.80.0"
 description = "MCP conformance test server — implements all scenarios from the MCP conformance suite. Also serves as a reference implementation showing how to build a fully-featured MCP server with rust-mcp-sdk."

--- a/crates/rust-mcp-actix/CHANGELOG.md
+++ b/crates/rust-mcp-actix/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.2...rust-mcp-actix-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.1...rust-mcp-actix-v1.0.2) (2026-08-26)
 
 

--- a/crates/rust-mcp-actix/Cargo.toml
+++ b/crates/rust-mcp-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-actix"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Actix-web HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-actix/README.md
+++ b/crates/rust-mcp-actix/README.md
@@ -207,7 +207,7 @@ server.start().await?;
 <!-- x-release-please-start-version -->
 ```toml
 # With TLS/SSL
-rust-mcp-actix = { version = "1.0.2", features = ["ssl"] }
+rust-mcp-actix = { version = "2.0.0", features = ["ssl"] }
 ```
 <!-- x-release-please-end -->
 

--- a/crates/rust-mcp-axum/CHANGELOG.md
+++ b/crates/rust-mcp-axum/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.2...rust-mcp-axum-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.1...rust-mcp-axum-v1.0.2) (2026-08-26)
 
 

--- a/crates/rust-mcp-axum/Cargo.toml
+++ b/crates/rust-mcp-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-axum"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Ali Hashemi"]
 categories = ["web-programming", "asynchronous", "network-programming"]
 description = "Axum HTTP server integration for rust-mcp-sdk"

--- a/crates/rust-mcp-axum/README.md
+++ b/crates/rust-mcp-axum/README.md
@@ -205,7 +205,7 @@ server.start().await?;
 <!-- x-release-please-start-version -->
 ```toml
 # With TLS/SSL
-rust-mcp-axum = { version = "1.0.2", features = ["ssl"] }
+rust-mcp-axum = { version = "2.0.0", features = ["ssl"] }
 ```
 <!-- x-release-please-end -->
 

--- a/crates/rust-mcp-extra/CHANGELOG.md
+++ b/crates/rust-mcp-extra/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.2...rust-mcp-extra-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.0.2](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.1...rust-mcp-extra-v1.0.2) (2026-08-26)
 
 

--- a/crates/rust-mcp-extra/Cargo.toml
+++ b/crates/rust-mcp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-extra"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Ali Hashemi"]
 categories = ["api-bindings", "development-tools", "asynchronous", "parsing"]
 description = "A companion crate to rust-mcp-sdk offering extra implementations of core traits like SessionStore and EventStore, enabling integration with various database backends and third-party platforms such as AWS Lambda for serverless and cloud-native MCP applications."
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 exclude = ["assets/", "tests/"]
 
 [dependencies]
-rust-mcp-sdk = {  version = "1.1.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
+rust-mcp-sdk = {  version = "2.0.0" , path = "../rust-mcp-sdk", default-features = false, features=["server","auth","sse","macros"] }
 base64 = {workspace = true, optional=true}
 url= {workspace = true, optional=true}
 nanoid = {version="0.5", optional=true}

--- a/crates/rust-mcp-macros/CHANGELOG.md
+++ b/crates/rust-mcp-macros/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v1.1.0...rust-mcp-macros-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v1.0.0...rust-mcp-macros-v1.1.0) (2026-08-26)
 
 

--- a/crates/rust-mcp-macros/Cargo.toml
+++ b/crates/rust-mcp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-macros"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "A procedural macro that derives the MCPToolSchema implementation for structs or enums, generating a tool_input_schema function used with rust_mcp_schema::Tool."

--- a/crates/rust-mcp-sdk/CHANGELOG.md
+++ b/crates/rust-mcp-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.1.0...rust-mcp-sdk-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.1.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.0.1...rust-mcp-sdk-v1.1.0) (2026-08-26)
 
 

--- a/crates/rust-mcp-sdk/Cargo.toml
+++ b/crates/rust-mcp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-sdk"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures", "parser-implementations", "parsing"]
 description = "An asynchronous SDK and framework for building MCP-Servers and MCP-Clients, leveraging the rust-mcp-schema for type safe MCP Schema Objects."

--- a/crates/rust-mcp-transport/CHANGELOG.md
+++ b/crates/rust-mcp-transport/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v1.0.1...rust-mcp-transport-v2.0.0) (2026-08-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))
+
+### 🚀 Features
+
+* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
+
 ## [1.0.1](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v1.0.0...rust-mcp-transport-v1.0.1) (2026-08-26)
 
 

--- a/crates/rust-mcp-transport/Cargo.toml
+++ b/crates/rust-mcp-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mcp-transport"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Ali Hashemi"]
 categories = ["data-structures"]
 description = "Transport implementations for the MCP (Model Context Protocol) within the rust-mcp-sdk ecosystem, enabling asynchronous data exchange and efficient message handling between MCP clients and servers."


### PR DESCRIPTION
:robot: Auto-generated release PR
---


<details><summary>conformance-client: 0.1.5</summary>

### Dependencies


</details>

<details><summary>conformance-server: 0.1.8</summary>

### Dependencies


</details>

<details><summary>rust-mcp-actix: 2.0.0</summary>

## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-actix-v1.0.2...rust-mcp-actix-v2.0.0) (2026-08-27)


### ⚠ BREAKING CHANGES

* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))

### 🚀 Features

* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
</details>

<details><summary>rust-mcp-axum: 2.0.0</summary>

## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-axum-v1.0.2...rust-mcp-axum-v2.0.0) (2026-08-27)


### ⚠ BREAKING CHANGES

* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))

### 🚀 Features

* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
</details>

<details><summary>rust-mcp-extra: 2.0.0</summary>

## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-extra-v1.0.2...rust-mcp-extra-v2.0.0) (2026-08-27)


### ⚠ BREAKING CHANGES

* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))

### 🚀 Features

* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * rust-mcp-sdk bumped from 1.1.0 to 2.0.0
</details>

<details><summary>rust-mcp-macros: 2.0.0</summary>

## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-macros-v1.1.0...rust-mcp-macros-v2.0.0) (2026-08-27)


### ⚠ BREAKING CHANGES

* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))

### 🚀 Features

* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
</details>

<details><summary>rust-mcp-sdk: 2.0.0</summary>

## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-sdk-v1.1.0...rust-mcp-sdk-v2.0.0) (2026-08-27)


### ⚠ BREAKING CHANGES

* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))

### 🚀 Features

* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
</details>

<details><summary>rust-mcp-transport: 2.0.0</summary>

## [2.0.0](https://github.com/rust-mcp-stack/rust-mcp-sdk/compare/rust-mcp-transport-v1.0.1...rust-mcp-transport-v2.0.0) (2026-08-27)


### ⚠ BREAKING CHANGES

* migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240))

### 🚀 Features

* Migrate to MCP 2026-07-28 (stateless) ([#240](https://github.com/rust-mcp-stack/rust-mcp-sdk/issues/240)) ([809faea](https://github.com/rust-mcp-stack/rust-mcp-sdk/commit/809faeae4ea4e636653026133f5836987377ab82))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).